### PR TITLE
Com 2315

### DIFF
--- a/src/controllers/Google/driveController.js
+++ b/src/controllers/Google/driveController.js
@@ -75,8 +75,9 @@ const generateDocxFromDrive = async (req, h) => {
 
 const downloadFile = async (req, h) => {
   try {
-    const filePath = await DriveHelper.downloadFile(req.params.id);
-    return h.file(filePath, { confine: false });
+    const { filePath, type } = await DriveHelper.downloadFile(req.params.id);
+
+    return h.file(filePath, { confine: false, mode: 'attachment' }).type(type);
   } catch (e) {
     req.log('error', e);
     return Boom.isBoom(e) ? e : Boom.badImplementation(e);

--- a/src/helpers/drive.js
+++ b/src/helpers/drive.js
@@ -17,6 +17,6 @@ exports.uploadFile = async (driveId, docPayload) => {
 exports.downloadFile = async (driveId) => {
   const now = new Date();
   const filePath = path.join(os.tmpdir(), `download-${now.getTime()}`);
-  const type = await drive.downloadFileById({ fileId: driveId, tmpFilePath: filePath });
+  const { type } = await drive.downloadFileById({ fileId: driveId, tmpFilePath: filePath });
   return { filePath, type };
 };

--- a/src/helpers/drive.js
+++ b/src/helpers/drive.js
@@ -17,6 +17,6 @@ exports.uploadFile = async (driveId, docPayload) => {
 exports.downloadFile = async (driveId) => {
   const now = new Date();
   const filePath = path.join(os.tmpdir(), `download-${now.getTime()}`);
-  await drive.downloadFileById({ fileId: driveId, tmpFilePath: filePath });
-  return filePath;
+  const type = await drive.downloadFileById({ fileId: driveId, tmpFilePath: filePath });
+  return { filePath, type };
 };

--- a/src/models/Google/Drive.js
+++ b/src/models/Google/Drive.js
@@ -76,7 +76,7 @@ exports.downloadFileById = async (params) => {
       }
 
       res.data.on('end', () => {
-        resolve(res.headers['content-type']);
+        resolve({ type: res.headers['content-type'] });
       }).on('error', () => {
         reject(new Error(`Error during Google drive doc download ${err}`));
       }).pipe(dest);

--- a/src/models/Google/Drive.js
+++ b/src/models/Google/Drive.js
@@ -76,7 +76,7 @@ exports.downloadFileById = async (params) => {
       }
 
       res.data.on('end', () => {
-        resolve();
+        resolve(res.headers['content-type']);
       }).on('error', () => {
         reject(new Error(`Error during Google drive doc download ${err}`));
       }).pipe(dest);

--- a/src/routes/Google/drive.js
+++ b/src/routes/Google/drive.js
@@ -47,15 +47,13 @@ exports.plugin = {
     server.route({
       method: 'GET',
       path: '/file/{id}/download',
-      handler: downloadFile,
       options: {
         validate: {
           params: Joi.object({ id: Joi.string() }),
         },
-        auth: {
-          strategy: 'jwt',
-        },
+        auth: { strategy: 'jwt', mode: 'required' },
       },
+      handler: downloadFile,
     });
 
     server.route({

--- a/tests/integration/drive.test.js
+++ b/tests/integration/drive.test.js
@@ -281,9 +281,9 @@ describe('POST /gdrive/file/:id/download', () => {
       downloadFileStub.restore();
     });
 
-    it('should generate a docx document from google drive', async () => {
+    it('should download a doc from drive', async () => {
       const fileDriveId = '1234567890';
-      downloadFileStub.returns(path.join(__dirname, './assets/signature_request.docx'));
+      downloadFileStub.returns({ filePath: path.join(__dirname, './assets/test_upload.png'), type: 'image/png' });
 
       const response = await app.inject({
         method: 'GET',

--- a/tests/unit/helpers/drive.test.js
+++ b/tests/unit/helpers/drive.test.js
@@ -31,7 +31,7 @@ describe('downloadFile', () => {
     const date = new Date('2020-01-06');
     const fakeDate = sinon.useFakeTimers(date);
     const downloadFileByIdStub = sinon.stub(Drive, 'downloadFileById');
-    downloadFileByIdStub.returns('image/png');
+    downloadFileByIdStub.returns({ type: 'image/png' });
     const filePath = path.join(os.tmpdir(), `download-${date.getTime()}`);
     const driveId = '1234567890';
 

--- a/tests/unit/helpers/drive.test.js
+++ b/tests/unit/helpers/drive.test.js
@@ -31,12 +31,13 @@ describe('downloadFile', () => {
     const date = new Date('2020-01-06');
     const fakeDate = sinon.useFakeTimers(date);
     const downloadFileByIdStub = sinon.stub(Drive, 'downloadFileById');
+    downloadFileByIdStub.returns('image/png');
     const filePath = path.join(os.tmpdir(), `download-${date.getTime()}`);
     const driveId = '1234567890';
 
     const result = await DriveHelper.downloadFile(driveId);
 
-    expect(result).toEqual(filePath);
+    expect(result).toEqual({ filePath, type: 'image/png' });
     sinon.assert.calledWithExactly(downloadFileByIdStub, { fileId: driveId, tmpFilePath: filePath });
     fakeDate.restore();
     downloadFileByIdStub.restore();


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations :
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [x] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles -np
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES -np
- Si mes changements impactent l'application formation :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- Si mes changements impactent l'application erp :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME -np
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES -np
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV -np
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : client

- Périmetre roles : admin (non gere cote auxiliaire pour l'instant)

- Cas d'usage : quand j'appuie sur le bouton de telechargement d'un document administratif (config rh), le document se telecharge effectivement. 
A tester sur plusieurs navigateurs, avec plusieurs types de fichier. 

C'est une premiere pr sur la refacto du drive pour que vous validiez la facon de faire. 
La route est un peu complique a cause des gcs mais je me suis dit que ca ne vallait pas le coup de faire deux routes car on s'etait dit qu'il faudrait probablement revoir les cgs a un moment pour autoriser d'autres fichiers que les html. 

Note: sur firefox j'ai un message etrange lorsque j'ouvre le fichier mais j'aimerais voir quel est le message qui s'affiche autrement qu'en local avant de gerer ce cas. 
