### PR TITLE
COM-2302: populate trainer

### DIFF
--- a/src/helpers/questionnaires.js
+++ b/src/helpers/questionnaires.js
@@ -83,7 +83,10 @@ exports.getFollowUp = async (id, courseId) => {
     .populate({
       path: 'histories',
       match: courseId ? { course: courseId } : null,
-      populate: { path: 'questionnaireAnswersList.card', select: '-createdAt -updatedAt' },
+      populate: [
+        { path: 'questionnaireAnswersList.card', select: '-createdAt -updatedAt' },
+        { path: 'course', select: 'trainer', populate: { path: 'trainer', select: 'identity' } },
+      ],
     })
     .lean();
 
@@ -94,7 +97,7 @@ exports.getFollowUp = async (id, courseId) => {
       if (answerList.length === 1 && !answerList[0].trim()) continue;
 
       if (!followUp[answer.card._id]) followUp[answer.card._id] = { ...answer.card, answers: [] };
-      followUp[answer.card._id].answers.push(...answerList);
+      followUp[answer.card._id].answers.push(...answerList.map(a => ({ answer: a, course: history.course })));
     }
   }
 

--- a/tests/unit/helpers/questionnaires.test.js
+++ b/tests/unit/helpers/questionnaires.test.js
@@ -625,13 +625,13 @@ describe('getFollowUp', () => {
       questionnaire: { type: EXPECTATIONS, name: 'questionnaire' },
       followUp: [
         {
-          answers: ['blabla', 'test test'],
+          answers: [{ answer: 'blabla', course: course._id }, { answer: 'test test', course: course._id }],
           isMandatory: true,
           question: 'aimez-vous ce test ?',
           template: 'open_question',
         },
         {
-          answers: ['3', '2'],
+          answers: [{ answer: '3', course: course._id }, { answer: '2', course: course._id }],
           isMandatory: true,
           question: 'combien aimez vous ce test sur une échelle de 1 à 5 ?',
           template: 'survey',
@@ -662,7 +662,10 @@ describe('getFollowUp', () => {
           args: [{
             path: 'histories',
             match: { course: courseId },
-            populate: { path: 'questionnaireAnswersList.card', select: '-createdAt -updatedAt' },
+            populate: [
+              { path: 'questionnaireAnswersList.card', select: '-createdAt -updatedAt' },
+              { path: 'course', select: 'trainer', populate: { path: 'trainer', select: 'identity' } },
+            ],
           }],
         },
         { query: 'lean' },
@@ -751,13 +754,13 @@ describe('getFollowUp', () => {
       questionnaire: { type: EXPECTATIONS, name: 'questionnaire' },
       followUp: [
         {
-          answers: ['blabla', 'test test'],
+          answers: [{ answer: 'blabla', course: course._id }, { answer: 'test test', course: course._id }],
           isMandatory: true,
           question: 'aimez-vous ce test ?',
           template: 'open_question',
         },
         {
-          answers: ['3', '2'],
+          answers: [{ answer: '3', course: course._id }, { answer: '2', course: course._id }],
           isMandatory: true,
           question: 'combien aimez vous ce test sur une échelle de 1 à 5 ?',
           template: 'survey',
@@ -788,7 +791,10 @@ describe('getFollowUp', () => {
           args: [{
             path: 'histories',
             match: { course: courseId },
-            populate: { path: 'questionnaireAnswersList.card', select: '-createdAt -updatedAt' },
+            populate: [
+              { path: 'questionnaireAnswersList.card', select: '-createdAt -updatedAt' },
+              { path: 'course', select: 'trainer', populate: { path: 'trainer', select: 'identity' } },
+            ],
           }],
         },
         { query: 'lean' },
@@ -865,13 +871,19 @@ describe('getFollowUp', () => {
       questionnaire: { type: EXPECTATIONS, name: 'questionnaire' },
       followUp: [
         {
-          answers: ['blabla', 'test test'],
+          answers: [
+            { answer: 'blabla', course: questionnaire.histories[0].course },
+            { answer: 'test test', course: questionnaire.histories[1].course },
+          ],
           isMandatory: true,
           question: 'aimez-vous ce test ?',
           template: 'open_question',
         },
         {
-          answers: ['3', '2'],
+          answers: [
+            { answer: '3', course: questionnaire.histories[0].course },
+            { answer: '2', course: questionnaire.histories[1].course },
+          ],
           isMandatory: true,
           question: 'combien aimez vous ce test sur une échelle de 1 à 5 ?',
           template: 'survey',
@@ -889,7 +901,10 @@ describe('getFollowUp', () => {
           args: [{
             path: 'histories',
             match: null,
-            populate: { path: 'questionnaireAnswersList.card', select: '-createdAt -updatedAt' },
+            populate: [
+              { path: 'questionnaireAnswersList.card', select: '-createdAt -updatedAt' },
+              { path: 'course', select: 'trainer', populate: { path: 'trainer', select: 'identity' } },
+            ],
           }],
         },
         { query: 'lean' },
@@ -957,7 +972,10 @@ describe('getFollowUp', () => {
           args: [{
             path: 'histories',
             match: { course: courseId },
-            populate: { path: 'questionnaireAnswersList.card', select: '-createdAt -updatedAt' },
+            populate: [
+              { path: 'questionnaireAnswersList.card', select: '-createdAt -updatedAt' },
+              { path: 'course', select: 'trainer', populate: { path: 'trainer', select: 'identity' } },
+            ],
           }],
         },
         { query: 'lean' },
@@ -1018,7 +1036,10 @@ describe('getFollowUp', () => {
           args: [{
             path: 'histories',
             match: { course: courseId },
-            populate: { path: 'questionnaireAnswersList.card', select: '-createdAt -updatedAt' },
+            populate: [
+              { path: 'questionnaireAnswersList.card', select: '-createdAt -updatedAt' },
+              { path: 'course', select: 'trainer', populate: { path: 'trainer', select: 'identity' } },
+            ],
           }],
         },
         { query: 'lean' },
@@ -1083,7 +1104,10 @@ describe('getFollowUp', () => {
           args: [{
             path: 'histories',
             match: { course: courseId },
-            populate: { path: 'questionnaireAnswersList.card', select: '-createdAt -updatedAt' },
+            populate: [
+              { path: 'questionnaireAnswersList.card', select: '-createdAt -updatedAt' },
+              { path: 'course', select: 'trainer', populate: { path: 'trainer', select: 'identity' } },
+            ],
           }],
         },
         { query: 'lean' },


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations : -np
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [ ] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES
- ~~Si mes changements impactent l'application formation :~~
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- ~~Si mes changements impactent l'application erp :~~
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME -np
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES
- ~~J'ai ajouté un modèle spécifique à une structure:~~
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- ~~J'ai changé un modèle utilisé par l'app mobile:~~
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV
- ~~J'ai changé une constante :~~
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

-~~ J'ai ajouté une variable d'environnement :~~
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : vendeur

- Périmetre roles : rof/admin

- Cas d'usage : je peux afficher les réponses aux questionnaires pour un.e formateur.rice spécifique
