### PR TITLE
Com 2274

### DIFF
--- a/src/routes/Google/drive.js
+++ b/src/routes/Google/drive.js
@@ -64,10 +64,7 @@ exports.plugin = {
       handler: getList,
       options: {
         validate: {
-          query: Joi.object({
-            folderId: Joi.string(),
-            nextPageToken: Joi.string(),
-          }),
+          query: Joi.object({ folderId: Joi.string(), nextPageToken: Joi.string() }),
         },
         auth: {
           strategy: 'jwt',

--- a/src/routes/attendances.js
+++ b/src/routes/attendances.js
@@ -33,10 +33,7 @@ exports.plugin = {
       path: '/',
       options: {
         validate: {
-          payload: Joi.object({
-            trainee: Joi.string().required(),
-            courseSlot: Joi.string().required(),
-          }),
+          payload: Joi.object({ trainee: Joi.string().required(), courseSlot: Joi.string().required() }),
         },
         auth: { scope: ['attendancesheets:edit'] },
         pre: [{ method: authorizeAttendanceCreation }],

--- a/src/routes/authentication.js
+++ b/src/routes/authentication.js
@@ -42,9 +42,7 @@ exports.plugin = {
         auth: { scope: ['users:edit', 'user:edit-{params._id}'] },
         validate: {
           params: Joi.object({ _id: Joi.objectId().required() }),
-          payload: Joi.object().keys({
-            email: Joi.string().email().required(),
-          }),
+          payload: Joi.object().keys({ email: Joi.string().email().required() }),
         },
         pre: [
           { method: getUser, assign: 'user' },

--- a/src/routes/cards.js
+++ b/src/routes/cards.js
@@ -78,14 +78,8 @@ exports.plugin = {
       path: '/{_id}/answers/{answerId}',
       options: {
         validate: {
-          params: Joi.object({
-            _id: Joi.objectId().required(),
-            answerId: Joi.objectId().required(),
-          }),
-          payload: Joi.object({
-            text: Joi.string(),
-            correct: Joi.boolean(),
-          }).min(1),
+          params: Joi.object({ _id: Joi.objectId().required(), answerId: Joi.objectId().required() }),
+          payload: Joi.object({ text: Joi.string(), correct: Joi.boolean() }).min(1),
         },
         auth: { scope: ['programs:edit'] },
         pre: [{ method: authorizeCardAnswerUpdate, assign: 'card' }],
@@ -114,14 +108,9 @@ exports.plugin = {
           payload: Joi.object({
             fileName: Joi.string().required(),
             file: Joi.any().required(),
-            media: Joi.object().keys({
-              link: Joi.string().allow(null),
-              publicId: Joi.string().allow(null),
-            }),
+            media: Joi.object().keys({ link: Joi.string().allow(null), publicId: Joi.string().allow(null) }),
           }),
-          params: Joi.object({
-            _id: Joi.objectId().required(),
-          }),
+          params: Joi.object({ _id: Joi.objectId().required() }),
         },
         auth: { scope: ['programs:edit'] },
       },

--- a/src/routes/categories.js
+++ b/src/routes/categories.js
@@ -22,9 +22,7 @@ exports.plugin = {
       path: '/',
       options: {
         validate: {
-          payload: Joi.object({
-            name: Joi.string().required(),
-          }),
+          payload: Joi.object({ name: Joi.string().required() }),
         },
         auth: { scope: ['programs:edit'] },
         pre: [{ method: checkCategoryNameExists }],
@@ -38,9 +36,7 @@ exports.plugin = {
       options: {
         validate: {
           params: Joi.object({ _id: Joi.objectId().required() }),
-          payload: Joi.object({
-            name: Joi.string().required(),
-          }),
+          payload: Joi.object({ name: Joi.string().required() }),
         },
         auth: { scope: ['programs:edit'] },
         pre: [{ method: checkCategoryNameExists }, { method: checkCategoryExists }],

--- a/src/routes/companies.js
+++ b/src/routes/companies.js
@@ -32,9 +32,7 @@ exports.plugin = {
             name: Joi.string(),
             tradeName: tradeNameValidation.allow('', null),
             address: addressValidation,
-            subscriptions: Joi.object().keys({
-              erp: Joi.boolean(),
-            }).min(1),
+            subscriptions: Joi.object().keys({ erp: Joi.boolean() }).min(1),
             ics: Joi.string(),
             rcs: Joi.string(),
             rna: Joi.string(),
@@ -51,18 +49,12 @@ exports.plugin = {
               grossHourlyRate: Joi.number(),
               phoneFeeAmount: Joi.number(),
               amountPerKm: Joi.number(),
-              transportSubs: [Joi.array().items({
-                department: Joi.string(),
-                price: Joi.number(),
-              }), Joi.object().keys({
-                subId: Joi.objectId().required(),
-                price: Joi.number(),
-              })],
+              transportSubs: [
+                Joi.array().items({ department: Joi.string(), price: Joi.number() }),
+                Joi.object().keys({ subId: Joi.objectId().required(), price: Joi.number() }),
+              ],
               templates: Joi.object().keys({
-                contract: Joi.object().keys({
-                  driveId: Joi.string().allow(null),
-                  link: Joi.string().allow(null),
-                }),
+                contract: Joi.object().keys({ driveId: Joi.string().allow(null), link: Joi.string().allow(null) }),
                 contractVersion: Joi.object().keys({
                   driveId: Joi.string().allow(null),
                   link: Joi.string().allow(null),
@@ -72,18 +64,9 @@ exports.plugin = {
             customersConfig: Joi.object().keys({
               billingPeriod: Joi.string().valid(...COMPANY_BILLING_PERIODS),
               templates: Joi.object().keys({
-                debitMandate: Joi.object().keys({
-                  driveId: Joi.string().allow(null),
-                  link: Joi.string().allow(null),
-                }),
-                quote: Joi.object().keys({
-                  driveId: Joi.string().allow(null),
-                  link: Joi.string().allow(null),
-                }),
-                gcs: Joi.object().keys({
-                  driveId: Joi.string().allow(null),
-                  link: Joi.string().allow(null),
-                }),
+                debitMandate: Joi.object().keys({ driveId: Joi.string().allow(null), link: Joi.string().allow(null) }),
+                quote: Joi.object().keys({ driveId: Joi.string().allow(null), link: Joi.string().allow(null) }),
+                gcs: Joi.object().keys({ driveId: Joi.string().allow(null), link: Joi.string().allow(null) }),
               }),
             }),
           }),
@@ -130,10 +113,7 @@ exports.plugin = {
               grossHourlyRate: Joi.number(),
               phoneFeeAmount: Joi.number(),
               amountPerKm: Joi.number(),
-              transportSubs: Joi.array().items({
-                department: Joi.string(),
-                price: Joi.number(),
-              }).min(1),
+              transportSubs: Joi.array().items({ department: Joi.string(), price: Joi.number() }).min(1),
             }).min(1),
           }),
         },

--- a/src/routes/contracts.js
+++ b/src/routes/contracts.js
@@ -67,9 +67,7 @@ exports.plugin = {
                   name: Joi.string().required(),
                   email: Joi.string().required(),
                 })).required(),
-                meta: Joi.object({
-                  auxiliaryDriveId: Joi.string().required(),
-                }),
+                meta: Joi.object({ auxiliaryDriveId: Joi.string().required() }),
                 redirect: Joi.string().uri().required(),
                 redirectDecline: Joi.string().uri().required(),
               }),
@@ -131,9 +129,7 @@ exports.plugin = {
                 name: Joi.string().required(),
                 email: Joi.string().required(),
               })).required(),
-              meta: Joi.object({
-                auxiliaryDriveId: Joi.string().required(),
-              }),
+              meta: Joi.object({ auxiliaryDriveId: Joi.string().required() }),
               redirect: Joi.string().uri().required(),
               redirectDecline: Joi.string().uri().required(),
             }),
@@ -150,10 +146,7 @@ exports.plugin = {
       options: {
         auth: { scope: ['contracts:edit'] },
         validate: {
-          params: Joi.object({
-            _id: Joi.objectId().required(),
-            versionId: Joi.objectId().required(),
-          }),
+          params: Joi.object({ _id: Joi.objectId().required(), versionId: Joi.objectId().required() }),
           payload: Joi.object({
             startDate: Joi.date(),
             endDate: Joi.date(),
@@ -167,9 +160,7 @@ exports.plugin = {
                 name: Joi.string().required(),
                 email: Joi.string().required(),
               })).required(),
-              meta: Joi.object({
-                auxiliaryDriveId: Joi.string().required(),
-              }),
+              meta: Joi.object({ auxiliaryDriveId: Joi.string().required() }),
               redirect: Joi.string().uri().required(),
               redirectDecline: Joi.string().uri().required(),
             }),
@@ -186,10 +177,7 @@ exports.plugin = {
       options: {
         auth: { scope: ['contracts:edit'] },
         validate: {
-          params: Joi.object({
-            _id: Joi.objectId().required(),
-            versionId: Joi.objectId().required(),
-          }),
+          params: Joi.object({ _id: Joi.objectId().required(), versionId: Joi.objectId().required() }),
         },
         pre: [{ method: getContract, assign: 'contract' }, { method: authorizeContractUpdate }],
       },
@@ -204,10 +192,7 @@ exports.plugin = {
         auth: { scope: ['contracts:edit'] },
         payload: formDataPayload(),
         validate: {
-          params: Joi.object({
-            _id: Joi.objectId().required(),
-            driveId: Joi.string().required(),
-          }),
+          params: Joi.object({ _id: Joi.objectId().required(), driveId: Joi.string().required() }),
           payload: Joi.object({
             fileName: Joi.string().required(),
             contractId: Joi.objectId().required(),

--- a/src/routes/courseHistories.js
+++ b/src/routes/courseHistories.js
@@ -15,10 +15,7 @@ exports.plugin = {
       options: {
         auth: { scope: ['courses:edit'] },
         validate: {
-          query: Joi.object({
-            course: Joi.objectId().required(),
-            createdAt: Joi.date(),
-          }),
+          query: Joi.object({ course: Joi.objectId().required(), createdAt: Joi.date() }),
         },
         pre: [{ method: authorizeGetCourseHistories }],
       },

--- a/src/routes/courses.js
+++ b/src/routes/courses.js
@@ -240,10 +240,7 @@ exports.plugin = {
         validate: {
           params: Joi.object({ _id: Joi.objectId().required() }),
           payload: Joi.object({
-            identity: Joi.object().keys({
-              firstname: Joi.string(),
-              lastname: Joi.string(),
-            }).min(1),
+            identity: Joi.object().keys({ firstname: Joi.string(), lastname: Joi.string() }).min(1),
             local: Joi.object().keys({ email: Joi.string().email().required() }).required(),
             contact: Joi.object().keys({ phone: phoneNumberValidation }),
             company: Joi.objectId(),

--- a/src/routes/customerPartners.js
+++ b/src/routes/customerPartners.js
@@ -15,10 +15,7 @@ exports.plugin = {
       options: {
         auth: { scope: ['customerpartners:edit'] },
         validate: {
-          payload: Joi.object().keys({
-            partner: Joi.objectId().required(),
-            customer: Joi.objectId().required(),
-          }),
+          payload: Joi.object().keys({ partner: Joi.objectId().required(), customer: Joi.objectId().required() }),
         },
         pre: [{ method: authorizeCustomerPartnerCreation }],
       },

--- a/src/routes/customers.js
+++ b/src/routes/customers.js
@@ -60,9 +60,7 @@ exports.plugin = {
               firstname: Joi.string().allow(null, ''),
               lastname: Joi.string().required(),
             }).required(),
-            contact: Joi.object().keys({
-              primaryAddress: addressValidation.required(),
-            }).required(),
+            contact: Joi.object().keys({ primaryAddress: addressValidation.required() }).required(),
           }),
         },
       },
@@ -146,11 +144,7 @@ exports.plugin = {
       options: {
         auth: { scope: ['customers:read'] },
         validate: {
-          query: Joi.object().keys({
-            sector: objectIdOrArray,
-            startDate: Joi.date(),
-            endDate: Joi.date(),
-          }),
+          query: Joi.object().keys({ sector: objectIdOrArray, startDate: Joi.date(), endDate: Joi.date() }),
         },
         pre: [{ method: authorizeCustomerGetBySector }],
       },
@@ -242,10 +236,7 @@ exports.plugin = {
       options: {
         auth: { scope: ['customers:administrative:edit'] },
         validate: {
-          params: Joi.object({
-            _id: Joi.objectId().required(),
-            subscriptionId: Joi.objectId().required(),
-          }),
+          params: Joi.object({ _id: Joi.objectId().required(), subscriptionId: Joi.objectId().required() }),
           payload: Joi.object({
             unitTTCRate: Joi.number().required(),
             estimatedWeeklyVolume: Joi.number().required(),
@@ -264,10 +255,7 @@ exports.plugin = {
       options: {
         auth: { scope: ['customers:administrative:edit'] },
         validate: {
-          params: Joi.object({
-            _id: Joi.objectId().required(),
-            subscriptionId: Joi.objectId().required(),
-          }),
+          params: Joi.object({ _id: Joi.objectId().required(), subscriptionId: Joi.objectId().required() }),
         },
         pre: [{ method: authorizeSubscriptionDeletion }],
       },
@@ -293,10 +281,7 @@ exports.plugin = {
       options: {
         auth: { scope: ['customers:administrative:edit'] },
         validate: {
-          params: Joi.object({
-            _id: Joi.objectId().required(),
-            mandateId: Joi.objectId().required(),
-          }),
+          params: Joi.object({ _id: Joi.objectId().required(), mandateId: Joi.objectId().required() }),
         },
         pre: [{ method: authorizeCustomerUpdate }],
       },
@@ -309,10 +294,7 @@ exports.plugin = {
       options: {
         auth: { scope: ['customer-{params._id}'] },
         validate: {
-          params: Joi.object({
-            _id: Joi.objectId().required(),
-            mandateId: Joi.objectId().required(),
-          }),
+          params: Joi.object({ _id: Joi.objectId().required(), mandateId: Joi.objectId().required() }),
           payload: Joi.object({
             fileId: Joi.string().required(),
             customer: Joi.object().keys({
@@ -376,18 +358,12 @@ exports.plugin = {
         auth: { scope: ['customers:administrative:edit', 'customer-{params._id}'] },
         payload: formDataPayload(),
         validate: {
-          params: Joi.object({
-            _id: Joi.objectId().required(),
-            driveId: Joi.string().required(),
-          }),
+          params: Joi.object({ _id: Joi.objectId().required(), driveId: Joi.string().required() }),
           payload: Joi.object({
             fileName: Joi.string().required(),
             file: Joi.any().required(),
             type: Joi.string().valid('signedQuote', 'signedMandate', 'financialCertificates').required(),
-            quoteId: Joi.string().when(
-              'type',
-              { is: 'signedQuote', then: Joi.required(), otherwise: Joi.forbidden() }
-            ),
+            quoteId: Joi.string().when('type', { is: 'signedQuote', then: Joi.required(), otherwise: Joi.forbidden() }),
             mandateId: Joi.string().when(
               'type',
               { is: 'signedMandate', then: Joi.required(), otherwise: Joi.forbidden() }
@@ -405,9 +381,7 @@ exports.plugin = {
         auth: { scope: ['customers:administrative:edit', 'customer-{params._id}'] },
         validate: {
           params: Joi.object({ _id: Joi.objectId().required() }),
-          payload: Joi.object().keys({
-            driveId: Joi.string().required(),
-          }),
+          payload: Joi.object().keys({ driveId: Joi.string().required() }),
         },
         pre: [{ method: authorizeCustomerUpdate }],
       },
@@ -420,10 +394,7 @@ exports.plugin = {
       options: {
         auth: { scope: ['customer-{params._id}'] },
         validate: {
-          params: Joi.object({
-            _id: Joi.objectId().required(),
-            mandateId: Joi.objectId().required(),
-          }),
+          params: Joi.object({ _id: Joi.objectId().required(), mandateId: Joi.objectId().required() }),
         },
         pre: [{ method: authorizeCustomerUpdate }],
       },
@@ -486,10 +457,7 @@ exports.plugin = {
       options: {
         auth: { scope: ['customers:administrative:edit'] },
         validate: {
-          params: Joi.object({
-            _id: Joi.objectId().required(),
-            fundingId: Joi.objectId().required(),
-          }),
+          params: Joi.object({ _id: Joi.objectId().required(), fundingId: Joi.objectId().required() }),
           payload: Joi.object().keys({
             subscription: Joi.objectId().required(),
             ...fundingValidation,
@@ -507,10 +475,7 @@ exports.plugin = {
       options: {
         auth: { scope: ['customers:administrative:edit'] },
         validate: {
-          params: Joi.object({
-            _id: Joi.objectId().required(),
-            fundingId: Joi.objectId().required(),
-          }),
+          params: Joi.object({ _id: Joi.objectId().required(), fundingId: Joi.objectId().required() }),
         },
         pre: [{ method: authorizeCustomerUpdate }],
       },

--- a/src/routes/endToEnd.js
+++ b/src/routes/endToEnd.js
@@ -14,9 +14,7 @@ exports.plugin = {
       options: {
         auth: false,
         validate: {
-          params: Joi.object({
-            type: Joi.string().required().valid(PLANNING, AUTHENTICATION, BILLING),
-          }),
+          params: Joi.object({ type: Joi.string().required().valid(PLANNING, AUTHENTICATION, BILLING) }),
         },
         pre: [{ method: authorizeDatabaseSeed }],
       },

--- a/src/routes/events.js
+++ b/src/routes/events.js
@@ -154,10 +154,7 @@ exports.plugin = {
       options: {
         auth: { scope: ['events:read'] },
         validate: {
-          query: Joi.object().keys({
-            sector: objectIdOrArray.required(),
-            month: monthValidation.required(),
-          }),
+          query: Joi.object().keys({ sector: objectIdOrArray.required(), month: monthValidation.required() }),
         },
         pre: [{ method: authorizeEventGet }],
       },
@@ -274,10 +271,7 @@ exports.plugin = {
       options: {
         auth: { scope: ['events:read'] },
         validate: {
-          query: Joi.object().keys({
-            sector: objectIdOrArray.required(),
-            month: monthValidation.required(),
-          }),
+          query: Joi.object().keys({ sector: objectIdOrArray.required(), month: monthValidation.required() }),
         },
         pre: [{ method: authorizeEventGet }],
       },

--- a/src/routes/exports.js
+++ b/src/routes/exports.js
@@ -49,10 +49,7 @@ exports.plugin = {
           params: Joi.object({
             type: Joi.string().required().valid(WORKING_EVENT, BILL, PAYMENT, ABSENCE, PAY, CONTRACT),
           }),
-          query: Joi.object({
-            startDate: Joi.date().required(),
-            endDate: Joi.date().required(),
-          }),
+          query: Joi.object({ startDate: Joi.date().required(), endDate: Joi.date().required() }),
         },
         auth: { scope: ['exports:read'] },
       },

--- a/src/routes/finalPay.js
+++ b/src/routes/finalPay.js
@@ -14,10 +14,7 @@ exports.plugin = {
       options: {
         auth: { scope: ['pay:edit'] },
         validate: {
-          query: Joi.object({
-            endDate: Joi.date(),
-            startDate: Joi.date(),
-          }),
+          query: Joi.object({ endDate: Joi.date(), startDate: Joi.date() }),
         },
       },
       handler: draftFinalPayList,

--- a/src/routes/helpers.js
+++ b/src/routes/helpers.js
@@ -26,9 +26,7 @@ exports.plugin = {
       options: {
         validate: {
           params: Joi.object({ _id: Joi.objectId().required() }),
-          payload: Joi.object({
-            referent: Joi.boolean().valid(true),
-          }),
+          payload: Joi.object({ referent: Joi.boolean().valid(true) }),
         },
         auth: { scope: ['helpers:edit'] },
       },

--- a/src/routes/partners.js
+++ b/src/routes/partners.js
@@ -23,10 +23,7 @@ exports.plugin = {
         validate: {
           params: Joi.object({ _id: Joi.objectId().required() }),
           payload: Joi.object().keys({
-            identity: Joi.object({
-              firstname: Joi.string().allow(''),
-              lastname: Joi.string(),
-            }),
+            identity: Joi.object({ firstname: Joi.string().allow(''), lastname: Joi.string() }),
             phone: phoneNumberValidation.allow(''),
             email: Joi.string().email().allow(''),
             job: Joi.string().valid(...JOBS).allow(''),

--- a/src/routes/pay.js
+++ b/src/routes/pay.js
@@ -23,10 +23,7 @@ exports.plugin = {
       options: {
         auth: { scope: ['pay:edit'] },
         validate: {
-          query: Joi.object({
-            endDate: Joi.date(),
-            startDate: Joi.date(),
-          }),
+          query: Joi.object({ endDate: Joi.date(), startDate: Joi.date() }),
         },
       },
       handler: draftPayList,
@@ -70,10 +67,7 @@ exports.plugin = {
       options: {
         auth: { scope: ['pay:read'] },
         validate: {
-          query: Joi.object({
-            sector: objectIdOrArray.required(),
-            month: monthValidation.required(),
-          }),
+          query: Joi.object({ sector: objectIdOrArray.required(), month: monthValidation.required() }),
         },
         pre: [{ method: authorizeGetHoursToWork }],
       },

--- a/src/routes/preHandlers/steps.js
+++ b/src/routes/preHandlers/steps.js
@@ -29,13 +29,13 @@ exports.authorizeActivityAdd = async (req) => {
 };
 
 exports.authorizeActivityReuse = async (req) => {
-  const step = await Step.findOne({ _id: req.params._id }).lean();
+  const step = await Step.findOne({ _id: req.params._id }, { activities: 1, status: 1 }).lean();
   if (!step) throw Boom.notFound();
   if (step.status === PUBLISHED) throw Boom.forbidden();
 
   const { activities } = req.payload;
   const existingActivity = await Activity.countDocuments({ _id: activities });
-  if (!existingActivity) throw Boom.badRequest();
+  if (!existingActivity) throw Boom.notFound();
   if (step.activities.map(a => a.toHexString()).includes(activities)) throw Boom.badRequest();
 
   return null;

--- a/src/routes/preHandlers/steps.js
+++ b/src/routes/preHandlers/steps.js
@@ -4,7 +4,7 @@ const Activity = require('../../models/Activity');
 const { PUBLISHED } = require('../../helpers/constants');
 
 exports.authorizeStepUpdate = async (req) => {
-  const step = await Step.findOne({ _id: req.params._id }).lean();
+  const step = await Step.findOne({ _id: req.params._id }, { activities: 1, status: 1 }).lean();
   if (!step) throw Boom.notFound();
   if (step.status === PUBLISHED && Object.keys(req.payload).some(key => key !== 'name')) throw Boom.forbidden();
 
@@ -13,7 +13,7 @@ exports.authorizeStepUpdate = async (req) => {
     const lengthAreEquals = step.activities.length === activities.length;
     const dbActivitiesAreInPayload = step.activities.every(value => activities.includes(value.toHexString()));
     const payloadActivitiesAreInDb = activities
-      .every(value => step.activities.map(s => s.toHexString()).includes(value));
+      .every(value => step.activities.map(a => a.toHexString()).includes(value));
     if (!lengthAreEquals || !payloadActivitiesAreInDb || !dbActivitiesAreInPayload) return Boom.badRequest();
   }
 

--- a/src/routes/preHandlers/steps.js
+++ b/src/routes/preHandlers/steps.js
@@ -42,7 +42,7 @@ exports.authorizeActivityReuse = async (req) => {
 };
 
 exports.authorizeActivityDetachment = async (req) => {
-  const step = await Step.findOne({ _id: req.params._id, activities: req.params.activityId }).lean();
+  const step = await Step.findOne({ _id: req.params._id, activities: req.params.activityId }, { status: 1 }).lean();
   if (!step) throw Boom.notFound();
   if (step.status === PUBLISHED) throw Boom.forbidden();
 

--- a/src/routes/preHandlers/steps.js
+++ b/src/routes/preHandlers/steps.js
@@ -21,7 +21,7 @@ exports.authorizeStepUpdate = async (req) => {
 };
 
 exports.authorizeActivityAdd = async (req) => {
-  const step = await Step.findOne({ _id: req.params._id }).lean();
+  const step = await Step.findOne({ _id: req.params._id }, { status: 1 }).lean();
   if (!step) throw Boom.notFound();
   if (step.status === PUBLISHED) throw Boom.forbidden();
 

--- a/src/routes/preHandlers/steps.js
+++ b/src/routes/preHandlers/steps.js
@@ -12,9 +12,7 @@ exports.authorizeStepUpdate = async (req) => {
   if (activities) {
     const lengthAreEquals = step.activities.length === activities.length;
     const dbActivitiesAreInPayload = step.activities.every(value => activities.includes(value.toHexString()));
-    const payloadActivitiesAreInDb = activities
-      .every(value => step.activities.map(a => a.toHexString()).includes(value));
-    if (!lengthAreEquals || !payloadActivitiesAreInDb || !dbActivitiesAreInPayload) return Boom.badRequest();
+    if (!lengthAreEquals || !dbActivitiesAreInPayload) return Boom.badRequest();
   }
 
   return null;

--- a/src/routes/programs.js
+++ b/src/routes/programs.js
@@ -85,10 +85,7 @@ exports.plugin = {
             name: Joi.string(),
             description: Joi.string(),
             learningGoals: Joi.string(),
-            image: Joi.object().keys({
-              link: Joi.string().allow(null),
-              publicId: Joi.string().allow(null),
-            }),
+            image: Joi.object().keys({ link: Joi.string().allow(null), publicId: Joi.string().allow(null) }),
           }).min(1),
         },
         auth: { scope: ['programs:edit'] },
@@ -103,9 +100,7 @@ exports.plugin = {
       options: {
         validate: {
           params: Joi.object({ _id: Joi.objectId().required() }),
-          payload: Joi.object({
-            categoryId: Joi.objectId().required(),
-          }),
+          payload: Joi.object({ categoryId: Joi.objectId().required() }),
         },
         auth: { scope: ['programs:edit'] },
         pre: [{ method: checkProgramExists }, { method: checkCategoryExists }],
@@ -147,13 +142,8 @@ exports.plugin = {
       options: {
         payload: formDataPayload(),
         validate: {
-          payload: Joi.object({
-            fileName: Joi.string().required(),
-            file: Joi.any().required(),
-          }),
-          params: Joi.object({
-            _id: Joi.objectId().required(),
-          }),
+          payload: Joi.object({ fileName: Joi.string().required(), file: Joi.any().required() }),
+          params: Joi.object({ _id: Joi.objectId().required() }),
         },
         auth: { scope: ['programs:edit'] },
         pre: [{ method: checkProgramExists }],
@@ -166,9 +156,7 @@ exports.plugin = {
       handler: deleteImage,
       options: {
         validate: {
-          params: Joi.object({
-            _id: Joi.objectId().required(),
-          }),
+          params: Joi.object({ _id: Joi.objectId().required() }),
         },
         auth: { scope: ['programs:edit'] },
         pre: [{ method: getProgramImagePublicId, assign: 'publicId' }],

--- a/src/routes/scripts.js
+++ b/src/routes/scripts.js
@@ -17,9 +17,7 @@ exports.plugin = {
       options: {
         auth: { scope: ['scripts:run'] },
         validate: {
-          query: Joi.object({
-            date: Joi.date(),
-          }),
+          query: Joi.object({ date: Joi.date() }),
         },
       },
       handler: billDispatchScript,
@@ -31,10 +29,7 @@ exports.plugin = {
       options: {
         auth: { scope: ['scripts:run'] },
         validate: {
-          query: Joi.object({
-            date: Joi.date(),
-            type: Joi.string(),
-          }),
+          query: Joi.object({ date: Joi.date(), type: Joi.string() }),
         },
       },
       handler: eventRepetitionsScript,

--- a/src/routes/stats.js
+++ b/src/routes/stats.js
@@ -75,10 +75,7 @@ exports.plugin = {
       options: {
         auth: { scope: ['events:read'] },
         validate: {
-          query: Joi.object().keys({
-            sector: objectIdOrArray.required(),
-            month: monthValidation.required(),
-          }),
+          query: Joi.object().keys({ sector: objectIdOrArray.required(), month: monthValidation.required() }),
         },
         pre: [{ method: authorizeGetStats }],
       },
@@ -91,10 +88,7 @@ exports.plugin = {
       options: {
         auth: { scope: ['events:read'] },
         validate: {
-          query: Joi.object().keys({
-            sector: objectIdOrArray.required(),
-            month: monthValidation.required(),
-          }),
+          query: Joi.object().keys({ sector: objectIdOrArray.required(), month: monthValidation.required() }),
         },
         pre: [{ method: authorizeGetStats }],
       },

--- a/src/routes/steps.js
+++ b/src/routes/steps.js
@@ -22,10 +22,7 @@ exports.plugin = {
       options: {
         validate: {
           params: Joi.object({ _id: Joi.objectId().required() }),
-          payload: Joi.object({
-            name: Joi.string(),
-            activities: Joi.array().items(Joi.objectId()),
-          }).min(1),
+          payload: Joi.object({ name: Joi.string(), activities: Joi.array().items(Joi.objectId()) }).min(1),
         },
         auth: { scope: ['programs:edit'] },
         pre: [{ method: authorizeStepUpdate }],
@@ -70,10 +67,7 @@ exports.plugin = {
       path: '/{_id}/activities/{activityId}',
       options: {
         validate: {
-          params: Joi.object({
-            _id: Joi.objectId().required(),
-            activityId: Joi.objectId().required(),
-          }),
+          params: Joi.object({ _id: Joi.objectId().required(), activityId: Joi.objectId().required() }),
         },
         auth: { scope: ['programs:edit'] },
         pre: [{ method: authorizeActivityDetachment }],

--- a/src/routes/steps.js
+++ b/src/routes/steps.js
@@ -57,9 +57,7 @@ exports.plugin = {
       options: {
         validate: {
           params: Joi.object({ _id: Joi.objectId().required() }),
-          payload: Joi.object({
-            activities: Joi.objectId().required(),
-          }),
+          payload: Joi.object({ activities: Joi.objectId().required() }),
         },
         auth: { scope: ['programs:edit'] },
         pre: [{ method: authorizeActivityReuse }],

--- a/src/routes/steps.js
+++ b/src/routes/steps.js
@@ -70,7 +70,10 @@ exports.plugin = {
       path: '/{_id}/activities/{activityId}',
       options: {
         validate: {
-          params: Joi.object({ _id: Joi.objectId().required(), activityId: Joi.objectId().required() }),
+          params: Joi.object({
+            _id: Joi.objectId().required(),
+            activityId: Joi.objectId().required(),
+          }),
         },
         auth: { scope: ['programs:edit'] },
         pre: [{ method: authorizeActivityDetachment }],

--- a/src/routes/subPrograms.js
+++ b/src/routes/subPrograms.js
@@ -24,10 +24,7 @@ exports.plugin = {
           params: Joi.object({ _id: Joi.objectId().required() }),
           payload: Joi.alternatives().try(
             Joi.object({ name: Joi.string(), steps: Joi.array().items(Joi.string()).min(1) }).min(1),
-            Joi.object({
-              status: Joi.string().required().valid(PUBLISHED),
-              accessCompany: Joi.objectId(),
-            })
+            Joi.object({ status: Joi.string().required().valid(PUBLISHED), accessCompany: Joi.objectId() })
           ),
         },
         auth: { scope: ['programs:edit'] },

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -100,10 +100,7 @@ exports.plugin = {
       options: {
         auth: { scope: ['users:list'] },
         validate: {
-          query: Joi.object({
-            role: [Joi.array(), Joi.string()],
-            company: Joi.objectId(),
-          }),
+          query: Joi.object({ role: [Joi.array(), Joi.string()], company: Joi.objectId() }),
         },
         pre: [{ method: authorizeUsersGet }],
       },
@@ -193,14 +190,9 @@ exports.plugin = {
             emergencyPhone: Joi.string(),
             sector: Joi.objectId(),
             'local.email': Joi.string().email(), // bot special case
-            local: Joi.object().keys({
-              email: Joi.string().email(),
-            }),
+            local: Joi.object().keys({ email: Joi.string().email() }),
             role: Joi.objectId(),
-            picture: Joi.object().keys({
-              link: Joi.string().allow(null),
-              publicId: Joi.string().allow(null),
-            }),
+            picture: Joi.object().keys({ link: Joi.string().allow(null), publicId: Joi.string().allow(null) }),
             mentor: Joi.string().allow('', null),
             identity: Joi.object().keys({
               title: Joi.string(),
@@ -213,50 +205,26 @@ exports.plugin = {
               birthCity: Joi.string(),
               socialSecurityNumber: Joi.number(),
             }),
-            contact: Joi.object().keys({
-              phone: phoneNumberValidation.allow('', null),
-              address: addressValidation,
-            }),
+            contact: Joi.object().keys({ phone: phoneNumberValidation.allow('', null), address: addressValidation }),
             administrative: Joi.object().keys({
-              signup: Joi.object().keys({
-                step: Joi.string(),
-                complete: Joi.boolean(),
-              }),
+              signup: Joi.object().keys({ step: Joi.string(), complete: Joi.boolean() }),
               identityDocs: Joi.string().valid('pp', 'cni', 'ts'),
               mutualFund: Joi.object().keys({
                 has: Joi.boolean(),
                 driveId: Joi.string().allow(null),
                 link: Joi.string().allow(null),
               }),
-              navigoInvoice: Joi.object().keys({
-                driveId: Joi.string().allow(null),
-                link: Joi.string().allow(null),
-              }),
+              navigoInvoice: Joi.object().keys({ driveId: Joi.string().allow(null), link: Joi.string().allow(null) }),
               transportInvoice: Joi.object().keys({
                 transportType: Joi.string(),
                 driveId: Joi.string().allow(null),
                 link: Joi.string().allow(null),
               }),
-              phoneInvoice: Joi.object().keys({
-                driveId: Joi.string().allow(null),
-                link: Joi.string().allow(null),
-              }),
-              healthAttest: Joi.object().keys({
-                driveId: Joi.string().allow(null),
-                link: Joi.string().allow(null),
-              }),
-              idCardRecto: Joi.object().keys({
-                driveId: Joi.string().allow(null),
-                link: Joi.string().allow(null),
-              }),
-              idCardVerso: Joi.object().keys({
-                driveId: Joi.string().allow(null),
-                link: Joi.string().allow(null),
-              }),
-              passport: Joi.object().keys({
-                driveId: Joi.string().allow(null),
-                link: Joi.string().allow(null),
-              }),
+              phoneInvoice: Joi.object().keys({ driveId: Joi.string().allow(null), link: Joi.string().allow(null) }),
+              healthAttest: Joi.object().keys({ driveId: Joi.string().allow(null), link: Joi.string().allow(null) }),
+              idCardRecto: Joi.object().keys({ driveId: Joi.string().allow(null), link: Joi.string().allow(null) }),
+              idCardVerso: Joi.object().keys({ driveId: Joi.string().allow(null), link: Joi.string().allow(null) }),
+              passport: Joi.object().keys({ driveId: Joi.string().allow(null), link: Joi.string().allow(null) }),
               residencePermitRecto: Joi.object().keys({
                 driveId: Joi.string().allow(null),
                 link: Joi.string().allow(null),
@@ -270,16 +238,8 @@ exports.plugin = {
                 link: Joi.string().allow(null),
               }),
               socialSecurityNumber: Joi.number(),
-              payment: Joi.object().keys({
-                rib: Joi.object().keys({
-                  iban: Joi.string(),
-                  bic: Joi.string(),
-                }),
-              }),
-              emergencyContact: Joi.object().keys({
-                name: Joi.string(),
-                phoneNumber: Joi.string(),
-              }),
+              payment: Joi.object().keys({ rib: Joi.object().keys({ iban: Joi.string(), bic: Joi.string() }) }),
+              emergencyContact: Joi.object().keys({ name: Joi.string(), phoneNumber: Joi.string() }),
             }),
             isActive: Joi.boolean(),
             establishment: Joi.objectId(),
@@ -300,9 +260,7 @@ exports.plugin = {
         auth: { scope: ['users:edit', 'user:edit-{params._id}'] },
         validate: {
           params: Joi.object({ _id: Joi.objectId().required() }),
-          payload: Joi.object().keys({
-            certificates: Joi.object().keys({ driveId: Joi.string() }),
-          }),
+          payload: Joi.object().keys({ certificates: Joi.object().keys({ driveId: Joi.string() }) }),
         },
         pre: [
           { method: getUser, assign: 'user' },
@@ -342,10 +300,7 @@ exports.plugin = {
             type: Joi.string().required().valid(...driveUploadKeys),
             file: Joi.any().required(),
           }),
-          params: Joi.object({
-            _id: Joi.objectId().required(),
-            driveId: Joi.string().required(),
-          }),
+          params: Joi.object({ _id: Joi.objectId().required(), driveId: Joi.string().required() }),
         },
         pre: [
           { method: getUser, assign: 'user' },
@@ -375,10 +330,7 @@ exports.plugin = {
         auth: { scope: ['users:edit', 'user:edit-{params._id}'] },
         validate: {
           params: Joi.object({ _id: Joi.objectId().required() }),
-          payload: Joi.object({
-            fileName: Joi.string().required(),
-            file: Joi.any().required(),
-          }),
+          payload: Joi.object({ fileName: Joi.string().required(), file: Joi.any().required() }),
         },
         payload: formDataPayload(),
       },
@@ -417,10 +369,7 @@ exports.plugin = {
       options: {
         auth: { scope: ['user:edit-{params._id}'] },
         validate: {
-          params: Joi.object({
-            _id: Joi.objectId().required(),
-            expoToken: Joi.string().required(),
-          }),
+          params: Joi.object({ _id: Joi.objectId().required(), expoToken: Joi.string().required() }),
         },
         pre: [{ method: authorizeExpoTokenEdit }],
       },

--- a/src/routes/version.js
+++ b/src/routes/version.js
@@ -13,9 +13,7 @@ exports.plugin = {
       options: {
         auth: false,
         validate: {
-          query: Joi.object({
-            apiVersion: Joi.string(),
-          }).required(),
+          query: Joi.object({ apiVersion: Joi.string() }).required(),
         },
       },
       handler: shouldUpdate,

--- a/tests/integration/courses.test.js
+++ b/tests/integration/courses.test.js
@@ -119,7 +119,7 @@ describe('COURSES ROUTES - POST /courses', () => {
     it('should return 400 if invalid type', async () => {
       const payload = {
         misc: 'course',
-        type: 'qwer',
+        type: 'invalid type',
         subProgram: subProgramsList[0]._id,
         salesRepresentative: vendorAdmin._id,
       };

--- a/tests/integration/steps.test.js
+++ b/tests/integration/steps.test.js
@@ -401,10 +401,10 @@ describe('STEPS ROUTES - PUT /steps/{_id}/activities', () => {
       }));
     });
 
-    it('should return a 400 if missing acitivities in payload', async () => {
+    it('should return a 400 if missing activities in payload', async () => {
       const response = await app.inject({
         method: 'PUT',
-        url: `/steps/${new ObjectID()}/activities`,
+        url: `/steps/${stepId}/activities`,
         payload: {},
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
@@ -505,15 +505,26 @@ describe('STEPS ROUTES - DELETE /steps/{_id}/activities/{activityId}', () => {
       });
 
       const stepUpdated = await Step.findById(step._id).lean();
-      const detachedActivity = await Activity.findById(activityId).lean();
+      const detachedActivity = await Activity.countDocuments({ _id: activityId });
 
       expect(response.statusCode).toBe(200);
       expect(stepUpdated._id).toEqual(step._id);
       expect(stepUpdated.activities.length).toEqual(step.activities.length - 1);
-      expect(detachedActivity._id).toEqual(activityId);
+      expect(detachedActivity).toEqual(1);
     });
 
-    it('should return a 404 if step does not exists or doesn\'t have the specified activities', async () => {
+    it('should return a 404 if step doesn\'t exist', async () => {
+      const unknownStepId = new ObjectID();
+      const response = await app.inject({
+        method: 'DELETE',
+        url: `/steps/${unknownStepId.toHexString()}/activities/${activityId.toHexString()}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+
+    it('should return a 404 if step doesn\'t have the specified activities', async () => {
       const invalidActivityId = activitiesList[1]._id;
       const response = await app.inject({
         method: 'DELETE',

--- a/tests/integration/steps.test.js
+++ b/tests/integration/steps.test.js
@@ -401,28 +401,27 @@ describe('STEPS ROUTES - PUT /steps/{_id}/activities', () => {
       }));
     });
 
-    it('should not push a reused activity from the same step', async () => {
-      const payload = { activities: activitiesList[1]._id };
+    it('should return a 400 if missing acitivities in payload', async () => {
       const response = await app.inject({
         method: 'PUT',
-        url: `/steps/${stepId.toHexString()}/activities`,
-        payload,
+        url: `/steps/${new ObjectID()}/activities`,
+        payload: {},
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
       expect(response.statusCode).toBe(400);
     });
 
-    it('should not push an invalid activityid', async () => {
-      const payload = { activities: (new ObjectID()).toHexString() };
+    it('should return a 404 if invalid step id', async () => {
+      const payload = { activities: activitiesList[0]._id };
       const response = await app.inject({
         method: 'PUT',
-        url: `/steps/${stepId.toHexString()}/activities`,
+        url: `/steps/${new ObjectID()}/activities`,
         payload,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
-      expect(response.statusCode).toBe(400);
+      expect(response.statusCode).toBe(404);
     });
 
     it('should return a 403 if step is published', async () => {
@@ -435,6 +434,30 @@ describe('STEPS ROUTES - PUT /steps/{_id}/activities', () => {
       });
 
       expect(response.statusCode).toBe(403);
+    });
+
+    it('should return a 404 if invalid activity id', async () => {
+      const payload = { activities: (new ObjectID()).toHexString() };
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/steps/${stepId.toHexString()}/activities`,
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+
+    it('should return a 400 if reused activity is from the same step', async () => {
+      const payload = { activities: activitiesList[1]._id };
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/steps/${stepId.toHexString()}/activities`,
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(400);
     });
   });
 

--- a/tests/integration/steps.test.js
+++ b/tests/integration/steps.test.js
@@ -27,7 +27,7 @@ describe('STEPS ROUTES - PUT /steps/{_id}', () => {
       const payload = { name: 'une nouvelle étape super innovante' };
       const response = await app.inject({
         method: 'PUT',
-        url: `/steps/${stepId.toHexString()}`,
+        url: `/steps/${stepId}`,
         payload,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
@@ -42,7 +42,7 @@ describe('STEPS ROUTES - PUT /steps/{_id}', () => {
       const payload = { name: 'une nouvelle étape super innovante' };
       const response = await app.inject({
         method: 'PUT',
-        url: `/steps/${stepsList[3]._id.toHexString()}`,
+        url: `/steps/${stepsList[3]._id}`,
         payload,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
@@ -54,7 +54,7 @@ describe('STEPS ROUTES - PUT /steps/{_id}', () => {
       const payload = { activities: [stepsList[0].activities[1], stepsList[0].activities[0]] };
       const response = await app.inject({
         method: 'PUT',
-        url: `/steps/${stepId.toHexString()}`,
+        url: `/steps/${stepId}`,
         payload,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
@@ -80,7 +80,7 @@ describe('STEPS ROUTES - PUT /steps/{_id}', () => {
       const payload = { activities: [stepsList[0].activities[1], stepsList[0].activities[0]], name: 'skusku' };
       const response = await app.inject({
         method: 'PUT',
-        url: `/steps/${stepsList[3]._id.toHexString()}`,
+        url: `/steps/${stepsList[3]._id}`,
         payload,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
@@ -91,7 +91,7 @@ describe('STEPS ROUTES - PUT /steps/{_id}', () => {
     it('should return a 400 if payload is empty', async () => {
       const response = await app.inject({
         method: 'PUT',
-        url: `/steps/${stepId.toHexString()}`,
+        url: `/steps/${stepId}`,
         payload: {},
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
@@ -102,7 +102,7 @@ describe('STEPS ROUTES - PUT /steps/{_id}', () => {
     it('should return a 400 if name is empty ', async () => {
       const response = await app.inject({
         method: 'PUT',
-        url: `/steps/${stepId.toHexString()}`,
+        url: `/steps/${stepId}`,
         payload: { name: '' },
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
@@ -114,7 +114,7 @@ describe('STEPS ROUTES - PUT /steps/{_id}', () => {
       const payload = { activities: [stepsList[0].activities[1]] };
       const response = await app.inject({
         method: 'PUT',
-        url: `/steps/${stepId.toHexString()}`,
+        url: `/steps/${stepId}`,
         payload,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
@@ -126,7 +126,7 @@ describe('STEPS ROUTES - PUT /steps/{_id}', () => {
       const payload = { activities: [stepsList[0].activities[1], new ObjectID()] };
       const response = await app.inject({
         method: 'PUT',
-        url: `/steps/${stepId.toHexString()}`,
+        url: `/steps/${stepId}`,
         payload,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
@@ -150,7 +150,7 @@ describe('STEPS ROUTES - PUT /steps/{_id}', () => {
         const response = await app.inject({
           method: 'PUT',
           payload,
-          url: `/steps/${stepId.toHexString()}`,
+          url: `/steps/${stepId}`,
           headers: { Cookie: `alenvi_token=${authToken}` },
         });
 
@@ -174,7 +174,7 @@ describe('STEPS ROUTES - POST /steps/{_id}/activity', () => {
       const payload = { name: 'new activity', type: 'video' };
       const response = await app.inject({
         method: 'POST',
-        url: `/steps/${step._id.toHexString()}/activities`,
+        url: `/steps/${step._id}/activities`,
         payload,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
@@ -191,7 +191,7 @@ describe('STEPS ROUTES - POST /steps/{_id}/activity', () => {
         const payload = { name: 'new activity', type: 'video' };
         const response = await app.inject({
           method: 'POST',
-          url: `/steps/${step._id.toHexString()}/activities`,
+          url: `/steps/${step._id}/activities`,
           payload: omit(payload, missingParam),
           headers: { Cookie: `alenvi_token=${authToken}` },
         });
@@ -205,7 +205,7 @@ describe('STEPS ROUTES - POST /steps/{_id}/activity', () => {
       const wrongPayload = { ...payload, type: 'something_wrong' };
       const response = await app.inject({
         method: 'POST',
-        url: `/steps/${step._id.toHexString()}/activities`,
+        url: `/steps/${step._id}/activities`,
         payload: wrongPayload,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
@@ -218,7 +218,7 @@ describe('STEPS ROUTES - POST /steps/{_id}/activity', () => {
       const duplicatedCardId = cardsList[0]._id;
       const response = await app.inject({
         method: 'POST',
-        url: `/steps/${step._id.toHexString()}/activities`,
+        url: `/steps/${step._id}/activities`,
         payload: { activityId: duplicatedActivityId },
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
@@ -256,7 +256,7 @@ describe('STEPS ROUTES - POST /steps/{_id}/activity', () => {
       const duplicatedActivityId = activitiesList[3]._id;
       const response = await app.inject({
         method: 'POST',
-        url: `/steps/${step._id.toHexString()}/activities`,
+        url: `/steps/${step._id}/activities`,
         payload: { activityId: duplicatedActivityId },
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
@@ -319,7 +319,7 @@ describe('STEPS ROUTES - POST /steps/{_id}/activity', () => {
       const payload = { name: 'new activity', type: 'video' };
       const response = await app.inject({
         method: 'POST',
-        url: `/steps/${stepsList[3]._id.toHexString()}/activities`,
+        url: `/steps/${stepsList[3]._id}/activities`,
         payload,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
@@ -343,7 +343,7 @@ describe('STEPS ROUTES - POST /steps/{_id}/activity', () => {
         const response = await app.inject({
           method: 'POST',
           payload,
-          url: `/steps/${step._id.toHexString()}/activities`,
+          url: `/steps/${step._id}/activities`,
           headers: { Cookie: `alenvi_token=${authToken}` },
         });
 
@@ -369,7 +369,7 @@ describe('STEPS ROUTES - PUT /steps/{_id}/activities', () => {
       const reusedCardId = cardsList[0]._id;
       const response = await app.inject({
         method: 'PUT',
-        url: `/steps/${stepId.toHexString()}/activities`,
+        url: `/steps/${stepId}/activities`,
         payload,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
@@ -428,7 +428,7 @@ describe('STEPS ROUTES - PUT /steps/{_id}/activities', () => {
       const payload = { activities: activitiesList[0]._id };
       const response = await app.inject({
         method: 'PUT',
-        url: `/steps/${stepsList[3]._id.toHexString()}/activities`,
+        url: `/steps/${stepsList[3]._id}/activities`,
         payload,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
@@ -437,10 +437,10 @@ describe('STEPS ROUTES - PUT /steps/{_id}/activities', () => {
     });
 
     it('should return a 404 if invalid activity id', async () => {
-      const payload = { activities: (new ObjectID()).toHexString() };
+      const payload = { activities: (new ObjectID()) };
       const response = await app.inject({
         method: 'PUT',
-        url: `/steps/${stepId.toHexString()}/activities`,
+        url: `/steps/${stepId}/activities`,
         payload,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
@@ -452,7 +452,7 @@ describe('STEPS ROUTES - PUT /steps/{_id}/activities', () => {
       const payload = { activities: activitiesList[1]._id };
       const response = await app.inject({
         method: 'PUT',
-        url: `/steps/${stepId.toHexString()}/activities`,
+        url: `/steps/${stepId}/activities`,
         payload,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
@@ -476,7 +476,7 @@ describe('STEPS ROUTES - PUT /steps/{_id}/activities', () => {
         const response = await app.inject({
           method: 'PUT',
           payload,
-          url: `/steps/${stepId.toHexString()}/activities`,
+          url: `/steps/${stepId}/activities`,
           headers: { Cookie: `alenvi_token=${authToken}` },
         });
 
@@ -500,7 +500,7 @@ describe('STEPS ROUTES - DELETE /steps/{_id}/activities/{activityId}', () => {
     it('should detach activity from step', async () => {
       const response = await app.inject({
         method: 'DELETE',
-        url: `/steps/${step._id.toHexString()}/activities/${activityId.toHexString()}`,
+        url: `/steps/${step._id}/activities/${activityId}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
@@ -517,7 +517,7 @@ describe('STEPS ROUTES - DELETE /steps/{_id}/activities/{activityId}', () => {
       const invalidActivityId = activitiesList[1]._id;
       const response = await app.inject({
         method: 'DELETE',
-        url: `/steps/${step._id.toHexString()}/activities/${invalidActivityId.toHexString()}`,
+        url: `/steps/${step._id}/activities/${invalidActivityId}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
@@ -528,7 +528,7 @@ describe('STEPS ROUTES - DELETE /steps/{_id}/activities/{activityId}', () => {
       const payload = { activities: activitiesList[0]._id };
       const response = await app.inject({
         method: 'DELETE',
-        url: `/steps/${stepsList[3]._id.toHexString()}/activities/${activitiesList[3]._id.toHexString()}`,
+        url: `/steps/${stepsList[3]._id}/activities/${activitiesList[3]._id}`,
         payload,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
@@ -550,7 +550,7 @@ describe('STEPS ROUTES - DELETE /steps/{_id}/activities/{activityId}', () => {
         authToken = await getToken(role.name);
         const response = await app.inject({
           method: 'DELETE',
-          url: `/steps/${step._id.toHexString()}/activities/${activityId.toHexString()}`,
+          url: `/steps/${step._id}/activities/${activityId}`,
           headers: { Cookie: `alenvi_token=${authToken}` },
         });
 

--- a/tests/integration/steps.test.js
+++ b/tests/integration/steps.test.js
@@ -504,8 +504,8 @@ describe('STEPS ROUTES - DELETE /steps/{_id}/activities/{activityId}', () => {
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
-      const stepUpdated = await Step.findById(step._id);
-      const detachedActivity = await Activity.findById(activityId);
+      const stepUpdated = await Step.findById(step._id).lean();
+      const detachedActivity = await Activity.findById(activityId).lean();
 
       expect(response.statusCode).toBe(200);
       expect(stepUpdated._id).toEqual(step._id);
@@ -513,18 +513,7 @@ describe('STEPS ROUTES - DELETE /steps/{_id}/activities/{activityId}', () => {
       expect(detachedActivity._id).toEqual(activityId);
     });
 
-    it('should return a 404 if step does not exist', async () => {
-      const unknownStepId = new ObjectID();
-      const response = await app.inject({
-        method: 'DELETE',
-        url: `/steps/${unknownStepId.toHexString()}/activities/${activityId.toHexString()}`,
-        headers: { Cookie: `alenvi_token=${authToken}` },
-      });
-
-      expect(response.statusCode).toBe(404);
-    });
-
-    it('should return a 404 if step does not contain activity', async () => {
+    it('should return a 404 if step does not exists or doesn\'t have the specified activities', async () => {
       const invalidActivityId = activitiesList[1]._id;
       const response = await app.inject({
         method: 'DELETE',

--- a/tests/integration/steps.test.js
+++ b/tests/integration/steps.test.js
@@ -18,9 +18,9 @@ describe('STEPS ROUTES - PUT /steps/{_id}', () => {
   beforeEach(populateDB);
   const stepId = stepsList[0]._id;
 
-  describe('VENDOR_ADMIN', () => {
+  describe('TRAINING_ORGANISATION_MANAGER', () => {
     beforeEach(async () => {
-      authToken = await getToken('vendor_admin');
+      authToken = await getToken('training_organisation_manager');
     });
 
     it('should update step name', async () => {
@@ -125,11 +125,8 @@ describe('STEPS ROUTES - PUT /steps/{_id}', () => {
     const payload = { name: 'une nouvelle étape super innovant' };
     const roles = [
       { name: 'helper', expectedCode: 403 },
-      { name: 'auxiliary', expectedCode: 403 },
-      { name: 'auxiliary_without_company', expectedCode: 403 },
-      { name: 'coach', expectedCode: 403 },
+      { name: 'planning_referent', expectedCode: 403 },
       { name: 'client_admin', expectedCode: 403 },
-      { name: 'training_organisation_manager', expectedCode: 200 },
       { name: 'trainer', expectedCode: 403 },
     ];
 
@@ -155,9 +152,9 @@ describe('STEPS ROUTES - POST /steps/{_id}/activity', () => {
   const payload = { name: 'new activity', type: 'video' };
   const step = stepsList[0];
 
-  describe('VENDOR_ADMIN', () => {
+  describe('TRAINING_ORGANISATION_MANAGER', () => {
     beforeEach(async () => {
-      authToken = await getToken('vendor_admin');
+      authToken = await getToken('training_organisation_manager');
     });
 
     describe('creation', () => {
@@ -292,11 +289,8 @@ describe('STEPS ROUTES - POST /steps/{_id}/activity', () => {
   describe('Other roles', () => {
     const roles = [
       { name: 'helper', expectedCode: 403 },
-      { name: 'auxiliary', expectedCode: 403 },
-      { name: 'auxiliary_without_company', expectedCode: 403 },
-      { name: 'coach', expectedCode: 403 },
+      { name: 'planning_referent', expectedCode: 403 },
       { name: 'client_admin', expectedCode: 403 },
-      { name: 'training_organisation_manager', expectedCode: 200 },
       { name: 'trainer', expectedCode: 403 },
     ];
 
@@ -321,9 +315,9 @@ describe('STEPS ROUTES - PUT /steps/{_id}/activities', () => {
   beforeEach(populateDB);
   const stepId = stepsList[0]._id;
 
-  describe('VENDOR_ADMIN', () => {
+  describe('TRAINING_ORGANISATION_MANAGER', () => {
     beforeEach(async () => {
-      authToken = await getToken('vendor_admin');
+      authToken = await getToken('training_organisation_manager');
     });
 
     it('should push a reused activity', async () => {
@@ -405,11 +399,8 @@ describe('STEPS ROUTES - PUT /steps/{_id}/activities', () => {
     const payload = { activities: activitiesList[0]._id };
     const roles = [
       { name: 'helper', expectedCode: 403 },
-      { name: 'auxiliary', expectedCode: 403 },
-      { name: 'auxiliary_without_company', expectedCode: 403 },
-      { name: 'coach', expectedCode: 403 },
+      { name: 'planning_referent', expectedCode: 403 },
       { name: 'client_admin', expectedCode: 403 },
-      { name: 'training_organisation_manager', expectedCode: 200 },
       { name: 'trainer', expectedCode: 403 },
     ];
 
@@ -435,9 +426,9 @@ describe('STEPS ROUTES - DELETE /steps/{_id}/activities/{activityId}', () => {
   const activityId = activitiesList[0]._id;
   beforeEach(populateDB);
 
-  describe('VENDOR_ADMIN', () => {
+  describe('TRAINING_ORGANISATION_MANAGER', () => {
     beforeEach(async () => {
-      authToken = await getToken('vendor_admin');
+      authToken = await getToken('training_organisation_manager');
     });
 
     it('should detach activity from step', async () => {
@@ -494,11 +485,8 @@ describe('STEPS ROUTES - DELETE /steps/{_id}/activities/{activityId}', () => {
   describe('Other roles', () => {
     const roles = [
       { name: 'helper', expectedCode: 403 },
-      { name: 'auxiliary', expectedCode: 403 },
-      { name: 'auxiliary_without_company', expectedCode: 403 },
-      { name: 'coach', expectedCode: 403 },
+      { name: 'planning_referent', expectedCode: 403 },
       { name: 'client_admin', expectedCode: 403 },
-      { name: 'training_organisation_manager', expectedCode: 200 },
       { name: 'trainer', expectedCode: 403 },
     ];
 


### PR DESCRIPTION
Refacto des tests d'intégration de steps
La PR est découpée par commit, si ça peut vous aider

Repasser sur tous les tests d’intégration pour supprimer les tests inutiles : 
- s’assurer que pour chaque groupe de test, le rôle choisi est le plus pertinent (rôle le plus bas pour un test en 200, rôle le plus haut pour un test en 403)
- s’assurer que le test ne teste pas des choses déjà testées en test unitaire (format du retour d’une route)
- s’assurer que le test n’est pas redondant (ex : un test 404 cette entité n’existe pas + un test 404 cette entité n’appartient pas à la bonne structure, alors que le 2e test serait suffisant)
- s’assurer que le test n’est pas inutile