### PR TITLE
COM-2283 - update seeds

### DIFF
--- a/tests/integration/activities.test.js
+++ b/tests/integration/activities.test.js
@@ -27,7 +27,7 @@ describe('ACTIVITIES ROUTES - GET /activity/{_id}', () => {
     it('should get activity', async () => {
       const response = await app.inject({
         method: 'GET',
-        url: `/activities/${activityId.toHexString()}`,
+        url: `/activities/${activityId}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
@@ -40,7 +40,6 @@ describe('ACTIVITIES ROUTES - GET /activity/{_id}', () => {
 describe('ACTIVITIES ROUTES - PUT /activity/{_id}', () => {
   let authToken = null;
   beforeEach(populateDB);
-  const activityId = activitiesList[0]._id;
 
   describe('TRAINING_ORGANISATION_MANAGER', () => {
     beforeEach(async () => {
@@ -51,7 +50,7 @@ describe('ACTIVITIES ROUTES - PUT /activity/{_id}', () => {
       const payload = { name: 'rigoler' };
       const response = await app.inject({
         method: 'PUT',
-        url: `/activities/${activitiesList[3]._id.toHexString()}`,
+        url: `/activities/${activitiesList[3]._id}`,
         payload,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
@@ -73,12 +72,12 @@ describe('ACTIVITIES ROUTES - PUT /activity/{_id}', () => {
       };
       const response = await app.inject({
         method: 'PUT',
-        url: `/activities/${activityId.toHexString()}`,
+        url: `/activities/${activitiesList[0]._id}`,
         payload,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
-      const activityUpdated = await Activity.countDocuments({ _id: activityId, cards: payload.cards });
+      const activityUpdated = await Activity.countDocuments({ _id: activitiesList[0]._id, cards: payload.cards });
 
       expect(response.statusCode).toBe(200);
       expect(activityUpdated).toEqual(1);
@@ -87,7 +86,7 @@ describe('ACTIVITIES ROUTES - PUT /activity/{_id}', () => {
     it('should return a 400 if name is equal to \'\' ', async () => {
       const response = await app.inject({
         method: 'PUT',
-        url: `/activities/${activityId.toHexString()}`,
+        url: `/activities/${activitiesList[0]._id}`,
         payload: { name: '' },
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
@@ -99,7 +98,7 @@ describe('ACTIVITIES ROUTES - PUT /activity/{_id}', () => {
       const payload = { cards: [activitiesList[0].cards[1]] };
       const response = await app.inject({
         method: 'PUT',
-        url: `/activities/${activityId.toHexString()}`,
+        url: `/activities/${activitiesList[0]._id}`,
         payload,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
@@ -111,7 +110,7 @@ describe('ACTIVITIES ROUTES - PUT /activity/{_id}', () => {
       const payload = { cards: [activitiesList[0].cards[1], new ObjectID()] };
       const response = await app.inject({
         method: 'PUT',
-        url: `/activities/${activityId.toHexString()}`,
+        url: `/activities/${activitiesList[0]._id}`,
         payload,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
@@ -123,7 +122,7 @@ describe('ACTIVITIES ROUTES - PUT /activity/{_id}', () => {
       const payload = { type: 'quiz' };
       const response = await app.inject({
         method: 'PUT',
-        url: `/activities/${activitiesList[3]._id.toHexString()}`,
+        url: `/activities/${activitiesList[3]._id}`,
         payload,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
@@ -147,7 +146,7 @@ describe('ACTIVITIES ROUTES - PUT /activity/{_id}', () => {
         const response = await app.inject({
           method: 'PUT',
           payload,
-          url: `/activities/${activityId.toHexString()}`,
+          url: `/activities/${activitiesList[0]._id}`,
           headers: { Cookie: `alenvi_token=${authToken}` },
         });
 
@@ -159,7 +158,6 @@ describe('ACTIVITIES ROUTES - PUT /activity/{_id}', () => {
 
 describe('ACTIVITIES ROUTES - POST /activities/{_id}/card', () => {
   let authToken = null;
-  const activityId = activitiesList[0]._id;
   beforeEach(populateDB);
   const payload = { template: TITLE_TEXT_MEDIA };
 
@@ -171,12 +169,12 @@ describe('ACTIVITIES ROUTES - POST /activities/{_id}/card', () => {
     it('should create card', async () => {
       const response = await app.inject({
         method: 'POST',
-        url: `/activities/${activityId.toHexString()}/cards`,
+        url: `/activities/${activitiesList[0]._id}/cards`,
         payload,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
-      const activityUpdated = await Activity.findById(activityId).lean();
+      const activityUpdated = await Activity.findById(activitiesList[0]._id).lean();
 
       expect(response.statusCode).toBe(200);
       expect(activityUpdated.cards.length).toEqual(5);
@@ -185,7 +183,7 @@ describe('ACTIVITIES ROUTES - POST /activities/{_id}/card', () => {
     it('should return a 400 if invalid template', async () => {
       const response = await app.inject({
         method: 'POST',
-        url: `/activities/${activityId.toHexString()}/cards`,
+        url: `/activities/${activitiesList[0]._id}/cards`,
         payload: { template: 'invalid template' },
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
@@ -196,7 +194,7 @@ describe('ACTIVITIES ROUTES - POST /activities/{_id}/card', () => {
     it('should return a 400 if missing template', async () => {
       const response = await app.inject({
         method: 'POST',
-        url: `/activities/${activityId.toHexString()}/cards`,
+        url: `/activities/${activitiesList[0]._id}/cards`,
         payload: {},
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
@@ -205,10 +203,9 @@ describe('ACTIVITIES ROUTES - POST /activities/{_id}/card', () => {
     });
 
     it('should return a 404 if activity does not exist', async () => {
-      const invalidId = new ObjectID();
       const response = await app.inject({
         method: 'POST',
-        url: `/activities/${invalidId}/cards`,
+        url: `/activities/${new ObjectID()}/cards`,
         payload,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
@@ -219,7 +216,7 @@ describe('ACTIVITIES ROUTES - POST /activities/{_id}/card', () => {
     it('should return a 403 if activity is published', async () => {
       const response = await app.inject({
         method: 'POST',
-        url: `/activities/${activitiesList[3]._id.toHexString()}/cards`,
+        url: `/activities/${activitiesList[3]._id}/cards`,
         payload,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
@@ -242,7 +239,7 @@ describe('ACTIVITIES ROUTES - POST /activities/{_id}/card', () => {
         const response = await app.inject({
           method: 'POST',
           payload: { template: 'transition' },
-          url: `/activities/${activityId.toHexString()}/cards`,
+          url: `/activities/${activitiesList[0]._id}/cards`,
           headers: { Cookie: `alenvi_token=${authToken}` },
         });
 
@@ -266,7 +263,7 @@ describe('ACTIVITIES ROUTES - DELETE /activities/cards/{cardId}', () => {
     it('should delete activity card', async () => {
       const response = await app.inject({
         method: 'DELETE',
-        url: `/activities/cards/${draftActivity.cards[0].toHexString()}`,
+        url: `/activities/cards/${draftActivity.cards[0]}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
@@ -283,7 +280,7 @@ describe('ACTIVITIES ROUTES - DELETE /activities/cards/{cardId}', () => {
     it('should return 404 if card not found', async () => {
       const response = await app.inject({
         method: 'DELETE',
-        url: `/activities/cards/${(new ObjectID()).toHexString()}`,
+        url: `/activities/cards/${new ObjectID()}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
@@ -293,7 +290,7 @@ describe('ACTIVITIES ROUTES - DELETE /activities/cards/{cardId}', () => {
     it('should return 403 if activity is published', async () => {
       const response = await app.inject({
         method: 'DELETE',
-        url: `/activities/cards/${publishedActivity.cards[0].toHexString()}`,
+        url: `/activities/cards/${publishedActivity.cards[0]}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
@@ -314,7 +311,7 @@ describe('ACTIVITIES ROUTES - DELETE /activities/cards/{cardId}', () => {
         authToken = await getToken(role.name);
         const response = await app.inject({
           method: 'DELETE',
-          url: `/activities/cards/${draftActivity.cards[0].toHexString()}`,
+          url: `/activities/cards/${draftActivity.cards[0]}`,
           headers: { Cookie: `alenvi_token=${authToken}` },
         });
 

--- a/tests/integration/activities.test.js
+++ b/tests/integration/activities.test.js
@@ -15,7 +15,7 @@ describe('NODE ENV', () => {
 });
 
 describe('ACTIVITIES ROUTES - GET /activity/{_id}', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
   const activityId = activitiesList[0]._id;
 
@@ -38,7 +38,7 @@ describe('ACTIVITIES ROUTES - GET /activity/{_id}', () => {
 });
 
 describe('ACTIVITIES ROUTES - PUT /activity/{_id}', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
 
   describe('TRAINING_ORGANISATION_MANAGER', () => {
@@ -157,7 +157,7 @@ describe('ACTIVITIES ROUTES - PUT /activity/{_id}', () => {
 });
 
 describe('ACTIVITIES ROUTES - POST /activities/{_id}/card', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
   const payload = { template: TITLE_TEXT_MEDIA };
 
@@ -250,7 +250,7 @@ describe('ACTIVITIES ROUTES - POST /activities/{_id}/card', () => {
 });
 
 describe('ACTIVITIES ROUTES - DELETE /activities/cards/{cardId}', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
   const draftActivity = activitiesList.find(activity => activity.status === 'draft');
   const publishedActivity = activitiesList.find(activity => activity.status === 'published');

--- a/tests/integration/activityHistories.test.js
+++ b/tests/integration/activityHistories.test.js
@@ -13,7 +13,7 @@ describe('NODE ENV', () => {
 });
 
 describe('ACTIVITY HISTORIES ROUTES - POST /activityhistories', () => {
-  let authToken = null;
+  let authToken;
   const payload = {
     user: userList[1]._id,
     activity: activitiesList[0]._id,
@@ -213,7 +213,7 @@ describe('ACTIVITY HISTORIES ROUTES - POST /activityhistories', () => {
 });
 
 describe('ACTIVITY HISTORIES ROUTES - GET /activityhistories', () => {
-  let authToken = null;
+  let authToken;
 
   describe('COACH', () => {
     beforeEach(populateDB);

--- a/tests/integration/administrativeDocument.test.js
+++ b/tests/integration/administrativeDocument.test.js
@@ -17,7 +17,7 @@ describe('NODE ENV', () => {
 });
 
 describe('ADMINISTRATIVE DOCUMENT ROUTES - GET /administrativedocuments', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
 
   describe('COACH', () => {
@@ -61,7 +61,7 @@ describe('ADMINISTRATIVE DOCUMENT ROUTES - GET /administrativedocuments', () => 
 });
 
 describe('ADMINISTRATIVE DOCUMENT ROUTES - POST /administrativedocuments', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
 
   describe('CLIENT_ADMIN', () => {
@@ -141,7 +141,7 @@ describe('ADMINISTRATIVE DOCUMENT ROUTES - POST /administrativedocuments', () =>
 });
 
 describe('ADMINISTRATIVE DOCUMENT ROUTES - DELETE /administrativedocuments', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
 
   describe('CLIENT_ADMIN', () => {

--- a/tests/integration/attendanceSheets.test.js
+++ b/tests/integration/attendanceSheets.test.js
@@ -18,7 +18,7 @@ describe('NODE ENV', () => {
 });
 
 describe('ATTENDANCE SHEETS ROUTES - POST /attendancesheets', () => {
-  let authToken = null;
+  let authToken;
   let uploadCourseFile;
   describe('TRAINER', () => {
     beforeEach(populateDB);
@@ -194,7 +194,7 @@ describe('ATTENDANCE SHEETS ROUTES - POST /attendancesheets', () => {
 });
 
 describe('ATTENDANCE SHEETS ROUTES - GET /attendancesheets', () => {
-  let authToken = null;
+  let authToken;
 
   describe('TRAINER', () => {
     beforeEach(populateDB);
@@ -276,7 +276,7 @@ describe('ATTENDANCE SHEETS ROUTES - GET /attendancesheets', () => {
 });
 
 describe('ATTENDANCE SHEETS ROUTES - DELETE /attendancesheets/{_id}', () => {
-  let authToken = null;
+  let authToken;
   let deleteCourseFile;
 
   describe('TRAINER', () => {

--- a/tests/integration/attendanceSheets.test.js
+++ b/tests/integration/attendanceSheets.test.js
@@ -294,7 +294,7 @@ describe('ATTENDANCE SHEETS ROUTES - DELETE /attendancesheets/{_id}', () => {
       const attendanceSheetsLength = await AttendanceSheet.countDocuments();
       const response = await app.inject({
         method: 'DELETE',
-        url: `/attendancesheets/${attendanceSheetId.toHexString()}`,
+        url: `/attendancesheets/${attendanceSheetId}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
@@ -306,7 +306,7 @@ describe('ATTENDANCE SHEETS ROUTES - DELETE /attendancesheets/{_id}', () => {
     it('should return a 404 if attendance sheet does not exist', async () => {
       const response = await app.inject({
         method: 'DELETE',
-        url: `/attendancesheets/${new ObjectID().toHexString()}`,
+        url: `/attendancesheets/${new ObjectID()}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
@@ -336,7 +336,7 @@ describe('ATTENDANCE SHEETS ROUTES - DELETE /attendancesheets/{_id}', () => {
         const attendanceSheetId = attendanceSheetsList[0]._id;
         const response = await app.inject({
           method: 'DELETE',
-          url: `/attendancesheets/${attendanceSheetId.toHexString()}`,
+          url: `/attendancesheets/${attendanceSheetId}`,
           headers: { Cookie: `alenvi_token=${authToken}` },
         });
 

--- a/tests/integration/attendances.test.js
+++ b/tests/integration/attendances.test.js
@@ -144,7 +144,7 @@ describe('ATTENDANCES ROUTES - POST /attendances', () => {
 });
 
 describe('ATTENDANCES ROUTES - GET /attendances', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
 
   describe('TRAINING_ORGANISATION_MANAGER', () => {
@@ -300,7 +300,7 @@ describe('ATTENDANCES ROUTES - GET /attendances', () => {
 });
 
 describe('ATTENDANCES ROUTES - DELETE /attendances/{_id}', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
 
   describe('TRAINING_ORGANISATION_MANAGER', () => {

--- a/tests/integration/attendances.test.js
+++ b/tests/integration/attendances.test.js
@@ -299,7 +299,7 @@ describe('ATTENDANCES ROUTES - GET /attendances', () => {
   });
 });
 
-describe('ATTENDANCE ROUTES - DELETE /attendances/{_id}', () => {
+describe('ATTENDANCES ROUTES - DELETE /attendances/{_id}', () => {
   let authToken = null;
   beforeEach(populateDB);
 
@@ -309,11 +309,10 @@ describe('ATTENDANCE ROUTES - DELETE /attendances/{_id}', () => {
     });
 
     it('should delete an attendance', async () => {
-      const attendanceId = attendancesList[0]._id;
       const attendanceCount = await Attendance.countDocuments();
       const response = await app.inject({
         method: 'DELETE',
-        url: `/attendances/${attendanceId.toHexString()}`,
+        url: `/attendances/${attendancesList[0]._id}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
@@ -324,7 +323,7 @@ describe('ATTENDANCE ROUTES - DELETE /attendances/{_id}', () => {
     it('should return a 404 if attendance does not exist', async () => {
       const response = await app.inject({
         method: 'DELETE',
-        url: `/attendances/${new ObjectID().toHexString()}`,
+        url: `/attendances/${new ObjectID()}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
@@ -335,10 +334,9 @@ describe('ATTENDANCE ROUTES - DELETE /attendances/{_id}', () => {
   describe('Other roles', () => {
     it('should return 200 if courseSlot is from trainer\'s courses', async () => {
       authToken = await getTokenByCredentials(userList[0].local);
-      const attendanceId = attendancesList[0]._id;
       const response = await app.inject({
         method: 'DELETE',
-        url: `/attendances/${attendanceId.toHexString()}`,
+        url: `/attendances/${attendancesList[0]._id}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
@@ -347,10 +345,9 @@ describe('ATTENDANCE ROUTES - DELETE /attendances/{_id}', () => {
 
     it('should return 403 if courseSlot is not from trainer\'s courses', async () => {
       authToken = await getTokenByCredentials(userList[1].local);
-      const attendanceId = attendancesList[0]._id;
       const response = await app.inject({
         method: 'DELETE',
-        url: `/attendances/${attendanceId.toHexString()}`,
+        url: `/attendances/${attendancesList[0]._id}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
@@ -365,10 +362,9 @@ describe('ATTENDANCE ROUTES - DELETE /attendances/{_id}', () => {
     roles.forEach((role) => {
       it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
         authToken = await getToken(role.name);
-        const attendanceId = attendancesList[0]._id;
         const response = await app.inject({
           method: 'DELETE',
-          url: `/attendances/${attendanceId.toHexString()}`,
+          url: `/attendances/${attendancesList[0]._id}`,
           headers: { Cookie: `alenvi_token=${authToken}` },
         });
 

--- a/tests/integration/authentication.test.js
+++ b/tests/integration/authentication.test.js
@@ -97,7 +97,7 @@ describe('POST /users/:id/passwordtoken', () => {
     it('should create password token', async () => {
       const res = await app.inject({
         method: 'POST',
-        url: `/users/${usersSeedList[0]._id.toHexString()}/passwordtoken`,
+        url: `/users/${usersSeedList[0]._id}/passwordtoken`,
         payload,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
@@ -108,7 +108,7 @@ describe('POST /users/:id/passwordtoken', () => {
     it('should not create password token if user is from an other company', async () => {
       const res = await app.inject({
         method: 'POST',
-        url: `/users/${auxiliaryFromOtherCompany._id.toHexString()}/passwordtoken`,
+        url: `/users/${auxiliaryFromOtherCompany._id}/passwordtoken`,
         payload,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
@@ -131,7 +131,7 @@ describe('POST /users/:id/passwordtoken', () => {
 
         const response = await app.inject({
           method: 'POST',
-          url: `/users/${userList[1]._id.toHexString()}/passwordtoken`,
+          url: `/users/${userList[1]._id}/passwordtoken`,
           payload,
           headers: { Cookie: `alenvi_token=${authToken}` },
         });
@@ -155,7 +155,7 @@ describe('PUT /users/:id/password', () => {
     it('should update user password if it is me', async () => {
       const response = await app.inject({
         method: 'PUT',
-        url: `/users/${noRoleNoCompany._id.toHexString()}/password`,
+        url: `/users/${noRoleNoCompany._id}/password`,
         payload: updatePayload,
         headers: { 'x-access-token': authToken },
       });
@@ -165,7 +165,7 @@ describe('PUT /users/:id/password', () => {
     it('should return a 400 error if password too short', async () => {
       const response = await app.inject({
         method: 'PUT',
-        url: `/users/${noRoleNoCompany._id.toHexString()}/password`,
+        url: `/users/${noRoleNoCompany._id}/password`,
         payload: { local: { password: '12345' } },
         headers: { 'x-access-token': authToken },
       });
@@ -189,7 +189,7 @@ describe('PUT /users/:id/password', () => {
 
         const response = await app.inject({
           method: 'PUT',
-          url: `/users/${usersSeedList[0]._id.toHexString()}/password`,
+          url: `/users/${usersSeedList[0]._id}/password`,
           payload: updatePayload,
           headers: { Cookie: `alenvi_token=${authToken}` },
         });

--- a/tests/integration/balances.test.js
+++ b/tests/integration/balances.test.js
@@ -2,6 +2,7 @@ const expect = require('expect');
 const { populateDB, balanceCustomerList, balanceUserList, customerFromOtherCompany } = require('./seed/balanceSeed');
 const { getToken, getTokenByCredentials } = require('./helpers/authentication');
 const app = require('../../server');
+const UtilsHelper = require('../../src/helpers/utils');
 
 describe('NODE ENV', () => {
   it('should be \'test\'', () => {
@@ -71,7 +72,7 @@ describe('BALANCES ROUTES - GET /details', () => {
       expect(response.statusCode).toBe(200);
       expect(response.result.data.balances).toBeDefined();
       expect(response.result.data.balances
-        .every(b => b.customer._id.toHexString() === customerId.toHexString())).toBeTruthy();
+        .every(b => UtilsHelper.areObjectIdsEquals(b.customer._id, customerId))).toBeTruthy();
       expect(response.result.data.bills).toBeDefined();
       expect(response.result.data.payments).toBeDefined();
       expect(response.result.data.creditNotes).toBeDefined();

--- a/tests/integration/balances.test.js
+++ b/tests/integration/balances.test.js
@@ -11,7 +11,7 @@ describe('NODE ENV', () => {
 });
 
 describe('BALANCES ROUTES - GET /', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
 
   describe('COACH', () => {
@@ -53,7 +53,7 @@ describe('BALANCES ROUTES - GET /', () => {
 });
 
 describe('BALANCES ROUTES - GET /details', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
 
   describe('COACH', () => {

--- a/tests/integration/balances.test.js
+++ b/tests/integration/balances.test.js
@@ -53,7 +53,6 @@ describe('BALANCES ROUTES - GET /', () => {
 
 describe('BALANCES ROUTES - GET /details', () => {
   let authToken = null;
-  const helper = balanceUserList[0];
   beforeEach(populateDB);
 
   describe('COACH', () => {
@@ -91,7 +90,7 @@ describe('BALANCES ROUTES - GET /details', () => {
 
   describe('Other roles', () => {
     it('should return customer balance if I am its helper', async () => {
-      authToken = await getTokenByCredentials(helper.local);
+      authToken = await getTokenByCredentials(balanceUserList[0].local);
       const res = await app.inject({
         method: 'GET',
         url: `/balances/details?customer=${balanceCustomerList[0]._id}&startDate=2019-10-10&endDate=2019-11-10`,

--- a/tests/integration/billSlips.test.js
+++ b/tests/integration/billSlips.test.js
@@ -10,7 +10,7 @@ describe('NODE ENV', () => {
 });
 
 describe('BILL SLIP ROUTES - GET /', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
 
   describe('CLIENT_ADMIN', () => {
@@ -54,7 +54,7 @@ describe('BILL SLIP ROUTES - GET /', () => {
 });
 
 describe('BILL SLIP ROUTES - GET /:_id/docx', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
 
   describe('CLIENT_ADMIN', () => {

--- a/tests/integration/bills.test.js
+++ b/tests/integration/bills.test.js
@@ -35,7 +35,7 @@ describe('NODE ENV', () => {
 });
 
 describe('BILL ROUTES - GET /bills/drafts', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
   const query = {
     endDate: new Date('2021-08-31T23:59:59.999Z'),
@@ -105,7 +105,7 @@ describe('BILL ROUTES - GET /bills/drafts', () => {
 });
 
 describe('BILL ROUTES - POST /bills', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
   const payload = [
     {
@@ -634,7 +634,7 @@ describe('BILL ROUTES - POST /bills', () => {
 });
 
 describe('BILL ROUTES - GET /bills/pdfs', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
 
   describe('COACH', () => {

--- a/tests/integration/cards.test.js
+++ b/tests/integration/cards.test.js
@@ -18,7 +18,7 @@ describe('NODE ENV', () => {
 });
 
 describe('CARDS ROUTES - PUT /cards/{_id}', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
   const transitionId = cardsList[0]._id;
   const flashCardId = cardsList[4]._id;
@@ -307,7 +307,7 @@ describe('CARDS ROUTES - PUT /cards/{_id}', () => {
 });
 
 describe('CARDS ROUTES - POST /cards/{_id}/answer', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
 
   describe('TRAINING_ORGANISATION_MANAGER', () => {
@@ -436,7 +436,7 @@ describe('CARDS ROUTES - POST /cards/{_id}/answer', () => {
 });
 
 describe('CARDS ROUTES - PUT /cards/{_id}/answers/{answerId}', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
 
   describe('TRAINING_ORGANISATION_MANAGER', () => {
@@ -624,7 +624,7 @@ describe('CARDS ROUTES - PUT /cards/{_id}/answers/{answerId}', () => {
 });
 
 describe('CARDS ROUTES - DELETE /cards/{_id}/answers/{answerId}', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
 
   describe('TRAINING_ORGANISATION_MANAGER', () => {

--- a/tests/integration/cards.test.js
+++ b/tests/integration/cards.test.js
@@ -108,7 +108,7 @@ describe('CARDS ROUTES - PUT /cards/{_id}', () => {
       it(`should update a ${card.template} card`, async () => {
         const response = await app.inject({
           method: 'PUT',
-          url: `/cards/${card.id.toHexString()}`,
+          url: `/cards/${card.id}`,
           payload: card.payload,
           headers: { Cookie: `alenvi_token=${authToken}` },
         });
@@ -123,7 +123,7 @@ describe('CARDS ROUTES - PUT /cards/{_id}', () => {
     it('should return a 400 if title is equal to \'\' on transition card', async () => {
       const response = await app.inject({
         method: 'PUT',
-        url: `/cards/${transitionId.toHexString()}`,
+        url: `/cards/${transitionId}`,
         payload: { name: '' },
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
@@ -134,7 +134,7 @@ describe('CARDS ROUTES - PUT /cards/{_id}', () => {
     it('should return a 403 when provide a useless canSwitchAnswers field on a non-FillTheGap card', async () => {
       const response = await app.inject({
         method: 'PUT',
-        url: `/cards/${transitionId.toHexString()}`,
+        url: `/cards/${transitionId}`,
         payload: { canSwitchAnswers: false },
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
@@ -145,7 +145,7 @@ describe('CARDS ROUTES - PUT /cards/{_id}', () => {
     it('should return a 403 when provide a useless isMandatory field on a non-Questionnaire card', async () => {
       const response = await app.inject({
         method: 'PUT',
-        url: `/cards/${transitionId.toHexString()}`,
+        url: `/cards/${transitionId}`,
         payload: { isMandatory: false },
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
@@ -170,7 +170,7 @@ describe('CARDS ROUTES - PUT /cards/{_id}', () => {
         it(`should return a ${request.code} if ${request.msg}`, async () => {
           const response = await app.inject({
             method: 'PUT',
-            url: `/cards/${fillTheGapId.toHexString()}`,
+            url: `/cards/${fillTheGapId}`,
             payload: request.payload,
             headers: { Cookie: `alenvi_token=${authToken}` },
           });
@@ -196,7 +196,7 @@ describe('CARDS ROUTES - PUT /cards/{_id}', () => {
         it(`should return a ${request.code} if ${request.msg}`, async () => {
           const response = await app.inject({
             method: 'PUT',
-            url: `/cards/${orderTheSequenceId.toHexString()}`,
+            url: `/cards/${orderTheSequenceId}`,
             payload: request.payload,
             headers: { Cookie: `alenvi_token=${authToken}` },
           });
@@ -223,7 +223,7 @@ describe('CARDS ROUTES - PUT /cards/{_id}', () => {
         it(`should return a ${request.code} if ${request.msg}`, async () => {
           const response = await app.inject({
             method: 'PUT',
-            url: `/cards/${singleChoiceQuestionId.toHexString()}`,
+            url: `/cards/${singleChoiceQuestionId}`,
             payload: request.payload,
             headers: { Cookie: `alenvi_token=${authToken}` },
           });
@@ -245,7 +245,7 @@ describe('CARDS ROUTES - PUT /cards/{_id}', () => {
         it(`should return a ${request.code} if ${request.msg}`, async () => {
           const response = await app.inject({
             method: 'PUT',
-            url: `/cards/${surveyId.toHexString()}`,
+            url: `/cards/${surveyId}`,
             payload: request.payload,
             headers: { Cookie: `alenvi_token=${authToken}` },
           });
@@ -271,7 +271,7 @@ describe('CARDS ROUTES - PUT /cards/{_id}', () => {
         it(`should return a ${request.code} if ${request.msg}`, async () => {
           const response = await app.inject({
             method: 'PUT',
-            url: `/cards/${flashCardId.toHexString()}`,
+            url: `/cards/${flashCardId}`,
             payload: request.payload,
             headers: { Cookie: `alenvi_token=${authToken}` },
           });
@@ -296,7 +296,7 @@ describe('CARDS ROUTES - PUT /cards/{_id}', () => {
         const response = await app.inject({
           method: 'PUT',
           payload,
-          url: `/cards/${transitionId.toHexString()}`,
+          url: `/cards/${transitionId}`,
           headers: { Cookie: `alenvi_token=${authToken}` },
         });
 
@@ -316,52 +316,49 @@ describe('CARDS ROUTES - POST /cards/{_id}/answer', () => {
     });
 
     it('should add a qcAnswer', async () => {
-      const card = cardsList[11];
       const response = await app.inject({
         method: 'POST',
-        url: `/cards/${card._id.toHexString()}/answers`,
+        url: `/cards/${cardsList[11]._id}/answers`,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
       expect(response.statusCode).toBe(200);
 
       const cardUpdated = await Card.countDocuments({
-        _id: card._id,
-        qcAnswers: { $size: card.qcAnswers.length + 1 },
+        _id: cardsList[11]._id,
+        qcAnswers: { $size: cardsList[11].qcAnswers.length + 1 },
       });
       expect(cardUpdated).toEqual(1);
     });
 
     it('should add an ordered answer', async () => {
-      const card = cardsList[16];
       const response = await app.inject({
         method: 'POST',
-        url: `/cards/${card._id.toHexString()}/answers`,
+        url: `/cards/${cardsList[16]._id}/answers`,
         headers: { 'x-access-token': authToken },
       });
 
       expect(response.statusCode).toBe(200);
 
       const cardUpdated = await Card.countDocuments({
-        _id: card._id,
-        orderedAnswers: { $size: card.orderedAnswers.length + 1 },
+        _id: cardsList[16]._id,
+        orderedAnswers: { $size: cardsList[16].orderedAnswers.length + 1 },
       });
       expect(cardUpdated).toEqual(1);
     });
 
     it('should add an falsy gap answer', async () => {
-      const card = cardsList[5];
       const response = await app.inject({
         method: 'POST',
-        url: `/cards/${card._id.toHexString()}/answers`,
+        url: `/cards/${cardsList[5]._id}/answers`,
         headers: { 'x-access-token': authToken },
       });
 
       expect(response.statusCode).toBe(200);
 
       const cardUpdated = await Card.countDocuments({
-        _id: card._id,
-        falsyGapAnswers: { $size: card.falsyGapAnswers.length + 1 },
+        _id: cardsList[5]._id,
+        falsyGapAnswers: { $size: cardsList[5].falsyGapAnswers.length + 1 },
       });
       expect(cardUpdated).toEqual(1);
     });
@@ -369,7 +366,7 @@ describe('CARDS ROUTES - POST /cards/{_id}/answer', () => {
     it('should return 404 if invalid card id', async () => {
       const response = await app.inject({
         method: 'POST',
-        url: `/cards/${(new ObjectID()).toHexString()}/answers`,
+        url: `/cards/${(new ObjectID())}/answers`,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
@@ -387,7 +384,7 @@ describe('CARDS ROUTES - POST /cards/{_id}/answer', () => {
       it(`should return 403 if ${template.name} with already max answers`, async () => {
         const response = await app.inject({
           method: 'POST',
-          url: `/cards/${template.card._id.toHexString()}/answers`,
+          url: `/cards/${template.card._id}/answers`,
           headers: { Cookie: `alenvi_token=${authToken}` },
         });
 
@@ -396,10 +393,9 @@ describe('CARDS ROUTES - POST /cards/{_id}/answer', () => {
     });
 
     it('should return 403 if card activity is published', async () => {
-      const card = cardsList[13];
       const response = await app.inject({
         method: 'POST',
-        url: `/cards/${card._id.toHexString()}/answers`,
+        url: `/cards/${cardsList[13]._id}/answers`,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
@@ -407,10 +403,9 @@ describe('CARDS ROUTES - POST /cards/{_id}/answer', () => {
     });
 
     it('should return 403 if card questionnaire is published', async () => {
-      const card = cardsList[6];
       const response = await app.inject({
         method: 'POST',
-        url: `/cards/${card._id.toHexString()}/answers`,
+        url: `/cards/${cardsList[6]._id}/answers`,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
@@ -430,7 +425,7 @@ describe('CARDS ROUTES - POST /cards/{_id}/answer', () => {
         authToken = await getToken(role.name);
         const response = await app.inject({
           method: 'POST',
-          url: `/cards/${cardsList[11]._id.toHexString()}/answers`,
+          url: `/cards/${cardsList[11]._id}/answers`,
           headers: { Cookie: `alenvi_token=${authToken}` },
         });
 
@@ -455,7 +450,7 @@ describe('CARDS ROUTES - PUT /cards/{_id}/answers/{answerId}', () => {
 
       const response = await app.inject({
         method: 'PUT',
-        url: `/cards/${card._id.toHexString()}/answers/${answer._id.toHexString()}`,
+        url: `/cards/${card._id}/answers/${answer._id}`,
         payload: { text: 'je suis un texte' },
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
@@ -475,7 +470,7 @@ describe('CARDS ROUTES - PUT /cards/{_id}/answers/{answerId}', () => {
 
       const response = await app.inject({
         method: 'PUT',
-        url: `/cards/${card._id.toHexString()}/answers/${answer._id.toHexString()}`,
+        url: `/cards/${card._id}/answers/${answer._id}`,
         payload: { text: 'je suis un texte' },
         headers: { 'x-access-token': authToken },
       });
@@ -495,7 +490,7 @@ describe('CARDS ROUTES - PUT /cards/{_id}/answers/{answerId}', () => {
 
       const response = await app.inject({
         method: 'PUT',
-        url: `/cards/${card._id.toHexString()}/answers/${answer._id.toHexString()}`,
+        url: `/cards/${card._id}/answers/${answer._id}`,
         payload: { text: '', correct: true },
         headers: { 'x-access-token': authToken },
       });
@@ -509,7 +504,7 @@ describe('CARDS ROUTES - PUT /cards/{_id}/answers/{answerId}', () => {
 
       const response = await app.inject({
         method: 'PUT',
-        url: `/cards/${card._id.toHexString()}/answers/${answer._id.toHexString()}`,
+        url: `/cards/${card._id}/answers/${answer._id}`,
         payload: { text: 'Je suis un text vraiment vraiment vraiment tres tres tres tres tres long', correct: true },
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
@@ -523,7 +518,7 @@ describe('CARDS ROUTES - PUT /cards/{_id}/answers/{answerId}', () => {
 
       const response = await app.inject({
         method: 'PUT',
-        url: `/cards/${card._id.toHexString()}/answers/${answer._id.toHexString()}`,
+        url: `/cards/${card._id}/answers/${answer._id}`,
         payload: { correct: null, text: 'Avery' },
         headers: { 'x-access-token': authToken },
       });
@@ -537,7 +532,7 @@ describe('CARDS ROUTES - PUT /cards/{_id}/answers/{answerId}', () => {
 
       const response = await app.inject({
         method: 'PUT',
-        url: `/cards/${card._id.toHexString()}/answers/${answer._id.toHexString()}`,
+        url: `/cards/${card._id}/answers/${answer._id}`,
         payload: {},
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
@@ -551,7 +546,7 @@ describe('CARDS ROUTES - PUT /cards/{_id}/answers/{answerId}', () => {
 
       const response = await app.inject({
         method: 'PUT',
-        url: `/cards/${(new ObjectID()).toHexString()}/answers/${answer._id.toHexString()}`,
+        url: `/cards/${(new ObjectID())}/answers/${answer._id}`,
         payload: { text: 'je suis un texte' },
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
@@ -565,7 +560,7 @@ describe('CARDS ROUTES - PUT /cards/{_id}/answers/{answerId}', () => {
 
       const response = await app.inject({
         method: 'PUT',
-        url: `/cards/${card._id.toHexString()}/answers/${otherQACard.qcAnswers[0]._id.toHexString()}`,
+        url: `/cards/${card._id}/answers/${otherQACard.qcAnswers[0]._id}`,
         payload: { text: 'je suis un texte' },
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
@@ -579,7 +574,7 @@ describe('CARDS ROUTES - PUT /cards/{_id}/answers/{answerId}', () => {
 
       const response = await app.inject({
         method: 'PUT',
-        url: `/cards/${card._id.toHexString()}/answers/${answer._id.toHexString()}`,
+        url: `/cards/${card._id}/answers/${answer._id}`,
         payload: { correct: false },
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
@@ -593,7 +588,7 @@ describe('CARDS ROUTES - PUT /cards/{_id}/answers/{answerId}', () => {
 
       const response = await app.inject({
         method: 'PUT',
-        url: `/cards/${card._id.toHexString()}/answers/${answer._id.toHexString()}`,
+        url: `/cards/${card._id}/answers/${answer._id}`,
         payload: { text: 'invalid char: c\'est tout' },
         headers: { 'x-access-token': authToken },
       });
@@ -618,7 +613,7 @@ describe('CARDS ROUTES - PUT /cards/{_id}/answers/{answerId}', () => {
         const response = await app.inject({
           method: 'PUT',
           payload: { text: 'je suis un texte' },
-          url: `/cards/${card._id.toHexString()}/answers/${answer._id.toHexString()}`,
+          url: `/cards/${card._id}/answers/${answer._id}`,
           headers: { Cookie: `alenvi_token=${authToken}` },
         });
 
@@ -643,7 +638,7 @@ describe('CARDS ROUTES - DELETE /cards/{_id}/answers/{answerId}', () => {
 
       const response = await app.inject({
         method: 'DELETE',
-        url: `/cards/${card._id.toHexString()}/answers/${answer._id.toHexString()}`,
+        url: `/cards/${card._id}/answers/${answer._id}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
@@ -660,7 +655,7 @@ describe('CARDS ROUTES - DELETE /cards/{_id}/answers/{answerId}', () => {
 
       const response = await app.inject({
         method: 'DELETE',
-        url: `/cards/${card._id.toHexString()}/answers/${answer._id.toHexString()}`,
+        url: `/cards/${card._id}/answers/${answer._id}`,
         headers: { 'x-access-token': authToken },
       });
 
@@ -677,7 +672,7 @@ describe('CARDS ROUTES - DELETE /cards/{_id}/answers/{answerId}', () => {
 
       const response = await app.inject({
         method: 'DELETE',
-        url: `/cards/${card._id.toHexString()}/answers/${answer._id.toHexString()}`,
+        url: `/cards/${card._id}/answers/${answer._id}`,
         headers: { 'x-access-token': authToken },
       });
 
@@ -700,7 +695,7 @@ describe('CARDS ROUTES - DELETE /cards/{_id}/answers/{answerId}', () => {
 
       const response = await app.inject({
         method: 'DELETE',
-        url: `/cards/${null}/answers/${answer._id.toHexString()}`,
+        url: `/cards/${null}/answers/${answer._id}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
@@ -712,7 +707,7 @@ describe('CARDS ROUTES - DELETE /cards/{_id}/answers/{answerId}', () => {
 
       const response = await app.inject({
         method: 'DELETE',
-        url: `/cards/${card._id.toHexString()}/answers/${null}`,
+        url: `/cards/${card._id}/answers/${null}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
@@ -723,7 +718,7 @@ describe('CARDS ROUTES - DELETE /cards/{_id}/answers/{answerId}', () => {
       const publishedCard = cardsList[13];
       const response = await app.inject({
         method: 'DELETE',
-        url: `/cards/${publishedCard._id.toHexString()}/answers/${publishedCard.qcAnswers[0]._id.toHexString()}`,
+        url: `/cards/${publishedCard._id}/answers/${publishedCard.qcAnswers[0]._id}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
@@ -734,7 +729,7 @@ describe('CARDS ROUTES - DELETE /cards/{_id}/answers/{answerId}', () => {
       const publishedCard = cardsList[6];
       const response = await app.inject({
         method: 'DELETE',
-        url: `/cards/${publishedCard._id.toHexString()}/answers/${publishedCard.qcAnswers[0]._id.toHexString()}`,
+        url: `/cards/${publishedCard._id}/answers/${publishedCard.qcAnswers[0]._id}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
@@ -753,7 +748,7 @@ describe('CARDS ROUTES - DELETE /cards/{_id}/answers/{answerId}', () => {
         const answers = template.card[`${template.key}`];
         const response = await app.inject({
           method: 'DELETE',
-          url: `/cards/${template.card._id.toHexString()}/answers/${answers[0]._id.toHexString()}`,
+          url: `/cards/${template.card._id}/answers/${answers[0]._id}`,
           headers: { 'x-access-token': authToken },
         });
 
@@ -765,8 +760,8 @@ describe('CARDS ROUTES - DELETE /cards/{_id}/answers/{answerId}', () => {
       const oneQuestionCard = cardsList[11];
       const response = await app.inject({
         method: 'DELETE',
-        url: `/cards/${oneQuestionCard._id.toHexString()}
-          /answers/${oneQuestionCard.qcAnswers[0]._id.toHexString()}`,
+        url: `/cards/${oneQuestionCard._id}
+          /answers/${oneQuestionCard.qcAnswers[0]._id}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
@@ -789,7 +784,7 @@ describe('CARDS ROUTES - DELETE /cards/{_id}/answers/{answerId}', () => {
         authToken = await getToken(role.name);
         const response = await app.inject({
           method: 'DELETE',
-          url: `/cards/${card._id.toHexString()}/answers/${answer._id.toHexString()}`,
+          url: `/cards/${card._id}/answers/${answer._id}`,
           headers: { Cookie: `alenvi_token=${authToken}` },
         });
 
@@ -819,7 +814,6 @@ describe('CARDS ROUTES - POST /cards/:id/upload', () => {
     });
 
     it('should add a card media', async () => {
-      const card = cardsList[0];
       const form = generateFormData({ fileName: 'title_text_media', file: 'true' });
       momentFormat.returns('20200625054512');
       uploadProgramMediaStub.returns({ link: 'https://gcp/BucketKFC/my', publicId: 'media-ttm' });
@@ -827,7 +821,7 @@ describe('CARDS ROUTES - POST /cards/:id/upload', () => {
       const payload = await GetStream(form);
       const response = await app.inject({
         method: 'POST',
-        url: `/cards/${card._id}/upload`,
+        url: `/cards/${cardsList[0]._id}/upload`,
         payload,
         headers: { ...form.getHeaders(), Cookie: `alenvi_token=${authToken}` },
       });
@@ -835,7 +829,7 @@ describe('CARDS ROUTES - POST /cards/:id/upload', () => {
       expect(response.statusCode).toBe(200);
 
       const cardUpdated = await Card
-        .countDocuments({ _id: card._id, media: { link: 'https://gcp/BucketKFC/my', publicId: 'media-ttm' } });
+        .countDocuments({ _id: cardsList[0]._id, media: { link: 'https://gcp/BucketKFC/my', publicId: 'media-ttm' } });
       expect(cardUpdated).toEqual(1);
       sinon.assert.calledOnceWithExactly(uploadProgramMediaStub, { fileName: 'title_text_media', file: 'true' });
     });
@@ -843,11 +837,10 @@ describe('CARDS ROUTES - POST /cards/:id/upload', () => {
     const wrongParams = ['file', 'fileName'];
     wrongParams.forEach((param) => {
       it(`should return a 400 error if missing '${param}' parameter`, async () => {
-        const card = cardsList[0];
         const invalidForm = generateFormData(omit({ fileName: 'title_text_media', file: 'true' }, param));
         const response = await app.inject({
           method: 'POST',
-          url: `/cards/${card._id}/upload`,
+          url: `/cards/${cardsList[0]._id}/upload`,
           payload: await GetStream(invalidForm),
           headers: { ...invalidForm.getHeaders(), Cookie: `alenvi_token=${authToken}` },
         });
@@ -900,20 +893,20 @@ describe('CARDS ROUTES - DELETE /cards/:id/upload', () => {
     });
 
     it('should delete a card media', async () => {
-      const card = cardsList[1];
       const imageExistsBeforeUpdate = await Card
-        .countDocuments({ _id: card._id, 'media.publicId': { $exists: true } });
+        .countDocuments({ _id: cardsList[1]._id, 'media.publicId': { $exists: true } });
 
       const response = await app.inject({
         method: 'DELETE',
-        url: `/cards/${card._id}/upload`,
+        url: `/cards/${cardsList[1]._id}/upload`,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
       expect(response.statusCode).toBe(200);
       sinon.assert.calledOnceWithExactly(deleteProgramMediaStub, 'publicId');
 
-      const isPictureDeleted = await Card.countDocuments({ _id: card._id, 'media.publicId': { $exists: false } });
+      const isPictureDeleted = await Card
+        .countDocuments({ _id: cardsList[1]._id, 'media.publicId': { $exists: false } });
       expect(imageExistsBeforeUpdate).toBeTruthy();
       expect(isPictureDeleted).toBeTruthy();
     });

--- a/tests/integration/categories.test.js
+++ b/tests/integration/categories.test.js
@@ -2,10 +2,7 @@ const expect = require('expect');
 const { ObjectID } = require('mongodb');
 const Category = require('../../src/models/Category');
 const app = require('../../server');
-const {
-  populateDB,
-  categoriesList,
-} = require('./seed/categoriesSeed');
+const { populateDB, categoriesList } = require('./seed/categoriesSeed');
 const { getToken } = require('./helpers/authentication');
 
 describe('NODE ENV', () => {

--- a/tests/integration/categories.test.js
+++ b/tests/integration/categories.test.js
@@ -79,7 +79,7 @@ describe('CATEGORIES ROUTES - POST /categories', () => {
 });
 
 describe('CATEGORIES ROUTES - GET /categories', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
 
   describe('TRAINING_ORGANISATION_MANAGER', () => {
@@ -124,7 +124,7 @@ describe('CATEGORIES ROUTES - GET /categories', () => {
 });
 
 describe('CATEGORIES ROUTES - PUT /categories/{_id}', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
 
   describe('TRAINING_ORGANISATION_MANAGER', () => {
@@ -194,7 +194,7 @@ describe('CATEGORIES ROUTES - PUT /categories/{_id}', () => {
 });
 
 describe('CATEGORIES ROUTES - DELETE /categories/{_id}', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
 
   describe('TRAINING_ORGANISATION_MANAGER', () => {

--- a/tests/integration/categories.test.js
+++ b/tests/integration/categories.test.js
@@ -123,7 +123,7 @@ describe('CATEGORIES ROUTES - GET /categories', () => {
   });
 });
 
-describe('CATEGORY ROUTES - PUT /categories/{_id}', () => {
+describe('CATEGORIES ROUTES - PUT /categories/{_id}', () => {
   let authToken = null;
   beforeEach(populateDB);
 
@@ -133,17 +133,16 @@ describe('CATEGORY ROUTES - PUT /categories/{_id}', () => {
     });
 
     it('should update category name', async () => {
-      const categoryId = categoriesList[0]._id;
       const response = await app.inject({
         method: 'PUT',
-        url: `/categories/${categoryId.toHexString()}`,
+        url: `/categories/${categoriesList[0]._id}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
         payload: { name: 'nouveau nom' },
       });
 
       expect(response.statusCode).toBe(200);
 
-      const categoryUpdated = await Category.countDocuments({ _id: categoryId, name: 'nouveau nom' });
+      const categoryUpdated = await Category.countDocuments({ _id: categoriesList[0]._id, name: 'nouveau nom' });
       expect(categoryUpdated).toEqual(1);
     });
 
@@ -159,10 +158,9 @@ describe('CATEGORY ROUTES - PUT /categories/{_id}', () => {
     });
 
     it('should return 409 if new name is already taken', async () => {
-      const categoryId = categoriesList[0]._id;
       const response = await app.inject({
         method: 'PUT',
-        url: `/categories/${categoryId.toHexString()}`,
+        url: `/categories/${categoriesList[0]._id}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
         payload: { name: 'ce nom de catégorie est déja pris!' },
       });
@@ -182,11 +180,10 @@ describe('CATEGORY ROUTES - PUT /categories/{_id}', () => {
     roles.forEach((role) => {
       it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
         authToken = await getToken(role.name);
-        const categoryId = categoriesList[0]._id;
         const response = await app.inject({
           method: 'PUT',
           payload: { name: `mon nouveau nom de catégorie en tant que ${role.name}` },
-          url: `/categories/${categoryId.toHexString()}`,
+          url: `/categories/${categoriesList[0]._id}`,
           headers: { Cookie: `alenvi_token=${authToken}` },
         });
 
@@ -196,7 +193,7 @@ describe('CATEGORY ROUTES - PUT /categories/{_id}', () => {
   });
 });
 
-describe('CATEGORY ROUTES - DELETE /categories/{_id}', () => {
+describe('CATEGORIES ROUTES - DELETE /categories/{_id}', () => {
   let authToken = null;
   beforeEach(populateDB);
 
@@ -206,11 +203,10 @@ describe('CATEGORY ROUTES - DELETE /categories/{_id}', () => {
     });
 
     it('should delete category', async () => {
-      const categoryId = categoriesList[0]._id;
       const categoriesCount = await Category.countDocuments();
       const response = await app.inject({
         method: 'DELETE',
-        url: `/categories/${categoryId.toHexString()}`,
+        url: `/categories/${categoriesList[0]._id}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
@@ -219,10 +215,9 @@ describe('CATEGORY ROUTES - DELETE /categories/{_id}', () => {
     });
 
     it('should return a 403 if category is used', async () => {
-      const categoryId = categoriesList[4]._id;
       const response = await app.inject({
         method: 'DELETE',
-        url: `/categories/${categoryId.toHexString()}`,
+        url: `/categories/${categoriesList[4]._id}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
@@ -232,7 +227,7 @@ describe('CATEGORY ROUTES - DELETE /categories/{_id}', () => {
     it('should return a 404 if category does not exist', async () => {
       const response = await app.inject({
         method: 'DELETE',
-        url: `/categories/${new ObjectID().toHexString()}`,
+        url: `/categories/${new ObjectID()}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
@@ -251,10 +246,9 @@ describe('CATEGORY ROUTES - DELETE /categories/{_id}', () => {
     roles.forEach((role) => {
       it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
         authToken = await getToken(role.name);
-        const categoryId = categoriesList[0]._id;
         const response = await app.inject({
           method: 'DELETE',
-          url: `/categories/${categoryId.toHexString()}`,
+          url: `/categories/${categoriesList[0]._id}`,
           headers: { Cookie: `alenvi_token=${authToken}` },
         });
 

--- a/tests/integration/companies.test.js
+++ b/tests/integration/companies.test.js
@@ -30,7 +30,7 @@ describe('PUT /companies/:id', () => {
       const payload = { name: 'Alenvi Alenvi', rhConfig: { phoneFeeAmount: 70 }, apeCode: '8110Z' };
       const response = await app.inject({
         method: 'PUT',
-        url: `/companies/${company._id.toHexString()}`,
+        url: `/companies/${company._id}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
         payload,
       });
@@ -40,11 +40,10 @@ describe('PUT /companies/:id', () => {
     });
 
     it('should return 404 if not found', async () => {
-      const invalidId = new ObjectID();
       const payload = { name: 'Alenvi Alenvi' };
       const response = await app.inject({
         method: 'PUT',
-        url: `/companies/${invalidId}`,
+        url: `/companies/${new ObjectID()}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
         payload,
       });
@@ -63,7 +62,7 @@ describe('PUT /companies/:id', () => {
       const payload = { name: 'Alenvi Alenvi', rhConfig: { phoneFeeAmount: 70 }, apeCode: '8110Z' };
       const response = await app.inject({
         method: 'PUT',
-        url: `/companies/${company._id.toHexString()}`,
+        url: `/companies/${company._id}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
         payload,
       });
@@ -73,11 +72,10 @@ describe('PUT /companies/:id', () => {
     });
 
     it('should return 403 if not its company', async () => {
-      const invalidId = otherCompany._id.toHexString();
       const payload = { name: 'Alenvi Alenvi' };
       const response = await app.inject({
         method: 'PUT',
-        url: `/companies/${invalidId}`,
+        url: `/companies/${otherCompany._id}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
         payload,
       });
@@ -98,7 +96,7 @@ describe('PUT /companies/:id', () => {
       it(`should return a 400 error if ${assertion.case}`, async () => {
         const response = await app.inject({
           method: 'PUT',
-          url: `/companies/${company._id.toHexString()}`,
+          url: `/companies/${company._id}`,
           headers: { Cookie: `alenvi_token=${authToken}` },
           payload: assertion.payload,
         });
@@ -121,7 +119,7 @@ describe('PUT /companies/:id', () => {
         const payload = { name: 'SuperTest' };
         const response = await app.inject({
           method: 'PUT',
-          url: `/companies/${company._id.toHexString()}`,
+          url: `/companies/${company._id}`,
           headers: { Cookie: `alenvi_token=${authToken}` },
           payload,
         });

--- a/tests/integration/contracts.test.js
+++ b/tests/integration/contracts.test.js
@@ -36,7 +36,7 @@ describe('NODE ENV', () => {
 });
 
 describe('GET /contracts', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
 
   describe('COACH', () => {
@@ -104,7 +104,7 @@ describe('GET /contracts', () => {
 });
 
 describe('POST /contracts', () => {
-  let authToken = null;
+  let authToken;
   let generateSignatureRequestStub;
   beforeEach(populateDB);
   beforeEach(async () => {
@@ -245,7 +245,7 @@ describe('POST /contracts', () => {
 });
 
 describe('PUT contract/:id', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
 
   describe('COACH', () => {
@@ -368,7 +368,7 @@ describe('PUT contract/:id', () => {
 });
 
 describe('GET contract/:id/dpae', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
   describe('COACH', () => {
     beforeEach(async () => {
@@ -418,7 +418,7 @@ describe('GET contract/:id/dpae', () => {
 });
 
 describe('POST contract/:id/versions', () => {
-  let authToken = null;
+  let authToken;
   let generateSignatureRequest;
   beforeEach(populateDB);
   beforeEach(async () => {
@@ -535,7 +535,7 @@ describe('POST contract/:id/versions', () => {
 });
 
 describe('PUT contract/:id/versions/:versionId', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
 
   describe('COACH', () => {
@@ -658,7 +658,7 @@ describe('PUT contract/:id/versions/:versionId', () => {
 });
 
 describe('DELETE contracts/:id/versions/:versionId', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
   beforeEach(async () => {
     authToken = await getToken('client_admin');
@@ -727,7 +727,7 @@ describe('DELETE contracts/:id/versions/:versionId', () => {
 });
 
 describe('GET contracts/staff-register', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
   beforeEach(async () => {
     authToken = await getToken('client_admin');
@@ -784,7 +784,7 @@ describe('GET /{_id}/gdrive/{driveId}/upload', () => {
   const fakeDriveId = 'fakeDriveId';
   let addStub;
   let getFileByIdStub;
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
   beforeEach(async () => {
     addStub = sinon.stub(Drive, 'add');
@@ -807,8 +807,8 @@ describe('GET /{_id}/gdrive/{driveId}/upload', () => {
         fileName: 'contrat_signe',
         file: fs.createReadStream(path.join(__dirname, 'assets/test_upload.png')),
         type: 'signedContract',
-        contractId: contractsList[0]._id,
-        versionId: contractsList[0].versions[0]._id,
+        contractId: contractsList[0]._id.toHexString(),
+        versionId: contractsList[0].versions[0]._id.toHexString(),
       };
       const form = generateFormData(payload);
 
@@ -841,8 +841,8 @@ describe('GET /{_id}/gdrive/{driveId}/upload', () => {
           fileName: 'contrat_signe',
           file: fs.createReadStream(path.join(__dirname, 'assets/test_upload.png')),
           type: 'signedContract',
-          contractId: contractsList[0]._id,
-          versionId: contractsList[0].versions[0]._id,
+          contractId: contractsList[0]._id.toHexString(),
+          versionId: contractsList[0].versions[0]._id.toHexString(),
         };
         const form = generateFormData(payload);
         const response = await app.inject({

--- a/tests/integration/contracts.test.js
+++ b/tests/integration/contracts.test.js
@@ -46,7 +46,6 @@ describe('GET /contracts', () => {
 
     it('should return list of contracts', async () => {
       const userId = contractUserCompanies[0].user;
-
       const response = await app.inject({
         method: 'GET',
         url: `/contracts?user=${userId}`,
@@ -695,10 +694,9 @@ describe('DELETE contracts/:id/versions/:versionId', () => {
     });
 
     it('should return a 403 error if versionId is not the last version', async () => {
-      const invalidId = new ObjectID().toHexString();
       const response = await app.inject({
         method: 'DELETE',
-        url: `/contracts/${contractsList[0]._id}/versions/${invalidId}`,
+        url: `/contracts/${contractsList[0]._id}/versions/${new ObjectID()}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
@@ -809,8 +807,8 @@ describe('GET /{_id}/gdrive/{driveId}/upload', () => {
         fileName: 'contrat_signe',
         file: fs.createReadStream(path.join(__dirname, 'assets/test_upload.png')),
         type: 'signedContract',
-        contractId: contractsList[0]._id.toHexString(),
-        versionId: contractsList[0].versions[0]._id.toHexString(),
+        contractId: contractsList[0]._id,
+        versionId: contractsList[0].versions[0]._id,
       };
       const form = generateFormData(payload);
 
@@ -843,8 +841,8 @@ describe('GET /{_id}/gdrive/{driveId}/upload', () => {
           fileName: 'contrat_signe',
           file: fs.createReadStream(path.join(__dirname, 'assets/test_upload.png')),
           type: 'signedContract',
-          contractId: contractsList[0]._id.toHexString(),
-          versionId: contractsList[0].versions[0]._id.toHexString(),
+          contractId: contractsList[0]._id,
+          versionId: contractsList[0].versions[0]._id,
         };
         const form = generateFormData(payload);
         const response = await app.inject({

--- a/tests/integration/contracts.test.js
+++ b/tests/integration/contracts.test.js
@@ -21,7 +21,6 @@ const {
   contractEvents,
   otherContract,
   otherContractUser,
-  userFromOtherCompany,
   contractUserCompanies,
 } = require('./seed/contractsSeed');
 const { generateFormData } = require('./utils');
@@ -62,7 +61,7 @@ describe('GET /contracts', () => {
     it('should not return the contracts if user is not from the company', async () => {
       const response = await app.inject({
         method: 'GET',
-        url: `/contracts?user=${userFromOtherCompany._id}`,
+        url: `/contracts?user=${otherContractUser._id}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
@@ -92,11 +91,10 @@ describe('GET /contracts', () => {
 
     roles.forEach((role) => {
       it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
-        const userId = contractsList[0].user;
         authToken = await getToken(role.name);
         const response = await app.inject({
           method: 'GET',
-          url: `/contracts?user=${userId}`,
+          url: `/contracts?user=${contractsList[0].user}`,
           headers: { Cookie: `alenvi_token=${authToken}` },
         });
 

--- a/tests/integration/courseHistories.test.js
+++ b/tests/integration/courseHistories.test.js
@@ -12,7 +12,7 @@ describe('NODE ENV', () => {
 });
 
 describe('COURSE HISTORIES ROUTES - GET /coursehistories', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
 
   describe('TRAINING_ORGANISATION_MANAGER', () => {

--- a/tests/integration/courseHistories.test.js
+++ b/tests/integration/courseHistories.test.js
@@ -1,7 +1,7 @@
 const expect = require('expect');
 const moment = require('moment');
 const app = require('../../server');
-const { populateDB, coursesList, courseHistoriesList } = require('./seed/courseHistoriesSeed');
+const { populateDB, coursesList, courseHistoriesList, userList } = require('./seed/courseHistoriesSeed');
 const { trainerAndCoach } = require('../seed/authUsersSeed');
 const { getToken, getTokenByCredentials } = require('./helpers/authentication');
 
@@ -13,7 +13,6 @@ describe('NODE ENV', () => {
 
 describe('COURSE HISTORIES ROUTES - GET /coursehistories', () => {
   let authToken = null;
-
   beforeEach(populateDB);
 
   describe('TRAINING_ORGANISATION_MANAGER', () => {
@@ -62,7 +61,7 @@ describe('COURSE HISTORIES ROUTES - GET /coursehistories', () => {
 
   describe('Other roles', () => {
     it('should return 200 as user is course trainer', async () => {
-      authToken = await getToken('trainer');
+      authToken = await getTokenByCredentials(userList[0].local);
       const response = await app.inject({
         method: 'GET',
         url: `/coursehistories?course=${coursesList[0]._id}`,

--- a/tests/integration/courses.test.js
+++ b/tests/integration/courses.test.js
@@ -183,7 +183,7 @@ describe('COURSES ROUTES - POST /courses', () => {
 });
 
 describe('COURSES ROUTES - GET /courses', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
 
   describe('TRAINING_ORGANISATION_MANAGER', () => {
@@ -310,7 +310,7 @@ describe('COURSES ROUTES - GET /courses', () => {
 });
 
 describe('COURSES ROUTES - GET /courses/{_id}', () => {
-  let authToken = null;
+  let authToken;
   const courseFromAuthCompanyIntra = coursesList[0];
   const courseFromAuthCompanyInterB2b = coursesList[4];
   beforeEach(populateDB);
@@ -437,7 +437,7 @@ describe('COURSES ROUTES - GET /courses/{_id}', () => {
 });
 
 describe('COURSES ROUTES - GET /courses/{_id}/follow-up', () => {
-  let authToken = null;
+  let authToken;
   const courseFromAuthCompanyIntra = coursesList[0];
   beforeEach(populateDB);
 
@@ -552,7 +552,7 @@ describe('COURSES ROUTES - GET /courses/{_id}/follow-up', () => {
 });
 
 describe('COURSES ROUTES - GET /courses/{_id}/activities', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
 
   describe('TRAINER', () => {
@@ -595,7 +595,7 @@ describe('COURSES ROUTES - GET /courses/{_id}/activities', () => {
 });
 
 describe('COURSES ROUTES - GET /courses/{_id}/questionnaires', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
 
   describe('TRAINER', () => {
@@ -668,7 +668,7 @@ describe('COURSES ROUTES - GET /courses/{_id}/questionnaires', () => {
 });
 
 describe('COURSES ROUTES - GET /courses/user', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
 
   it('should return 200 as user is logged in', async () => {
@@ -1607,7 +1607,7 @@ describe('COURSES ROUTES - POST /courses/{_id}/register-e-learning', () => {
 });
 
 describe('COURSES ROUTES - DELETE /courses/{_id}/trainee/{traineeId}', () => {
-  let authToken = null;
+  let authToken;
   const courseIdFromAuthCompany = coursesList[2]._id;
   const courseIdFromOtherCompany = coursesList[3]._id;
   const traineeId = coach._id;
@@ -1694,7 +1694,7 @@ describe('COURSES ROUTES - DELETE /courses/{_id}/trainee/{traineeId}', () => {
 });
 
 describe('COURSES ROUTES - GET /:_id/attendance-sheets', () => {
-  let authToken = null;
+  let authToken;
   const courseIdFromAuthCompany = coursesList[2]._id;
   const courseIdFromOtherCompany = coursesList[3]._id;
   beforeEach(populateDB);
@@ -1781,7 +1781,7 @@ describe('COURSES ROUTES - GET /:_id/attendance-sheets', () => {
 });
 
 describe('COURSES ROUTES - GET /:_id/completion-certificates', () => {
-  let authToken = null;
+  let authToken;
   const courseIdFromAuthCompany = coursesList[2]._id;
   const courseIdFromOtherCompany = coursesList[3]._id;
 
@@ -1899,7 +1899,7 @@ describe('COURSES ROUTES - GET /:_id/completion-certificates', () => {
 });
 
 describe('COURSES ROUTES - POST /:_id/accessrules', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
 
   describe('TRAINING_ORGANISATION_MANAGER', () => {
@@ -1978,7 +1978,7 @@ describe('COURSES ROUTES - POST /:_id/accessrules', () => {
 });
 
 describe('COURSES ROUTES - DELETE /:_id/accessrules/:accessRuleId', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
 
   describe('TRAINING_ORGANISATION_MANAGER', () => {

--- a/tests/integration/creditNotes.test.js
+++ b/tests/integration/creditNotes.test.js
@@ -369,8 +369,7 @@ describe('CREDIT NOTES ROUTES - GET /creditNotes/pdfs', () => {
 
   describe('Other roles', () => {
     it('should return customer creditnotes pdfs if I am its helper', async () => {
-      const helper = creditNoteUserList[0];
-      authToken = await getTokenByCredentials(helper.local);
+      authToken = await getTokenByCredentials(creditNoteUserList[0].local);
       const res = await app.inject({
         method: 'GET',
         url: `/creditNotes/${creditNotesList[0]._id}/pdfs`,

--- a/tests/integration/creditNotes.test.js
+++ b/tests/integration/creditNotes.test.js
@@ -27,7 +27,7 @@ describe('NODE ENV', () => {
 });
 
 describe('CREDIT NOTES ROUTES - POST /creditNotes', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
 
   const payloadWithEvents = {
@@ -270,7 +270,7 @@ describe('CREDIT NOTES ROUTES - POST /creditNotes', () => {
 });
 
 describe('CREDIT NOTES ROUTES - GET /creditNotes', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
 
   describe('CLIENT_ADMIN', () => {
@@ -328,7 +328,7 @@ describe('CREDIT NOTES ROUTES - GET /creditNotes', () => {
 });
 
 describe('CREDIT NOTES ROUTES - GET /creditNotes/pdfs', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
 
   describe('CLIENT_ADMIN', () => {
@@ -401,7 +401,7 @@ describe('CREDIT NOTES ROUTES - GET /creditNotes/pdfs', () => {
 });
 
 describe('CREDIT NOTES ROUTES - PUT /creditNotes/:id', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
 
   let payload = {
@@ -567,7 +567,7 @@ describe('CREDIT NOTES ROUTES - PUT /creditNotes/:id', () => {
 });
 
 describe('CREDIT NOTES ROUTES - DELETE /creditNotes/:id', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
 
   describe('CLIENT_ADMIN', () => {

--- a/tests/integration/creditNotes.test.js
+++ b/tests/integration/creditNotes.test.js
@@ -420,7 +420,7 @@ describe('CREDIT NOTES ROUTES - PUT /creditNotes/:id', () => {
     it('should update a credit note', async () => {
       const response = await app.inject({
         method: 'PUT',
-        url: `/creditNotes/${creditNotesList[0]._id.toHexString()}`,
+        url: `/creditNotes/${creditNotesList[0]._id}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
         payload,
       });
@@ -433,7 +433,7 @@ describe('CREDIT NOTES ROUTES - PUT /creditNotes/:id', () => {
     it('should return a 404 error if credit note does not exist', async () => {
       const response = await app.inject({
         method: 'PUT',
-        url: `/creditNotes/${new ObjectID().toHexString()}`,
+        url: `/creditNotes/${new ObjectID()}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
         payload,
       });
@@ -444,7 +444,7 @@ describe('CREDIT NOTES ROUTES - PUT /creditNotes/:id', () => {
     it('should return a 403 error if credit not origin is not Compani', async () => {
       const response = await app.inject({
         method: 'PUT',
-        url: `/creditNotes/${creditNotesList[1]._id.toHexString()}`,
+        url: `/creditNotes/${creditNotesList[1]._id}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
         payload,
       });
@@ -457,7 +457,7 @@ describe('CREDIT NOTES ROUTES - PUT /creditNotes/:id', () => {
 
       const response = await app.inject({
         method: 'PUT',
-        url: `/creditNotes/${creditNotesList[0]._id.toHexString()}`,
+        url: `/creditNotes/${creditNotesList[0]._id}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
         payload,
       });
@@ -470,7 +470,7 @@ describe('CREDIT NOTES ROUTES - PUT /creditNotes/:id', () => {
 
       const response = await app.inject({
         method: 'PUT',
-        url: `/creditNotes/${creditNotesList[0]._id.toHexString()}`,
+        url: `/creditNotes/${creditNotesList[0]._id}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
         payload,
       });
@@ -495,7 +495,7 @@ describe('CREDIT NOTES ROUTES - PUT /creditNotes/:id', () => {
 
       const response = await app.inject({
         method: 'PUT',
-        url: `/creditNotes/${creditNotesList[0]._id.toHexString()}`,
+        url: `/creditNotes/${creditNotesList[0]._id}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
         payload,
       });
@@ -508,17 +508,13 @@ describe('CREDIT NOTES ROUTES - PUT /creditNotes/:id', () => {
         customer: creditNoteCustomer._id,
         subscription: {
           _id: otherCompanyCustomer.subscriptions[0]._id,
-          service: {
-            serviceId: new ObjectID(),
-            nature: FIXED,
-            name: 'titi',
-          },
+          service: { serviceId: new ObjectID(), nature: FIXED, name: 'titi' },
           vat: 5.5,
         },
       };
       const response = await app.inject({
         method: 'PUT',
-        url: `/creditNotes/${creditNotesList[0]._id.toHexString()}`,
+        url: `/creditNotes/${creditNotesList[0]._id}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
         payload,
       });
@@ -537,7 +533,7 @@ describe('CREDIT NOTES ROUTES - PUT /creditNotes/:id', () => {
 
       const response = await app.inject({
         method: 'PUT',
-        url: `/creditNotes/${creditNotesList[2]._id.toHexString()}`,
+        url: `/creditNotes/${creditNotesList[2]._id}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
         payload,
       });
@@ -559,7 +555,7 @@ describe('CREDIT NOTES ROUTES - PUT /creditNotes/:id', () => {
         authToken = await getToken(role.name);
         const response = await app.inject({
           method: 'PUT',
-          url: `/creditNotes/${creditNotesList[0]._id.toHexString()}`,
+          url: `/creditNotes/${creditNotesList[0]._id}`,
           headers: { Cookie: `alenvi_token=${authToken}` },
           payload,
         });
@@ -582,7 +578,7 @@ describe('CREDIT NOTES ROUTES - DELETE /creditNotes/:id', () => {
     it('should delete a credit note', async () => {
       const response = await app.inject({
         method: 'DELETE',
-        url: `/creditNotes/${creditNotesList[0]._id.toHexString()}`,
+        url: `/creditNotes/${creditNotesList[0]._id}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
       expect(response.statusCode).toBe(200);
@@ -591,7 +587,7 @@ describe('CREDIT NOTES ROUTES - DELETE /creditNotes/:id', () => {
     it('should return a 404 error if credit does not exist', async () => {
       const response = await app.inject({
         method: 'DELETE',
-        url: `/creditNotes/${new ObjectID().toHexString()}`,
+        url: `/creditNotes/${new ObjectID()}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
       expect(response.statusCode).toBe(404);
@@ -602,7 +598,7 @@ describe('CREDIT NOTES ROUTES - DELETE /creditNotes/:id', () => {
 
       const response = await app.inject({
         method: 'DELETE',
-        url: `/creditNotes/${creditNotesList[0]._id.toHexString()}`,
+        url: `/creditNotes/${creditNotesList[0]._id}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
       expect(response.statusCode).toBe(404);
@@ -611,7 +607,7 @@ describe('CREDIT NOTES ROUTES - DELETE /creditNotes/:id', () => {
     it('should return a 403 error if credit note origin is not COMPANI', async () => {
       const response = await app.inject({
         method: 'DELETE',
-        url: `/creditNotes/${creditNotesList[1]._id.toHexString()}`,
+        url: `/creditNotes/${creditNotesList[1]._id}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
       expect(response.statusCode).toBe(403);
@@ -620,7 +616,7 @@ describe('CREDIT NOTES ROUTES - DELETE /creditNotes/:id', () => {
     it('should return a 403 error if credit note is not editable', async () => {
       const response = await app.inject({
         method: 'DELETE',
-        url: `/creditNotes/${creditNotesList[2]._id.toHexString()}`,
+        url: `/creditNotes/${creditNotesList[2]._id}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
       expect(response.statusCode).toBe(403);
@@ -640,7 +636,7 @@ describe('CREDIT NOTES ROUTES - DELETE /creditNotes/:id', () => {
         authToken = await getToken(role.name);
         const response = await app.inject({
           method: 'DELETE',
-          url: `/creditNotes/${creditNotesList[0]._id.toHexString()}`,
+          url: `/creditNotes/${creditNotesList[0]._id}`,
           headers: { Cookie: `alenvi_token=${authToken}` },
         });
 

--- a/tests/integration/customerNotes.test.js
+++ b/tests/integration/customerNotes.test.js
@@ -132,7 +132,7 @@ describe('CUSTOMER NOTES ROUTES - POST /customernotes', () => {
 });
 
 describe('CUSTOMER NOTES ROUTES - GET /customernotes', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
 
   describe('AUXILIARY', () => {

--- a/tests/integration/customerPartners.test.js
+++ b/tests/integration/customerPartners.test.js
@@ -151,7 +151,7 @@ describe('CUSTOMER PARTNERS ROUTES - POST /customerpartners', () => {
 });
 
 describe('CUSTOMER PARTNERS ROUTES - GET /customerpartners', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
 
   describe('AUXILIARY', () => {
@@ -223,7 +223,7 @@ describe('CUSTOMER PARTNERS ROUTES - GET /customerpartners', () => {
 });
 
 describe('CUSTOMER PARTNERS ROUTES - PUT /customerpartners/{_id}', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
 
   describe('AUXILIARY', () => {
@@ -315,7 +315,7 @@ describe('CUSTOMER PARTNERS ROUTES - PUT /customerpartners/{_id}', () => {
 });
 
 describe('CUSTOMER PARTNERS ROUTES - DELETE /customerpartners/{_id}', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
 
   describe('AUXILIARY', () => {

--- a/tests/integration/customers.test.js
+++ b/tests/integration/customers.test.js
@@ -10,7 +10,6 @@ const cloneDeep = require('lodash/cloneDeep');
 const GetStream = require('get-stream');
 const fs = require('fs');
 const { generateFormData } = require('./utils');
-
 const app = require('../../server');
 const {
   populateDB,
@@ -920,8 +919,7 @@ describe('CUSTOMERS ROUTES', () => {
 
     describe('Other roles', () => {
       it('should get QR code if I am its helper ', async () => {
-        const helper = userList[0];
-        authToken = await getTokenByCredentials(helper.local);
+        authToken = await getTokenByCredentials(userList[0].local);
         const res = await app.inject({
           method: 'GET',
           url: `/customers/${customersList[0]._id}/qrcode`,
@@ -1474,8 +1472,7 @@ describe('CUSTOMER MANDATES ROUTES', () => {
     const mandateId = customersList[1].payment.mandates[0]._id.toHexString();
 
     it('should create a mandate signature request if I am its helper', async () => {
-      const helper = userList[1];
-      authToken = await getTokenByCredentials(helper.local);
+      authToken = await getTokenByCredentials(userList[1].local);
       const res = await app.inject({
         method: 'POST',
         url: `/customers/${customerId}/mandates/${mandateId}/esign`,
@@ -1496,8 +1493,7 @@ describe('CUSTOMER MANDATES ROUTES', () => {
     });
 
     it('should return 403 if user is not from the same company', async () => {
-      const helper = userList[2];
-      authToken = await getTokenByCredentials(helper.local);
+      authToken = await getTokenByCredentials(userList[2].local);
       const res = await app.inject({
         method: 'POST',
         url: `/customers/${otherCompanyCustomer._id}/mandates/${mandateId}/esign`,

--- a/tests/integration/drive.test.js
+++ b/tests/integration/drive.test.js
@@ -124,7 +124,7 @@ describe('DELETE /gdrive/file/:id', () => {
       });
 
       expect(response.statusCode).toBe(200);
-      sinon.assert.calledWithExactly(deleteFileStub, missingFileId);
+      sinon.assert.calledWithExactly(deleteFileStub, missingFileId.toHexString());
     });
   });
 });

--- a/tests/integration/drive.test.js
+++ b/tests/integration/drive.test.js
@@ -26,8 +26,7 @@ describe('POST /gdrive/:id/upload', () => {
   let addFileStub;
   let uploadFileSpy;
   beforeEach(() => {
-    addFileStub = sinon
-      .stub(GDriveStorageHelper, 'addFile')
+    addFileStub = sinon.stub(GDriveStorageHelper, 'addFile')
       .returns({ id: 'qwerty', webViewLink: 'http://test.com/file.pdf' });
     uploadFileSpy = sinon.spy(DriveHelper, 'uploadFile');
   });
@@ -36,6 +35,7 @@ describe('POST /gdrive/:id/upload', () => {
     addFileStub.restore();
     uploadFileSpy.restore();
   });
+
   describe('CLIENT_ADMIN', () => {
     beforeEach(populateDB);
     beforeEach(async () => {

--- a/tests/integration/drive.test.js
+++ b/tests/integration/drive.test.js
@@ -124,7 +124,7 @@ describe('DELETE /gdrive/file/:id', () => {
       });
 
       expect(response.statusCode).toBe(200);
-      sinon.assert.calledWithExactly(deleteFileStub, missingFileId.toHexString());
+      sinon.assert.calledWithExactly(deleteFileStub, missingFileId);
     });
   });
 });

--- a/tests/integration/establishments.test.js
+++ b/tests/integration/establishments.test.js
@@ -19,7 +19,7 @@ describe('NODE ENV', () => {
 });
 
 describe('ESTABLISHMENTS ROUTES', () => {
-  let authToken = null;
+  let authToken;
   describe('POST /estblishments', () => {
     const payload = {
       name: 'Titi',

--- a/tests/integration/eventHistories.test.js
+++ b/tests/integration/eventHistories.test.js
@@ -18,7 +18,7 @@ describe('NODE ENV', () => {
 });
 
 describe('GET /eventhistories', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
   beforeEach(async () => {
     authToken = await getToken('coach');

--- a/tests/integration/eventHistories.test.js
+++ b/tests/integration/eventHistories.test.js
@@ -37,7 +37,7 @@ describe('GET /eventhistories', () => {
   });
 
   it('should return a list of event histories from auxiliaries ids', async () => {
-    const auxiliaryIds = [auxiliaries[0]._id.toHexString(), auxiliaries[1]._id.toHexString()];
+    const auxiliaryIds = [auxiliaries[0]._id, auxiliaries[1]._id];
     const response = await app.inject({
       method: 'GET',
       url: `/eventhistories?auxiliaries=${auxiliaryIds[0]}&auxiliaries=${auxiliaryIds[1]}`,
@@ -47,12 +47,12 @@ describe('GET /eventhistories', () => {
     expect(response.statusCode).toEqual(200);
     expect(response.result.data.eventHistories).toBeDefined();
     response.result.data.eventHistories.forEach((history) => {
-      expect(history.auxiliaries.every(aux => auxiliaryIds.includes(aux._id.toHexString()))).toBeTruthy();
+      expect(history.auxiliaries.every(aux => UtilsHelper.doesArrayIncludeId(auxiliaryIds, aux._id))).toBeTruthy();
     });
   });
 
   it('should return a list of event histories from sectors ids', async () => {
-    const sectorIds = sectors.map(s => s._id.toHexString());
+    const sectorIds = sectors.map(s => s._id);
     const response = await app.inject({
       method: 'GET',
       url: `/eventhistories?sectors=${sectorIds[0]}&sectors=${sectorIds[1]}`,
@@ -62,7 +62,7 @@ describe('GET /eventhistories', () => {
     expect(response.statusCode).toEqual(200);
     expect(response.result.data.eventHistories).toBeDefined();
     response.result.data.eventHistories.forEach((history) => {
-      expect(history.sectors.every(sectorId => sectorIds.includes(sectorId.toHexString()))).toBeTruthy();
+      expect(history.sectors.every(sectorId => UtilsHelper.doesArrayIncludeId(sectorIds, sectorId))).toBeTruthy();
     });
   });
 
@@ -84,7 +84,7 @@ describe('GET /eventhistories', () => {
   it('should return a 400 if invalid query', async () => {
     const response = await app.inject({
       method: 'GET',
-      url: `/eventhistories?auxiliary=${auxiliaries[0]._id.toHexString()}`,
+      url: `/eventhistories?auxiliary=${auxiliaries[0]._id}`,
       headers: { Cookie: `alenvi_token=${authToken}` },
     });
 
@@ -94,7 +94,7 @@ describe('GET /eventhistories', () => {
   it('should return a 403 if at least one auxiliary is not from the same company', async () => {
     const response = await app.inject({
       method: 'GET',
-      url: `/eventhistories?auxiliaries=${auxiliaryFromOtherCompany._id.toHexString()}`,
+      url: `/eventhistories?auxiliaries=${auxiliaryFromOtherCompany._id}`,
       headers: { Cookie: `alenvi_token=${authToken}` },
     });
 
@@ -104,7 +104,7 @@ describe('GET /eventhistories', () => {
   it('should return a 403 if at least one sector is not from the same company', async () => {
     const response = await app.inject({
       method: 'GET',
-      url: `/eventhistories?sectors=${sectorFromOtherCompany._id.toHexString()}`,
+      url: `/eventhistories?sectors=${sectorFromOtherCompany._id}`,
       headers: { Cookie: `alenvi_token=${authToken}` },
     });
 

--- a/tests/integration/events.test.js
+++ b/tests/integration/events.test.js
@@ -52,7 +52,7 @@ describe('NODE ENV', () => {
 });
 
 describe('GET /events', () => {
-  let authToken = null;
+  let authToken;
   describe('AUXILIARY', () => {
     beforeEach(populateDB);
     beforeEach(async () => {
@@ -220,7 +220,7 @@ describe('GET /events', () => {
 });
 
 describe('GET /events/credit-notes', () => {
-  let authToken = null;
+  let authToken;
   describe('AUXILIARY', () => {
     beforeEach(populateDB);
     beforeEach(async () => {
@@ -353,7 +353,7 @@ describe('GET /events/credit-notes', () => {
 });
 
 describe('GET /events/working-stats', () => {
-  let authToken = null;
+  let authToken;
   const startDate = moment('2019-01-17').toDate();
   const endDate = moment('2019-01-20').toDate();
   describe('AUXILIARY', () => {
@@ -423,7 +423,7 @@ describe('GET /events/working-stats', () => {
 });
 
 describe('GET /events/paid-transport', () => {
-  let authToken = null;
+  let authToken;
   describe('AUXILIARY', () => {
     beforeEach(populateDB);
     beforeEach(async () => {
@@ -514,7 +514,7 @@ describe('GET /events/paid-transport', () => {
 });
 
 describe('GET /events/unassigned-hours', () => {
-  let authToken = null;
+  let authToken;
   describe('AUXILIARY', () => {
     beforeEach(populateDB);
     beforeEach(async () => {
@@ -616,7 +616,7 @@ describe('GET /events/unassigned-hours', () => {
 });
 
 describe('POST /events', () => {
-  let authToken = null;
+  let authToken;
   let DatesHelperDayDiff;
   describe('PLANNING_REFERENT', () => {
     beforeEach(populateDB);
@@ -1224,7 +1224,7 @@ describe('POST /events', () => {
 });
 
 describe('PUT /events/{_id}', () => {
-  let authToken = null;
+  let authToken;
   describe('PLANNING_REFERENT', () => {
     beforeEach(populateDB);
     beforeEach(async () => {
@@ -1676,7 +1676,7 @@ describe('PUT /events/{_id}', () => {
 });
 
 describe('DELETE /events/{_id}', () => {
-  let authToken = null;
+  let authToken;
   describe('PLANNING_REFERENT', () => {
     beforeEach(populateDB);
     beforeEach(async () => {
@@ -1746,7 +1746,7 @@ describe('DELETE /events/{_id}', () => {
 });
 
 describe('DELETE /events', () => {
-  let authToken = null;
+  let authToken;
   describe('PLANNING_REFERENT', () => {
     beforeEach(populateDB);
     beforeEach(async () => {
@@ -1846,7 +1846,7 @@ describe('DELETE /events', () => {
 });
 
 describe('DELETE /{_id}/repetition', () => {
-  let authToken = null;
+  let authToken;
   describe('PLANNING_REFERENT', () => {
     beforeEach(populateDB);
     beforeEach(async () => {

--- a/tests/integration/events.test.js
+++ b/tests/integration/events.test.js
@@ -1414,13 +1414,12 @@ describe('PUT /events/{_id}', () => {
       const payload = {
         startDate: '2019-01-23T10:00:00.000Z',
         endDate: '2019-02-23T12:00:00.000Z',
-        sector: sectors[0]._id.toHexString(),
+        sector: sectors[0]._id,
       };
-      const invalidId = new ObjectID();
 
       const response = await app.inject({
         method: 'PUT',
-        url: `/events/${invalidId.toHexString()}`,
+        url: `/events/${new ObjectID()}`,
         payload,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
@@ -1696,11 +1695,9 @@ describe('DELETE /events/{_id}', () => {
     });
 
     it('should return a 404 error as event is not found', async () => {
-      const invalidId = new ObjectID();
-
       const response = await app.inject({
         method: 'DELETE',
-        url: `/events/${invalidId.toHexString()}`,
+        url: `/events/${new ObjectID()}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 

--- a/tests/integration/exports.test.js
+++ b/tests/integration/exports.test.js
@@ -116,7 +116,7 @@ historyExportTypes.forEach(({ exportType, expectedRows, query }) => {
         expect(rows.length).toBe(expectedRows.length);
 
         for (let i = 0; i < expectedRows.length; i++) {
-          expect(rows.some(er => er === expectedRows[i])).toBeTruthy();
+          expect(rows.some(r => r === expectedRows[i])).toBeTruthy();
         }
       });
     });
@@ -254,7 +254,7 @@ dataExportTypes.forEach(({ exportType, expectedRows }) => {
         expect(rows.length).toBe(expectedRows.length);
 
         for (let i = 0; i < expectedRows.length; i++) {
-          expect(rows.some(er => er === expectedRows[i])).toBeTruthy();
+          expect(rows.some(r => r === expectedRows[i])).toBeTruthy();
         }
       });
     });

--- a/tests/integration/exports.test.js
+++ b/tests/integration/exports.test.js
@@ -115,8 +115,8 @@ historyExportTypes.forEach(({ exportType, expectedRows, query }) => {
         const rows = response.result.split('\r\n');
         expect(rows.length).toBe(expectedRows.length);
 
-        for (let i = 0; i < rows.length; i++) {
-          expect(expectedRows.some(er => er === rows[i])).toBeTruthy();
+        for (let i = 0; i < expectedRows.length; i++) {
+          expect(rows.some(er => er === expectedRows[i])).toBeTruthy();
         }
       });
     });
@@ -253,8 +253,8 @@ dataExportTypes.forEach(({ exportType, expectedRows }) => {
         const rows = response.result.split('\r\n');
         expect(rows.length).toBe(expectedRows.length);
 
-        for (let i = 0; i < rows.length; i++) {
-          expect(expectedRows.some(er => er === rows[i])).toBeTruthy();
+        for (let i = 0; i < expectedRows.length; i++) {
+          expect(rows.some(er => er === expectedRows[i])).toBeTruthy();
         }
       });
     });

--- a/tests/integration/finalPay.test.js
+++ b/tests/integration/finalPay.test.js
@@ -15,7 +15,7 @@ describe('NODE ENV', () => {
 });
 
 describe('FINAL PAY ROUTES - GET /finalpay/draft', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
 
   describe('CLIENT_ADMIN', () => {
@@ -104,7 +104,7 @@ describe('FINAL PAY ROUTES - GET /finalpay/draft', () => {
 });
 
 describe('FINAL PAY ROUTES - POST /finalpay', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
   const payload = [{
     auxiliary: auxiliary._id,

--- a/tests/integration/helpers.test.js
+++ b/tests/integration/helpers.test.js
@@ -11,7 +11,7 @@ describe('NODE ENV', () => {
 });
 
 describe('GET /helpers', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
 
   describe('AUXILIARY', () => {
@@ -79,7 +79,7 @@ describe('GET /helpers', () => {
 });
 
 describe('PUT /helpers/{_id}', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
 
   describe('COACH', () => {

--- a/tests/integration/internalHours.test.js
+++ b/tests/integration/internalHours.test.js
@@ -18,7 +18,7 @@ describe('NODE ENV', () => {
 });
 
 describe('POST /internalhours', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
 
   describe('CLIENT_ADMIN', () => {
@@ -92,7 +92,7 @@ describe('POST /internalhours', () => {
 });
 
 describe('GET /internalhours', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
 
   describe('COACH', () => {
@@ -148,7 +148,7 @@ describe('GET /internalhours', () => {
 });
 
 describe('DELETE /internalhours/:id', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
 
   describe('CLIENT_ADMIN', () => {

--- a/tests/integration/pay.test.js
+++ b/tests/integration/pay.test.js
@@ -62,7 +62,7 @@ describe('PAY ROUTES - GET /pay/draft', () => {
 });
 
 describe('PAY ROUTES - POST /pay', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
   const payload = [{
     auxiliary: auxiliaries[0]._id,

--- a/tests/integration/payments.test.js
+++ b/tests/integration/payments.test.js
@@ -260,7 +260,7 @@ describe('PAYMENTS ROUTES - POST /payments/createlist', () => {
 });
 
 describe('PAYMENTS ROUTES - PUT /payments/_id', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
 
   describe('CLIENT_ADMIN', () => {
@@ -340,7 +340,7 @@ describe('PAYMENTS ROUTES - PUT /payments/_id', () => {
 });
 
 describe('PAYMENTS ROUTES - DELETE /payments/_id', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
 
   describe('CLIENT_ADMIN', () => {

--- a/tests/integration/questionnaireHistories.test.js
+++ b/tests/integration/questionnaireHistories.test.js
@@ -20,7 +20,7 @@ describe('NODE ENV', () => {
 });
 
 describe('QUESTIONNAIRE HISTORIES ROUTES - POST /questionnairehistories', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
 
   describe('Logged user', () => {

--- a/tests/integration/questionnaires.test.js
+++ b/tests/integration/questionnaires.test.js
@@ -96,7 +96,7 @@ describe('QUESTIONNAIRES ROUTES - POST /questionnaires', () => {
 });
 
 describe('QUESTIONNAIRES ROUTES - GET /questionnaires', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
 
   describe('TRAINING_ORGANISATION_MANAGER', () => {
@@ -140,7 +140,7 @@ describe('QUESTIONNAIRES ROUTES - GET /questionnaires', () => {
 });
 
 describe('QUESTIONNAIRES ROUTES - GET /questionnaires/{_id}', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
 
   describe('TRAINING_ORGANISATION_MANAGER', () => {
@@ -204,7 +204,7 @@ describe('QUESTIONNAIRES ROUTES - GET /questionnaires/{_id}', () => {
 });
 
 describe('QUESTIONNAIRES ROUTES - GET /questionnaires/user', () => {
-  let authToken = null;
+  let authToken;
   let nowStub;
   beforeEach(populateDB);
 
@@ -254,7 +254,7 @@ describe('QUESTIONNAIRES ROUTES - GET /questionnaires/user', () => {
 });
 
 describe('QUESTIONNAIRE ROUTES - GET /questionnaires/{_id}/follow-up', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
 
   describe('TRAINER', () => {
@@ -378,7 +378,7 @@ describe('QUESTIONNAIRE ROUTES - GET /questionnaires/{_id}/follow-up', () => {
 });
 
 describe('QUESTIONNAIRES ROUTES - PUT /questionnaires/{_id}', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
 
   describe('TRAINING_ORGANISATION_MANAGER', () => {
@@ -559,7 +559,7 @@ describe('QUESTIONNAIRES ROUTES - PUT /questionnaires/{_id}', () => {
 });
 
 describe('QUESTIONNAIRES ROUTES - POST /questionnaires/{_id}/card', () => {
-  let authToken = null;
+  let authToken;
   const questionnaireId = questionnairesList[0]._id;
   beforeEach(populateDB);
   const payload = { template: SURVEY };
@@ -655,7 +655,7 @@ describe('QUESTIONNAIRES ROUTES - POST /questionnaires/{_id}/card', () => {
 });
 
 describe('QUESTIONNAIRES ROUTES - DELETE /questionnaires/cards/{cardId}', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
   const draftQuestionnaire = questionnairesList.find(questionnaire => questionnaire.status === 'draft');
   const publishedQuestionnaire = questionnairesList.find(questionnaire => questionnaire.status === 'published');

--- a/tests/integration/questionnaires.test.js
+++ b/tests/integration/questionnaires.test.js
@@ -608,10 +608,9 @@ describe('QUESTIONNAIRES ROUTES - POST /questionnaires/{_id}/card', () => {
     });
 
     it('should return a 404 if questionnaire does not exist', async () => {
-      const invalidId = new ObjectID();
       const response = await app.inject({
         method: 'POST',
-        url: `/questionnaires/${invalidId}/cards`,
+        url: `/questionnaires/${new ObjectID()}/cards`,
         payload,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });

--- a/tests/integration/seed/administrativeDocumentSeed.js
+++ b/tests/integration/seed/administrativeDocumentSeed.js
@@ -27,7 +27,9 @@ const administrativeDocumentsList = [
 const populateDB = async () => {
   await deleteNonAuthenticationSeeds();
 
-  await AdministrativeDocument.create(administrativeDocumentsList);
+  await Promise.all([
+    AdministrativeDocument.create(administrativeDocumentsList),
+  ]);
 };
 
 module.exports = {

--- a/tests/integration/seed/administrativeDocumentSeed.js
+++ b/tests/integration/seed/administrativeDocumentSeed.js
@@ -27,9 +27,7 @@ const administrativeDocumentsList = [
 const populateDB = async () => {
   await deleteNonAuthenticationSeeds();
 
-  await Promise.all([
-    AdministrativeDocument.create(administrativeDocumentsList),
-  ]);
+  await Promise.all([AdministrativeDocument.create(administrativeDocumentsList)]);
 };
 
 module.exports = {

--- a/tests/integration/seed/balanceSeed.js
+++ b/tests/integration/seed/balanceSeed.js
@@ -129,11 +129,7 @@ const balanceCustomerList = [
   },
 ];
 
-const authBillService = {
-  serviceId: new ObjectID(),
-  name: 'Temps de qualité - autonomie',
-  nature: 'hourly',
-};
+const authBillService = { serviceId: new ObjectID(), name: 'Temps de qualité - autonomie', nature: 'hourly' };
 
 const balanceBillList = [
   {
@@ -234,20 +230,20 @@ const customerFromOtherCompany = {
 const populateDB = async () => {
   await deleteNonAuthenticationSeeds();
 
-  await ThirdPartyPayer.create(balanceThirdPartyPayer);
-  await Service.insertMany(customerServiceList);
-  await Customer.insertMany(balanceCustomerList.concat(customerFromOtherCompany));
-  await Bill.insertMany(balanceBillList);
-  await Helper.insertMany(helpersList);
-  await UserCompany.insertMany(balanceUserCompanies);
-  await User.create(balanceUserList);
+  await Promise.all([
+    Bill.create(balanceBillList),
+    Customer.create(balanceCustomerList.concat(customerFromOtherCompany)),
+    Helper.create(helpersList),
+    Service.create(customerServiceList),
+    ThirdPartyPayer.create(balanceThirdPartyPayer),
+    User.create(balanceUserList),
+    UserCompany.create(balanceUserCompanies),
+  ]);
 };
 
 module.exports = {
   populateDB,
   balanceCustomerList,
-  balanceBillList,
-  balanceThirdPartyPayer,
   balanceUserList,
   customerFromOtherCompany,
 };

--- a/tests/integration/seed/billSlipsSeed.js
+++ b/tests/integration/seed/billSlipsSeed.js
@@ -117,15 +117,16 @@ const billSlipFromAnotherCompany = {
 const populateDB = async () => {
   await deleteNonAuthenticationSeeds();
 
-  await ThirdPartyPayer.insertMany(tppList);
-  await BillSlip.insertMany([...billSlipList, billSlipFromAnotherCompany]);
-  await Bill.insertMany(billList);
-  await CreditNote.insertMany(creditNotesList);
+  await Promise.all([
+    Bill.create(billList),
+    BillSlip.create([...billSlipList, billSlipFromAnotherCompany]),
+    CreditNote.create(creditNotesList),
+    ThirdPartyPayer.create(tppList),
+  ]);
 };
 
 module.exports = {
   populateDB,
-  tppList,
   billSlipList,
   billSlipFromAnotherCompany,
 };

--- a/tests/integration/seed/billsSeed.js
+++ b/tests/integration/seed/billsSeed.js
@@ -177,13 +177,12 @@ const billUserList = [
     local: { email: 'helper_for_customer_bill@alenvi.io', password: '123456!eR' },
     refreshToken: uuidv4(),
     role: { client: helperRoleId },
-    customers: [billCustomerList[0]._id],
     origin: WEBAPP,
   },
   {
     _id: new ObjectID(),
     identity: { firstname: 'Youpi', lastname: 'Toto' },
-    local: { email: 'toto@alenvi.io', password: '123456!eR' },
+    local: { email: 'toto@alenvi.io' },
     refreshToken: uuidv4(),
     role: { client: auxiliaryRoleId },
     contracts: [new ObjectID()],
@@ -192,7 +191,7 @@ const billUserList = [
   {
     _id: new ObjectID(),
     identity: { firstname: 'Bravo', lastname: 'Toto' },
-    local: { email: 'tutu@alenvi.io', password: '123456!eR' },
+    local: { email: 'tutu@alenvi.io' },
     refreshToken: uuidv4(),
     role: { client: auxiliaryRoleId },
     contracts: [new ObjectID()],
@@ -201,7 +200,7 @@ const billUserList = [
   {
     _id: new ObjectID(),
     identity: { firstname: 'Tata', lastname: 'Toto' },
-    local: { email: 'toto2@alenvi.io', password: '123456!eR' },
+    local: { email: 'toto2@alenvi.io' },
     refreshToken: uuidv4(),
     role: { client: auxiliaryRoleId },
     contracts: [new ObjectID()],
@@ -545,18 +544,20 @@ const helpersList = [
 const populateDB = async () => {
   await deleteNonAuthenticationSeeds();
 
-  await ThirdPartyPayer.create(billThirdPartyPayer);
-  await Service.insertMany(billServices);
-  await Customer.insertMany(billCustomerList.concat(customerFromOtherCompany));
-  await Bill.insertMany([...authBillsList, ...billsList]);
-  await Event.insertMany(eventList);
-  await Helper.insertMany(helpersList);
-  await User.create(billUserList);
-  await CreditNote.create(creditNote);
-  await FundingHistory.create(fundingHistory);
-  await BillNumber.create(billNumbers);
-  await Contract.create(contracts);
-  await UserCompany.insertMany(userCompanies);
+  await Promise.all([
+    Bill.create([...authBillsList, ...billsList]),
+    BillNumber.create(billNumbers),
+    Contract.create(contracts),
+    CreditNote.create(creditNote),
+    Customer.create(billCustomerList.concat(customerFromOtherCompany)),
+    Event.create(eventList),
+    FundingHistory.create(fundingHistory),
+    Helper.create(helpersList),
+    Service.create(billServices),
+    ThirdPartyPayer.create(billThirdPartyPayer),
+    User.create(billUserList),
+    UserCompany.create(userCompanies),
+  ]);
 };
 
 module.exports = {
@@ -571,5 +572,4 @@ module.exports = {
   otherCompanyBillThirdPartyPayer,
   customerFromOtherCompany,
   fundingHistory,
-  billNumbers,
 };

--- a/tests/integration/seed/cardsSeed.js
+++ b/tests/integration/seed/cardsSeed.js
@@ -91,10 +91,7 @@ const cardsList = [
   {
     _id: new ObjectID(),
     template: ORDER_THE_SEQUENCE,
-    orderedAnswers: [
-      { _id: new ObjectID(), text: 'rien' },
-      { _id: new ObjectID(), text: 'des trucs' },
-    ],
+    orderedAnswers: [{ _id: new ObjectID(), text: 'rien' }, { _id: new ObjectID(), text: 'des trucs' }],
   },
   {
     _id: new ObjectID(),
@@ -149,14 +146,14 @@ const questionnairesList = [
 const populateDB = async () => {
   await deleteNonAuthenticationSeeds();
 
-  await Card.insertMany(cardsList);
-  await Activity.create(activitiesList);
-  await Questionnaire.create(questionnairesList);
+  await Promise.all([
+    Card.create(cardsList),
+    Activity.create(activitiesList),
+    Questionnaire.create(questionnairesList),
+  ]);
 };
 
 module.exports = {
   populateDB,
   cardsList,
-  activitiesList,
-  questionnairesList,
 };

--- a/tests/integration/seed/categoriesSeed.js
+++ b/tests/integration/seed/categoriesSeed.js
@@ -18,10 +18,7 @@ const programsList = [
 const populateDB = async () => {
   await deleteNonAuthenticationSeeds();
 
-  await Promise.all([
-    Category.create(categoriesList),
-    Program.create(programsList),
-  ]);
+  await Promise.all([Category.create(categoriesList), Program.create(programsList)]);
 };
 
 module.exports = {

--- a/tests/integration/seed/categoriesSeed.js
+++ b/tests/integration/seed/categoriesSeed.js
@@ -18,12 +18,13 @@ const programsList = [
 const populateDB = async () => {
   await deleteNonAuthenticationSeeds();
 
-  await Category.insertMany(categoriesList);
-  await Program.insertMany(programsList);
+  await Promise.all([
+    Category.create(categoriesList),
+    Program.create(programsList),
+  ]);
 };
 
 module.exports = {
   populateDB,
   categoriesList,
-  programsList,
 };

--- a/tests/integration/seed/companiesSeed.js
+++ b/tests/integration/seed/companiesSeed.js
@@ -3,11 +3,11 @@ const { v4: uuidv4 } = require('uuid');
 const Company = require('../../../src/models/Company');
 const Event = require('../../../src/models/Event');
 const User = require('../../../src/models/User');
+const UserCompany = require('../../../src/models/UserCompany');
 const { authCompany } = require('../../seed/authCompaniesSeed');
 const { deleteNonAuthenticationSeeds } = require('../helpers/authentication');
-const { INTERVENTION, MOBILE } = require('../../../src/helpers/constants');
-const UserCompany = require('../../../src/models/UserCompany');
 const { clientAdminRoleId } = require('../../seed/authRolesSeed');
+const { INTERVENTION, MOBILE } = require('../../../src/helpers/constants');
 
 const company = {
   _id: new ObjectID(),
@@ -58,10 +58,12 @@ const userCompany = { _id: new ObjectID(), user: companyClientAdmin._id, company
 const populateDB = async () => {
   await deleteNonAuthenticationSeeds();
 
-  await Company.create(company);
-  await Event.create(event);
-  await User.create(companyClientAdmin);
-  await UserCompany.create(userCompany);
+  await Promise.all([
+    Company.create(company),
+    Event.create(event),
+    User.create(companyClientAdmin),
+    UserCompany.create(userCompany),
+  ]);
 };
 
 module.exports = { company, companyClientAdmin, populateDB };

--- a/tests/integration/seed/contractsSeed.js
+++ b/tests/integration/seed/contractsSeed.js
@@ -11,7 +11,7 @@ const Establishment = require('../../../src/models/Establishment');
 const UserCompany = require('../../../src/models/UserCompany');
 const { authCompany, otherCompany } = require('../../seed/authCompaniesSeed');
 const { deleteNonAuthenticationSeeds } = require('../helpers/authentication');
-const { clientAdminRoleId, auxiliaryRoleId } = require('../../seed/authRolesSeed');
+const { auxiliaryRoleId } = require('../../seed/authRolesSeed');
 
 const customer = {
   _id: new ObjectID(),
@@ -45,9 +45,9 @@ const customer = {
 const otherContractUser = {
   _id: new ObjectID(),
   identity: { firstname: 'OCCU', lastname: 'OCCU' },
-  local: { email: 'other-company-contract-user@alenvi.io', password: '123456!eR' },
+  local: { email: 'other-company-contract-user@alenvi.io' },
   refreshToken: uuidv4(),
-  role: { client: clientAdminRoleId },
+  role: { client: auxiliaryRoleId },
   contracts: [new ObjectID()],
   prefixNumber: 103,
   origin: WEBAPP,
@@ -85,7 +85,7 @@ const contractUsers = [
       birthCity: 'Paris',
       birthState: 75,
     },
-    local: { email: 'test7@alenvi.io', password: '123456!eR' },
+    local: { email: 'test7@alenvi.io' },
     refreshToken: uuidv4(),
     role: { client: auxiliaryRoleId },
     contracts: [new ObjectID()],
@@ -112,7 +112,7 @@ const contractUsers = [
       birthState: 75,
     },
     establishment: new ObjectID(),
-    local: { email: 'tototest@alenvi.io', password: '123456!eR' },
+    local: { email: 'tototest@alenvi.io' },
     refreshToken: uuidv4(),
     role: { client: auxiliaryRoleId },
     contracts: [new ObjectID()],
@@ -139,7 +139,7 @@ const contractUsers = [
       birthState: 75,
     },
     establishment: new ObjectID(),
-    local: { email: 'ok@alenvi.io', password: '123456!eR' },
+    local: { email: 'ok@alenvi.io' },
     refreshToken: uuidv4(),
     role: { client: auxiliaryRoleId },
     contact: {
@@ -157,7 +157,7 @@ const contractUsers = [
   {
     _id: new ObjectID(),
     identity: { firstname: 'contract', lastname: 'Titi' },
-    local: { email: 'contract@alenvi.io', password: '123456!eR' },
+    local: { email: 'contract@alenvi.io' },
     refreshToken: uuidv4(),
     role: { client: auxiliaryRoleId },
     contracts: [new ObjectID()],
@@ -167,7 +167,7 @@ const contractUsers = [
   {
     _id: new ObjectID(),
     identity: { firstname: 'contract', lastname: 'Uelle' },
-    local: { email: 'dfghjkscs@alenvi.io', password: '123456!eR' },
+    local: { email: 'dfghjkscs@alenvi.io' },
     refreshToken: uuidv4(),
     role: { client: auxiliaryRoleId },
     contracts: [new ObjectID()],
@@ -177,7 +177,7 @@ const contractUsers = [
   {
     _id: new ObjectID(),
     identity: { firstname: 'contract', lastname: 'ant' },
-    local: { email: 'iuytr@alenvi.io', password: '123456!eR' },
+    local: { email: 'iuytr@alenvi.io' },
     refreshToken: uuidv4(),
     role: { client: auxiliaryRoleId },
     contracts: [new ObjectID()],
@@ -204,7 +204,7 @@ const contractUsers = [
         location: { type: 'Point', coordinates: [2.377133, 48.801389] },
       },
     },
-    local: { email: 'dfghjk@alenvi.io', password: '123456!eR' },
+    local: { email: 'dfghjk@alenvi.io' },
     refreshToken: uuidv4(),
     role: { client: auxiliaryRoleId },
     contracts: [new ObjectID()],
@@ -268,16 +268,6 @@ const otherContract = {
   versions: [{ grossHourlyRate: 10.28, startDate: '2018-12-03T23:00:00.000Z', weeklyHours: 9, _id: new ObjectID() }],
 };
 
-const userFromOtherCompany = {
-  _id: new ObjectID(),
-  identity: { firstname: 'Test7', lastname: 'Test7' },
-  local: { email: 'test@othercompany.io', password: '123456!eR' },
-  refreshToken: uuidv4(),
-  role: { client: clientAdminRoleId },
-  contracts: [new ObjectID()],
-  origin: WEBAPP,
-};
-
 const contractUserCompanies = [
   { _id: new ObjectID(), user: contractUsers[0]._id, company: authCompany._id },
   { _id: new ObjectID(), user: contractUsers[1]._id, company: authCompany._id },
@@ -287,7 +277,6 @@ const contractUserCompanies = [
   { _id: new ObjectID(), user: contractUsers[5]._id, company: authCompany._id },
   { _id: new ObjectID(), user: contractUsers[6]._id, company: authCompany._id },
   { _id: new ObjectID(), user: otherContractUser._id, company: otherCompany._id },
-  { _id: new ObjectID(), user: userFromOtherCompany._id, company: otherCompany._id },
 ];
 
 const contractsList = [
@@ -457,24 +446,24 @@ const contractEvents = [
 const populateDB = async () => {
   await deleteNonAuthenticationSeeds();
 
-  await User.insertMany([...contractUsers, otherContractUser, userFromOtherCompany]);
-  await Sector.create(sector);
-  await Establishment.create(establishment);
-  await Customer.create(customer);
-  await Contract.insertMany([...contractsList, otherContract]);
-  await Event.insertMany(contractEvents);
-  await SectorHistory.insertMany(sectorHistories);
-  await UserCompany.insertMany(contractUserCompanies);
+  await Promise.all([
+    Contract.create([...contractsList, otherContract]),
+    Customer.create(customer),
+    Establishment.create(establishment),
+    Event.create(contractEvents),
+    Sector.create(sector),
+    SectorHistory.create(sectorHistories),
+    UserCompany.create(contractUserCompanies),
+    User.create([...contractUsers, otherContractUser]),
+  ]);
 };
 
 module.exports = {
   contractsList,
   populateDB,
   contractUsers,
-  customer,
   contractEvents,
   otherContract,
   otherContractUser,
-  userFromOtherCompany,
   contractUserCompanies,
 };

--- a/tests/integration/seed/contractsSeed.js
+++ b/tests/integration/seed/contractsSeed.js
@@ -1,6 +1,5 @@
 const { v4: uuidv4 } = require('uuid');
 const { ObjectID } = require('mongodb');
-const { DAILY, PAID_LEAVE, INTERNAL_HOUR, ABSENCE, INTERVENTION, WEBAPP } = require('../../../src/helpers/constants');
 const Contract = require('../../../src/models/Contract');
 const User = require('../../../src/models/User');
 const Customer = require('../../../src/models/Customer');
@@ -9,8 +8,9 @@ const SectorHistory = require('../../../src/models/SectorHistory');
 const Event = require('../../../src/models/Event');
 const Establishment = require('../../../src/models/Establishment');
 const UserCompany = require('../../../src/models/UserCompany');
-const { authCompany, otherCompany } = require('../../seed/authCompaniesSeed');
+const { DAILY, PAID_LEAVE, INTERNAL_HOUR, ABSENCE, INTERVENTION, WEBAPP } = require('../../../src/helpers/constants');
 const { deleteNonAuthenticationSeeds } = require('../helpers/authentication');
+const { authCompany, otherCompany } = require('../../seed/authCompaniesSeed');
 const { auxiliaryRoleId } = require('../../seed/authRolesSeed');
 
 const customer = {

--- a/tests/integration/seed/courseHistoriesSeed.js
+++ b/tests/integration/seed/courseHistoriesSeed.js
@@ -1,10 +1,31 @@
 const { ObjectID } = require('mongodb');
+const { v4: uuidv4 } = require('uuid');
 const Course = require('../../../src/models/Course');
 const CourseHistory = require('../../../src/models/CourseHistory');
+const User = require('../../../src/models/User');
 const { authCompany } = require('../../seed/authCompaniesSeed');
-const { vendorAdmin, trainer } = require('../../seed/authUsersSeed');
-const { SLOT_CREATION } = require('../../../src/helpers/constants');
+const { SLOT_CREATION, WEBAPP } = require('../../../src/helpers/constants');
 const { deleteNonAuthenticationSeeds } = require('../helpers/authentication');
+const { vendorAdminRoleId, trainerRoleId } = require('../../seed/authRolesSeed');
+
+const userList = [
+  {
+    _id: new ObjectID(),
+    identity: { firstname: 'course', lastname: 'Trainer' },
+    refreshToken: uuidv4(),
+    local: { email: 'trainerCourseHistories@alenvi.io', password: '123456!eR' },
+    role: { vendor: trainerRoleId },
+    origin: WEBAPP,
+  },
+  {
+    _id: new ObjectID(),
+    identity: { firstname: 'salesrep', lastname: 'noCourse' },
+    refreshToken: uuidv4(),
+    local: { email: 'salerep@compani.fr' },
+    role: { vendor: vendorAdminRoleId },
+    origin: WEBAPP,
+  },
+];
 
 const subProgramsList = [{ _id: new ObjectID(), name: 'sous-programme A', steps: [] }];
 
@@ -14,9 +35,9 @@ const coursesList = [{
   company: authCompany._id,
   misc: 'first session',
   type: 'intra',
-  trainer: trainer._id,
+  trainer: userList[0]._id,
   trainees: [],
-  salesRepresentative: vendorAdmin._id,
+  salesRepresentative: userList[1]._id,
 },
 {
   _id: new ObjectID(),
@@ -26,7 +47,7 @@ const coursesList = [{
   type: 'intra',
   trainer: new ObjectID(),
   trainees: [],
-  salesRepresentative: vendorAdmin._id,
+  salesRepresentative: userList[1]._id,
 },
 {
   _id: new ObjectID(),
@@ -34,9 +55,9 @@ const coursesList = [{
   misc: 'inter b2b session',
   type: 'inter_b2b',
   format: 'blended',
-  trainer: trainer._id,
+  trainer: userList[0]._id,
   trainees: [],
-  salesRepresentative: vendorAdmin._id,
+  salesRepresentative: userList[1]._id,
 }];
 
 const courseHistoriesList = [{
@@ -109,12 +130,16 @@ const courseHistoriesList = [{
 const populateDB = async () => {
   await deleteNonAuthenticationSeeds();
 
-  await Course.insertMany(coursesList);
-  await CourseHistory.insertMany(courseHistoriesList);
+  await Promise.all([
+    Course.create(coursesList),
+    CourseHistory.create(courseHistoriesList),
+    User.create(userList),
+  ]);
 };
 
 module.exports = {
   populateDB,
   coursesList,
   courseHistoriesList,
+  userList,
 };

--- a/tests/integration/seed/courseHistoriesSeed.js
+++ b/tests/integration/seed/courseHistoriesSeed.js
@@ -130,11 +130,7 @@ const courseHistoriesList = [{
 const populateDB = async () => {
   await deleteNonAuthenticationSeeds();
 
-  await Promise.all([
-    Course.create(coursesList),
-    CourseHistory.create(courseHistoriesList),
-    User.create(userList),
-  ]);
+  await Promise.all([Course.create(coursesList), CourseHistory.create(courseHistoriesList), User.create(userList)]);
 };
 
 module.exports = {

--- a/tests/integration/seed/courseSlotsSeed.js
+++ b/tests/integration/seed/courseSlotsSeed.js
@@ -106,11 +106,11 @@ const attendance = { _id: new ObjectID(), trainee: new ObjectID(), courseSlot: c
 const populateDB = async () => {
   await deleteNonAuthenticationSeeds();
 
-  await SubProgram.insertMany(subProgramsList);
-  await Program.insertMany(programsList);
-  await Course.insertMany(coursesList);
-  await CourseSlot.insertMany(courseSlotsList);
-  await Step.insertMany(stepsList);
+  await SubProgram.create(subProgramsList);
+  await Program.create(programsList);
+  await Course.create(coursesList);
+  await CourseSlot.create(courseSlotsList);
+  await Step.create(stepsList);
   await User.create(trainer);
   await Attendance.create(attendance);
   await UserCompany.create(userCompanies);

--- a/tests/integration/seed/courseSlotsSeed.js
+++ b/tests/integration/seed/courseSlotsSeed.js
@@ -106,14 +106,16 @@ const attendance = { _id: new ObjectID(), trainee: new ObjectID(), courseSlot: c
 const populateDB = async () => {
   await deleteNonAuthenticationSeeds();
 
-  await SubProgram.create(subProgramsList);
-  await Program.create(programsList);
-  await Course.create(coursesList);
-  await CourseSlot.create(courseSlotsList);
-  await Step.create(stepsList);
-  await User.create(trainer);
-  await Attendance.create(attendance);
-  await UserCompany.create(userCompanies);
+  await Promise.all([
+    SubProgram.create(subProgramsList),
+    Program.create(programsList),
+    Course.create(coursesList),
+    CourseSlot.create(courseSlotsList),
+    Step.create(stepsList),
+    User.create(trainer),
+    Attendance.create(attendance),
+    UserCompany.create(userCompanies),
+  ]);
 };
 
 module.exports = {

--- a/tests/integration/seed/coursesSeed.js
+++ b/tests/integration/seed/coursesSeed.js
@@ -293,19 +293,21 @@ const slots = [
 const populateDB = async () => {
   await deleteNonAuthenticationSeeds();
 
-  await SubProgram.insertMany(subProgramsList);
-  await Program.insertMany(programsList);
-  await Course.insertMany(coursesList);
-  await CourseSlot.insertMany(slots);
-  await User.create([traineeFromOtherCompany, traineeWithoutCompany, traineeFromAuthCompanyWithFormationExpoToken]);
-  await CourseSmsHistory.create(courseSmsHistory);
-  await Step.create(step);
-  await Activity.insertMany(activitiesList);
-  await Card.insertMany(cardsList);
-  await ActivityHistory.insertMany(activitiesHistory);
-  await UserCompany.insertMany(userCompanies);
-  await Questionnaire.create(questionnaire);
-  await QuestionnaireHistory.create(questionnaireHistory);
+  await Promise.all([
+    Activity.create(activitiesList),
+    ActivityHistory.create(activitiesHistory),
+    Card.create(cardsList),
+    Course.create(coursesList),
+    CourseSlot.create(slots),
+    CourseSmsHistory.create(courseSmsHistory),
+    Program.create(programsList),
+    Questionnaire.create(questionnaire),
+    QuestionnaireHistory.create(questionnaireHistory),
+    Step.create(step),
+    SubProgram.create(subProgramsList),
+    User.create([traineeFromOtherCompany, traineeWithoutCompany, traineeFromAuthCompanyWithFormationExpoToken]),
+    UserCompany.create(userCompanies),
+  ]);
 };
 
 module.exports = {

--- a/tests/integration/seed/creditNotesSeed.js
+++ b/tests/integration/seed/creditNotesSeed.js
@@ -8,10 +8,10 @@ const User = require('../../../src/models/User');
 const Service = require('../../../src/models/Service');
 const ThirdPartyPayer = require('../../../src/models/ThirdPartyPayer');
 const Helper = require('../../../src/models/Helper');
+const UserCompany = require('../../../src/models/UserCompany');
 const { HOURLY, WEBAPP } = require('../../../src/helpers/constants');
 const { authCompany, otherCompany } = require('../../seed/authCompaniesSeed');
 const { deleteNonAuthenticationSeeds } = require('../helpers/authentication');
-const UserCompany = require('../../../src/models/UserCompany');
 const { helperRoleId, auxiliaryRoleId, clientAdminRoleId } = require('../../seed/authRolesSeed');
 
 const creditNoteThirdPartyPayer = {
@@ -82,7 +82,7 @@ const creditNoteUserList = [
   {
     _id: new ObjectID(),
     identity: { firstname: 'Tata', lastname: 'Toto' },
-    local: { email: 'toto@alenvi.io', password: '123456!eR' },
+    local: { email: 'toto@alenvi.io' },
     refreshToken: uuidv4(),
     role: { client: auxiliaryRoleId },
     origin: WEBAPP,
@@ -336,14 +336,16 @@ const userCompanies = [
 const populateDB = async () => {
   await deleteNonAuthenticationSeeds();
 
-  await Event.create([creditNoteEvent, otherCompanyEvent]);
-  await Customer.create([creditNoteCustomer, otherCompanyCustomer]);
-  await Service.create([creditNoteService, otherCompanyService]);
-  await ThirdPartyPayer.create([creditNoteThirdPartyPayer, otherCompanyThirdPartyPayer]);
-  await CreditNote.insertMany([...creditNotesList, otherCompanyCreditNote]);
-  await User.create([...creditNoteUserList, otherCompanyUser]);
-  await Helper.insertMany(helpersList);
-  await UserCompany.insertMany(userCompanies);
+  await Promise.all([
+    CreditNote.create([...creditNotesList, otherCompanyCreditNote]),
+    Customer.create([creditNoteCustomer, otherCompanyCustomer]),
+    Event.create([creditNoteEvent, otherCompanyEvent]),
+    Helper.create(helpersList),
+    Service.create([creditNoteService, otherCompanyService]),
+    ThirdPartyPayer.create([creditNoteThirdPartyPayer, otherCompanyThirdPartyPayer]),
+    User.create([...creditNoteUserList, otherCompanyUser]),
+    UserCompany.create(userCompanies),
+  ]);
 };
 
 module.exports = {

--- a/tests/integration/seed/customerNotesSeed.js
+++ b/tests/integration/seed/customerNotesSeed.js
@@ -55,10 +55,7 @@ const customerNotesList = [
 const populateDB = async () => {
   await deleteNonAuthenticationSeeds();
 
-  await Promise.all([
-    Customer.create(customersList),
-    CustomerNote.create(customerNotesList),
-  ]);
+  await Promise.all([Customer.create(customersList), CustomerNote.create(customerNotesList)]);
 };
 
 module.exports = {

--- a/tests/integration/seed/customerNotesSeed.js
+++ b/tests/integration/seed/customerNotesSeed.js
@@ -55,8 +55,10 @@ const customerNotesList = [
 const populateDB = async () => {
   await deleteNonAuthenticationSeeds();
 
-  await Customer.insertMany(customersList);
-  await CustomerNote.insertMany(customerNotesList);
+  await Promise.all([
+    Customer.create(customersList),
+    CustomerNote.create(customerNotesList),
+  ]);
 };
 
 module.exports = {

--- a/tests/integration/seed/customerPartnersSeed.js
+++ b/tests/integration/seed/customerPartnersSeed.js
@@ -81,11 +81,13 @@ const userCompanies = [{ _id: new ObjectID(), user: auxiliaryFromOtherCompany._i
 const populateDB = async () => {
   await deleteNonAuthenticationSeeds();
 
-  await User.create(auxiliaryFromOtherCompany);
-  await UserCompany.insertMany(userCompanies);
-  await Customer.insertMany(customersList);
-  await Partner.insertMany(partnersList);
-  await CustomerPartner.insertMany(customerPartnersList);
+  await Promise.all([
+    Customer.create(customersList),
+    CustomerPartner.create(customerPartnersList),
+    Partner.create(partnersList),
+    User.create(auxiliaryFromOtherCompany),
+    UserCompany.create(userCompanies),
+  ]);
 };
 
 module.exports = {

--- a/tests/integration/seed/customersSeed.js
+++ b/tests/integration/seed/customersSeed.js
@@ -12,10 +12,10 @@ const Payment = require('../../../src/models/Payment');
 const CreditNote = require('../../../src/models/CreditNote');
 const TaxCertificate = require('../../../src/models/TaxCertificate');
 const Helper = require('../../../src/models/Helper');
+const UserCompany = require('../../../src/models/UserCompany');
 const { FIXED, ONCE, HOURLY, WEBAPP, DEATH } = require('../../../src/helpers/constants');
 const { authCompany, otherCompany } = require('../../seed/authCompaniesSeed');
 const { deleteNonAuthenticationSeeds } = require('../helpers/authentication');
-const UserCompany = require('../../../src/models/UserCompany');
 const { auxiliaryRoleId, helperRoleId, clientAdminRoleId } = require('../../seed/authRolesSeed');
 
 const subId = new ObjectID();
@@ -27,7 +27,7 @@ const referentList = [
   {
     _id: new ObjectID(),
     identity: { firstname: 'Referent', lastname: 'Test', title: 'mr' },
-    local: { email: 'auxiliaryreferent@alenvi.io', password: '123456!eR' },
+    local: { email: 'auxiliaryreferent@alenvi.io' },
     contact: { phone: '0987654321' },
     picture: { publicId: '1234', link: 'test' },
     refreshToken: uuidv4(),
@@ -37,7 +37,7 @@ const referentList = [
   {
     _id: new ObjectID(),
     identity: { firstname: 'SuperReferent', lastname: 'Test', title: 'mr' },
-    local: { email: 'auxiliaryreferent2@alenvi.io', password: '123456!eR' },
+    local: { email: 'auxiliaryreferent2@alenvi.io' },
     refreshToken: uuidv4(),
     role: { client: auxiliaryRoleId },
     origin: WEBAPP,
@@ -659,7 +659,7 @@ const userList = [
   {
     _id: new ObjectID(),
     identity: { firstname: 'HelperForCustomerOtherCompany', lastname: 'Caragua' },
-    local: { email: 'helper_for_customer_other_company@alenvi.io', password: '123456!eR' },
+    local: { email: 'helper_for_customer_other_company@alenvi.io' },
     refreshToken: uuidv4(),
     role: { client: helperRoleId },
     origin: WEBAPP,
@@ -792,18 +792,20 @@ const userCompanies = [
 const populateDB = async () => {
   await deleteNonAuthenticationSeeds();
 
-  await ThirdPartyPayer.insertMany(customerThirdPartyPayers);
-  await Service.insertMany(customerServiceList);
-  await Customer.insertMany([...customersList, otherCompanyCustomer]);
-  await Event.insertMany(eventList);
-  await ReferentHistory.insertMany(referentHistories);
-  await Helper.insertMany(helpersList);
-  await UserCompany.insertMany(userCompanies);
-  await User.create([...userList, ...referentList]);
-  await Bill.create(bill);
-  await Payment.create(payment);
-  await CreditNote.create(creditNote);
-  await TaxCertificate.create(taxCertificate);
+  await Promise.all([
+    ThirdPartyPayer.create(customerThirdPartyPayers),
+    Service.create(customerServiceList),
+    Customer.create([...customersList, otherCompanyCustomer]),
+    Event.create(eventList),
+    ReferentHistory.create(referentHistories),
+    Helper.create(helpersList),
+    UserCompany.create(userCompanies),
+    User.create([...userList, ...referentList]),
+    Bill.create(bill),
+    Payment.create(payment),
+    CreditNote.create(creditNote),
+    TaxCertificate.create(taxCertificate),
+  ]);
 };
 
 module.exports = {

--- a/tests/integration/seed/driveSeed.js
+++ b/tests/integration/seed/driveSeed.js
@@ -25,10 +25,7 @@ const userCompany = { _id: new ObjectID(), user: auxiliary._id, company: authCom
 const populateDB = async () => {
   await deleteNonAuthenticationSeeds();
 
-  await Promise.all([
-    User.create(auxiliary),
-    UserCompany.create(userCompany),
-  ]);
+  await Promise.all([User.create(auxiliary), UserCompany.create(userCompany)]);
 };
 
 module.exports = { populateDB, auxiliary };

--- a/tests/integration/seed/driveSeed.js
+++ b/tests/integration/seed/driveSeed.js
@@ -10,7 +10,7 @@ const { deleteNonAuthenticationSeeds } = require('../helpers/authentication');
 const auxiliary = {
   _id: new ObjectID(),
   identity: { firstname: 'Harry', lastname: 'Potter' },
-  local: { email: 'h@p.com', password: '123456!eR' },
+  local: { email: 'h@p.com' },
   administrative: {
     driveFolder: { driveId: '1234567890' },
     passport: { driveId: '1234567890', link: 'https://test.com/1234567890' },
@@ -25,8 +25,10 @@ const userCompany = { _id: new ObjectID(), user: auxiliary._id, company: authCom
 const populateDB = async () => {
   await deleteNonAuthenticationSeeds();
 
-  await User.create(auxiliary);
-  await UserCompany.create(userCompany);
+  await Promise.all([
+    User.create(auxiliary),
+    UserCompany.create(userCompany),
+  ]);
 };
 
 module.exports = { populateDB, auxiliary };

--- a/tests/integration/seed/emailSeed.js
+++ b/tests/integration/seed/emailSeed.js
@@ -69,10 +69,7 @@ const userCompanies = [
 const populateDB = async () => {
   await deleteNonAuthenticationSeeds();
 
-  await Promise.all([
-    User.create(emailUsers),
-    UserCompany.create(userCompanies),
-  ]);
+  await Promise.all([User.create(emailUsers), UserCompany.create(userCompanies)]);
 };
 
 module.exports = {

--- a/tests/integration/seed/emailSeed.js
+++ b/tests/integration/seed/emailSeed.js
@@ -10,7 +10,7 @@ const { deleteNonAuthenticationSeeds } = require('../helpers/authentication');
 const emailUser = {
   _id: new ObjectID(),
   identity: { firstname: 'emailUser', lastname: 'Test' },
-  local: { email: 'email_user@alenvi.io', password: '123456!eR' },
+  local: { email: 'email_user@alenvi.io' },
   refreshToken: uuidv4(),
   role: { client: clientAdminRoleId },
   origin: WEBAPP,
@@ -37,7 +37,7 @@ const coachFromOtherCompany = {
 const trainerFromOtherCompany = {
   _id: new ObjectID(),
   identity: { firstname: 'trainer', lastname: 'Test' },
-  local: { email: 'trainer_email_other_company@alenvi.io', password: '123456!eR' },
+  local: { email: 'trainer_email_other_company@alenvi.io' },
   refreshToken: uuidv4(),
   role: { vendor: trainerRoleId },
   origin: WEBAPP,
@@ -69,8 +69,10 @@ const userCompanies = [
 const populateDB = async () => {
   await deleteNonAuthenticationSeeds();
 
-  await User.create(emailUsers);
-  await UserCompany.insertMany(userCompanies);
+  await Promise.all([
+    User.create(emailUsers),
+    UserCompany.create(userCompanies),
+  ]);
 };
 
 module.exports = {

--- a/tests/integration/seed/establishmentsSeed.js
+++ b/tests/integration/seed/establishmentsSeed.js
@@ -72,7 +72,7 @@ const userFromOtherCompany = {
 const user = {
   _id: new ObjectID(),
   identity: { firstname: 'User', lastname: 'Test' },
-  local: { email: 'auxiliary_establishment@alenvi.io', password: '123456!eR' },
+  local: { email: 'auxiliary_establishment@alenvi.io' },
   refreshToken: uuidv4(),
   role: { client: auxiliaryRoleId },
   establishment: establishmentsList[1]._id,
@@ -87,9 +87,11 @@ const userCompanies = [
 const populateDB = async () => {
   await deleteNonAuthenticationSeeds();
 
-  await User.create([userFromOtherCompany, user]);
-  await Establishment.insertMany([...establishmentsList, establishmentFromOtherCompany]);
-  await UserCompany.insertMany(userCompanies);
+  await Promise.all([
+    Establishment.create([...establishmentsList, establishmentFromOtherCompany]),
+    User.create([userFromOtherCompany, user]),
+    UserCompany.create(userCompanies),
+  ]);
 };
 
 module.exports = {

--- a/tests/integration/seed/eventHistoriesSeed.js
+++ b/tests/integration/seed/eventHistoriesSeed.js
@@ -184,10 +184,10 @@ const populateDB = async () => {
 
   await Promise.all([
     Customer.create(customer),
-    Event.insertMany(events),
-    EventHistory.insertMany(eventHistoryList),
+    Event.create(events),
+    EventHistory.create(eventHistoryList),
     Sector.create([...sectors, sectorFromOtherCompany]),
-    UserCompany.insertMany(userCompanies),
+    UserCompany.create(userCompanies),
     User.create(users),
   ]);
 };

--- a/tests/integration/seed/eventHistoriesSeed.js
+++ b/tests/integration/seed/eventHistoriesSeed.js
@@ -24,7 +24,7 @@ const users = [
   {
     _id: new ObjectID(),
     identity: { firstname: 'Mimi', lastname: 'Mita' },
-    local: { email: 'lili@alenvi.io', password: '123456!eR' },
+    local: { email: 'lili@alenvi.io' },
     role: { client: coachRoleId },
     refreshToken: uuidv4(),
     origin: WEBAPP,
@@ -32,7 +32,7 @@ const users = [
   {
     _id: new ObjectID(),
     identity: { firstname: 'Joséphine', lastname: 'Mita' },
-    local: { email: 'lili2@alenvi.io', password: '123456!eR' },
+    local: { email: 'lili2@alenvi.io' },
     role: { client: coachRoleId },
     refreshToken: uuidv4(),
     origin: WEBAPP,
@@ -40,7 +40,7 @@ const users = [
   {
     _id: new ObjectID(),
     identity: { firstname: 'Bob', lastname: 'Marley' },
-    local: { email: 'lala@alenvi.io', password: '123456!eR' },
+    local: { email: 'lala@alenvi.io' },
     role: { client: clientAdminRoleId },
     refreshToken: uuidv4(),
     origin: WEBAPP,
@@ -48,7 +48,7 @@ const users = [
   {
     _id: new ObjectID(),
     identity: { firstname: 'test', lastname: 'Mita' },
-    local: { email: 'otherCompany@alenvi.io', password: '123456!eR' },
+    local: { email: 'otherCompany@alenvi.io' },
     role: { client: coachRoleId },
     refreshToken: uuidv4(),
     origin: WEBAPP,
@@ -182,12 +182,14 @@ const eventHistoryList = [
 const populateDB = async () => {
   await deleteNonAuthenticationSeeds();
 
-  await EventHistory.insertMany(eventHistoryList);
-  await UserCompany.insertMany(userCompanies);
-  await User.create(users);
-  await Customer.create(customer);
-  await Sector.create([...sectors, sectorFromOtherCompany]);
-  await Event.insertMany(events);
+  await Promise.all([
+    Customer.create(customer),
+    Event.insertMany(events),
+    EventHistory.insertMany(eventHistoryList),
+    Sector.create([...sectors, sectorFromOtherCompany]),
+    UserCompany.insertMany(userCompanies),
+    User.create(users),
+  ]);
 };
 
 module.exports = {

--- a/tests/integration/services.test.js
+++ b/tests/integration/services.test.js
@@ -14,7 +14,7 @@ describe('NODE ENV', () => {
 });
 
 describe('POST /services', () => {
-  let authToken = null;
+  let authToken;
   describe('CLIENT_ADMIN', () => {
     beforeEach(populateDB);
     beforeEach(async () => {
@@ -104,7 +104,7 @@ describe('POST /services', () => {
 });
 
 describe('GET /services', () => {
-  let authToken = null;
+  let authToken;
   describe('COACH', () => {
     beforeEach(populateDB);
     beforeEach(async () => {
@@ -158,7 +158,7 @@ describe('GET /services', () => {
 });
 
 describe('PUT /services/:id', () => {
-  let authToken = null;
+  let authToken;
   describe('CLIENT_ADMIN', () => {
     beforeEach(populateDB);
     beforeEach(async () => {
@@ -272,7 +272,7 @@ describe('PUT /services/:id', () => {
 });
 
 describe('DELETE /services/:id', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
   beforeEach(async () => {
     authToken = await getToken('client_admin');

--- a/tests/integration/stats.test.js
+++ b/tests/integration/stats.test.js
@@ -12,7 +12,7 @@ const {
 const { getToken } = require('./helpers/authentication');
 
 describe('GET /stats/customer-follow-up', () => {
-  let authToken = null;
+  let authToken;
 
   describe('COACH', () => {
     beforeEach(populateDB);
@@ -78,7 +78,7 @@ describe('GET /stats/customer-follow-up', () => {
 });
 
 describe('GET /stats/customer-fundings-monitoring', () => {
-  let authToken = null;
+  let authToken;
 
   describe('COACH', () => {
     beforeEach(populateDB);
@@ -135,7 +135,7 @@ describe('GET /stats/customer-fundings-monitoring', () => {
 });
 
 describe('GET /stats/all-customers-fundings-monitoring', () => {
-  let authToken = null;
+  let authToken;
 
   describe('COACH', () => {
     beforeEach(populateDB);
@@ -189,7 +189,7 @@ describe('GET /stats/all-customers-fundings-monitoring', () => {
 });
 
 describe('GET /stats/paid-intervention-stats', () => {
-  let authToken = null;
+  let authToken;
 
   describe('COACH', () => {
     beforeEach(populateDB);
@@ -314,7 +314,7 @@ describe('GET /stats/paid-intervention-stats', () => {
 });
 
 describe('GET /stats/customer-duration/sector', () => {
-  let authToken = null;
+  let authToken;
 
   describe('COACH', () => {
     beforeEach(populateDB);
@@ -445,7 +445,7 @@ describe('GET /stats/customer-duration/sector', () => {
 });
 
 describe('GET /stats/internal-billed-hours', () => {
-  let authToken = null;
+  let authToken;
 
   describe('COACH', () => {
     beforeEach(populateDB);

--- a/tests/integration/steps.test.js
+++ b/tests/integration/steps.test.js
@@ -310,10 +310,9 @@ describe('STEPS ROUTES - POST /steps/{_id}/activity', () => {
 
     it('should return a 404 if step does not exist', async () => {
       const payload = { name: 'new activity', type: 'video' };
-      const invalidId = new ObjectID();
       const response = await app.inject({
         method: 'POST',
-        url: `/steps/${invalidId}/activities`,
+        url: `/steps/${new ObjectID()}/activities`,
         payload,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
@@ -505,10 +504,9 @@ describe('STEPS ROUTES - DELETE /steps/{_id}/activities/{activityId}', () => {
     });
 
     it('should return a 404 if step doesn\'t exist', async () => {
-      const unknownStepId = new ObjectID();
       const response = await app.inject({
         method: 'DELETE',
-        url: `/steps/${unknownStepId.toHexString()}/activities/${activityId.toHexString()}`,
+        url: `/steps/${new ObjectID()}/activities/${activityId}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 

--- a/tests/integration/steps.test.js
+++ b/tests/integration/steps.test.js
@@ -15,7 +15,7 @@ describe('NODE ENV', () => {
 });
 
 describe('STEPS ROUTES - PUT /steps/{_id}', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
   const stepId = stepsList[0]._id;
 
@@ -167,7 +167,7 @@ describe('STEPS ROUTES - PUT /steps/{_id}', () => {
 });
 
 describe('STEPS ROUTES - POST /steps/{_id}/activity', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
   const step = stepsList[0];
 
@@ -359,7 +359,7 @@ describe('STEPS ROUTES - POST /steps/{_id}/activity', () => {
 });
 
 describe('STEPS ROUTES - PUT /steps/{_id}/activities', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
   const stepId = stepsList[0]._id;
 
@@ -477,7 +477,7 @@ describe('STEPS ROUTES - PUT /steps/{_id}/activities', () => {
 });
 
 describe('STEPS ROUTES - DELETE /steps/{_id}/activities/{activityId}', () => {
-  let authToken = null;
+  let authToken;
   const step = stepsList[1];
   const activityId = activitiesList[0]._id;
   beforeEach(populateDB);

--- a/tests/integration/subPrograms.test.js
+++ b/tests/integration/subPrograms.test.js
@@ -17,7 +17,7 @@ describe('NODE ENV', () => {
 });
 
 describe('SUBPROGRAMS ROUTES - PUT /subprograms/{_id}', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
   const blendedSubProgramId = subProgramsList[0]._id;
   const eLearningSubProgramId = subProgramsList[1]._id;
@@ -315,7 +315,7 @@ describe('SUBPROGRAMS ROUTES - PUT /subprograms/{_id}', () => {
 });
 
 describe('SUBPROGRAMS ROUTES - POST /subprograms/{_id}/step', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
   const payload = { name: 'new step', type: 'e_learning' };
 
@@ -408,7 +408,7 @@ describe('SUBPROGRAMS ROUTES - POST /subprograms/{_id}/step', () => {
 });
 
 describe('SUBPROGRAMS ROUTES - DELETE /subprograms/{_id}/step/{stepId}', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
 
   describe('VENDOR_ADMIN', () => {
@@ -502,7 +502,7 @@ describe('SUBPROGRAMS ROUTES - DELETE /subprograms/{_id}/step/{stepId}', () => {
 });
 
 describe('SUBPROGRAMS ROUTES - GET /subprograms/draft-e-learning', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
 
   describe('TRAINING_ORGANISATION_MANAGER', () => {
@@ -562,7 +562,7 @@ describe('SUBPROGRAMS ROUTES - GET /subprograms/draft-e-learning', () => {
 });
 
 describe('SUBPROGRAMS ROUTES - GET /subprograms/{_id}', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
 
   describe('TRAINING_ORGANISATION_MANAGER', () => {

--- a/tests/integration/subPrograms.test.js
+++ b/tests/integration/subPrograms.test.js
@@ -357,10 +357,9 @@ describe('SUBPROGRAMS ROUTES - POST /subprograms/{_id}/step', () => {
     });
 
     it('should return a 400 if program does not exist', async () => {
-      const invalidId = new ObjectID();
       const response = await app.inject({
         method: 'POST',
-        url: `/subprograms/${invalidId}/steps`,
+        url: `/subprograms/${new ObjectID()}/steps`,
         payload,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
@@ -435,10 +434,9 @@ describe('SUBPROGRAMS ROUTES - DELETE /subprograms/{_id}/step/{stepId}', () => {
     });
 
     it('should return a 404 if subprogram does not exist', async () => {
-      const invalidId = new ObjectID();
       const response = await app.inject({
         method: 'DELETE',
-        url: `/subprograms/${invalidId}/steps/${subProgramsList[0].steps[0]._id}`,
+        url: `/subprograms/${new ObjectID()}/steps/${subProgramsList[0].steps[0]._id}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
@@ -446,10 +444,9 @@ describe('SUBPROGRAMS ROUTES - DELETE /subprograms/{_id}/step/{stepId}', () => {
     });
 
     it('should return a 404 if subprogram does not contain step', async () => {
-      const invalidId = new ObjectID();
       const response = await app.inject({
         method: 'DELETE',
-        url: `/subprograms/${subProgramsList[0]._id}/steps/${invalidId}`,
+        url: `/subprograms/${subProgramsList[0]._id}/steps/${new ObjectID()}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 

--- a/tests/integration/surcharges.test.js
+++ b/tests/integration/surcharges.test.js
@@ -220,10 +220,9 @@ describe('PUT /surcharges/:id', () => {
   });
 
   it('should return 404 if no surcharge', async () => {
-    const invalidId = new ObjectID().toHexString();
     const response = await app.inject({
       method: 'PUT',
-      url: `/surcharges/${invalidId}`,
+      url: `/surcharges/${new ObjectID()}`,
       headers: { Cookie: `alenvi_token=${authToken}` },
       payload: { name: 'Chasser sans son chien' },
     });

--- a/tests/integration/surcharges.test.js
+++ b/tests/integration/surcharges.test.js
@@ -13,7 +13,7 @@ describe('NODE ENV', () => {
 });
 
 describe('POST /surcharges', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
   beforeEach(async () => {
     authToken = await getToken('client_admin');
@@ -146,7 +146,7 @@ describe('POST /surcharges', () => {
 });
 
 describe('GET /surcharges', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
   beforeEach(async () => {
     authToken = await getToken('client_admin');
@@ -187,7 +187,7 @@ describe('GET /surcharges', () => {
 });
 
 describe('PUT /surcharges/:id', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
   beforeEach(async () => {
     authToken = await getToken('client_admin');
@@ -268,7 +268,7 @@ describe('PUT /surcharges/:id', () => {
 });
 
 describe('DELETE /surcharges/:id', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
   beforeEach(async () => {
     authToken = await getToken('client_admin');

--- a/tests/integration/taxCertificates.test.js
+++ b/tests/integration/taxCertificates.test.js
@@ -359,10 +359,9 @@ describe('TAX CERTIFICATES - DELETE /', () => {
     });
 
     it('should throw an error if tax certificate does not exist', async () => {
-      const taxCertificateId = new ObjectID();
       const response = await app.inject({
         method: 'DELETE',
-        url: `/taxcertificates/${taxCertificateId}`,
+        url: `/taxcertificates/${new ObjectID()}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 

--- a/tests/integration/taxCertificates.test.js
+++ b/tests/integration/taxCertificates.test.js
@@ -156,7 +156,7 @@ describe('TAX CERTIFICATES ROUTES - GET /{_id}/pdf', () => {
 });
 
 describe('TAX CERTIFICATES - POST /', () => {
-  let authToken = null;
+  let authToken;
   describe('CLIENT_ADMIN', () => {
     let addStub;
     let addFileStub;
@@ -337,7 +337,7 @@ describe('TAX CERTIFICATES - POST /', () => {
 });
 
 describe('TAX CERTIFICATES - DELETE /', () => {
-  let authToken = null;
+  let authToken;
   describe('CLIENT_ADMIN', () => {
     beforeEach(populateDB);
     beforeEach(async () => {

--- a/tests/integration/thirdPartyPayers.test.js
+++ b/tests/integration/thirdPartyPayers.test.js
@@ -15,7 +15,7 @@ describe('NODE ENV', () => {
 });
 
 describe('THIRD PARTY PAYERS ROUTES', () => {
-  let authToken = null;
+  let authToken;
   beforeEach(populateDB);
   beforeEach(async () => {
     authToken = await getToken('client_admin');

--- a/tests/integration/users.test.js
+++ b/tests/integration/users.test.js
@@ -833,10 +833,9 @@ describe('GET /users/:id', () => {
     });
 
     it('should return a 404 error if no user found', async () => {
-      const id = new ObjectID();
       const res = await app.inject({
         method: 'GET',
-        url: `/users/${id.toHexString()}`,
+        url: `/users/${new ObjectID()}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
@@ -1179,10 +1178,9 @@ describe('PUT /users/:id', () => {
     });
 
     it('should return a 404 error if no user found', async () => {
-      const id = new ObjectID().toHexString();
       const res = await app.inject({
         method: 'PUT',
-        url: `/users/${id}`,
+        url: `/users/${new ObjectID()}`,
         payload: {},
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
@@ -1769,10 +1767,9 @@ describe('DELETE /users/:id/upload', () => {
     });
 
     it('should return 404 if invalid user id', async () => {
-      const invalidId = new ObjectID();
       const response = await app.inject({
         method: 'DELETE',
-        url: `/users/${invalidId.toHexString()}/upload`,
+        url: `/users/${new ObjectID()}/upload`,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 


### PR DESCRIPTION
Revue des tests et des seeds suivants : 
- balance
- bills
- billSlips
- cards
- categories
- companies
- contracts
- courseHistories
- courseSlots
- creditNotes
- customerNotes
- customerPartners
- customer
- drive
- email
- establishments
- eventHistories


Ce qui a été fait : 
- Ajout d'un `Promise.all` dans le `populateDB`
- Changement des `insertMany` en `create`
- Utiliser des utilisateurs spécifiques dans les seeds et non pas les utilisateurs connectés
- Fix dans le tests des exports pour vérifier que toutes les lignes attendus sont bien présentes dans le fichier csv