### PR TITLE
COM-2327 - allow action in event history payload

### DIFF
--- a/src/helpers/eventHistories.js
+++ b/src/helpers/eventHistories.js
@@ -21,9 +21,10 @@ exports.getEventHistories = async (query, credentials) => {
 };
 
 exports.getListQuery = (query, credentials) => {
-  const { sectors, auxiliaries, createdAt } = query;
+  const { sectors, auxiliaries, createdAt, action } = query;
   const listQuery = { company: get(credentials, 'company._id', null) };
   if (createdAt) listQuery.createdAt = { $lt: createdAt };
+  if (action) listQuery.action = { $in: action };
 
   const orRules = [];
   if (sectors) orRules.push(...UtilsHelper.formatArrayOrStringQueryParam(sectors, 'sectors'));
@@ -31,6 +32,7 @@ exports.getListQuery = (query, credentials) => {
 
   if (orRules.length === 0) return listQuery;
   if (orRules.length === 1) return { ...listQuery, ...orRules[0] };
+
   return { ...listQuery, $or: orRules };
 };
 

--- a/src/models/EventHistory.js
+++ b/src/models/EventHistory.js
@@ -66,4 +66,5 @@ EventHistorySchema.pre('find', validateQuery);
 EventHistorySchema.pre('aggregate', validateAggregation);
 
 module.exports = mongoose.model('EventHistory', EventHistorySchema);
+module.exports.EVENTS_HISTORY_ACTIONS = EVENTS_HISTORY_ACTIONS;
 module.exports.TIME_STAMPING_ACTIONS = TIME_STAMPING_ACTIONS;

--- a/src/routes/eventHistories.js
+++ b/src/routes/eventHistories.js
@@ -5,6 +5,7 @@ Joi.objectId = require('joi-objectid')(Joi);
 const { list } = require('../controllers/eventHistoryController');
 const { EVENTS_HISTORY_ACTIONS } = require('../models/EventHistory');
 const { authorizeEventsHistoriesGet } = require('./preHandlers/eventHistories');
+const { objectIdOrArray } = require('./validations/utils');
 
 exports.plugin = {
   name: 'routes-event-history',
@@ -16,8 +17,8 @@ exports.plugin = {
         auth: { scope: ['events:edit'] },
         validate: {
           query: Joi.object({
-            auxiliaries: [Joi.array().items(Joi.objectId()), Joi.objectId()],
-            sectors: [Joi.array().items(Joi.objectId()), Joi.objectId()],
+            auxiliaries: objectIdOrArray,
+            sectors: objectIdOrArray,
             createdAt: Joi.date(),
             eventId: Joi.objectId(),
             action: Joi.array().items(Joi.string().valid(...EVENTS_HISTORY_ACTIONS)),

--- a/src/routes/eventHistories.js
+++ b/src/routes/eventHistories.js
@@ -3,6 +3,7 @@
 const Joi = require('joi');
 Joi.objectId = require('joi-objectid')(Joi);
 const { list } = require('../controllers/eventHistoryController');
+const { EVENTS_HISTORY_ACTIONS } = require('../models/EventHistory');
 const { authorizeEventsHistoriesGet } = require('./preHandlers/eventHistories');
 
 exports.plugin = {
@@ -15,10 +16,11 @@ exports.plugin = {
         auth: { scope: ['events:edit'] },
         validate: {
           query: Joi.object({
-            auxiliaries: [Joi.array().items(Joi.string()), Joi.string()],
-            sectors: [Joi.array().items(Joi.string()), Joi.string()],
+            auxiliaries: [Joi.array().items(Joi.objectId()), Joi.objectId()],
+            sectors: [Joi.array().items(Joi.objectId()), Joi.objectId()],
             createdAt: Joi.date(),
             eventId: Joi.objectId(),
+            action: Joi.array().items(Joi.string().valid(...EVENTS_HISTORY_ACTIONS)),
           }),
         },
         pre: [{ method: authorizeEventsHistoriesGet }],

--- a/tests/integration/eventHistories.test.js
+++ b/tests/integration/eventHistories.test.js
@@ -111,6 +111,16 @@ describe('GET /eventhistories', () => {
     expect(response.statusCode).toEqual(403);
   });
 
+  it('should return a 400 if invalid action in query', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/eventhistories?action=mauvaiseaction',
+      headers: { Cookie: `alenvi_token=${authToken}` },
+    });
+
+    expect(response.statusCode).toEqual(400);
+  });
+
   describe('Other roles', () => {
     const roles = [
       { name: 'helper', expectedCode: 403 },

--- a/tests/unit/helpers/eventHistories.test.js
+++ b/tests/unit/helpers/eventHistories.test.js
@@ -7,7 +7,7 @@ const EventHistoryHelper = require('../../../src/helpers/eventHistories');
 const EventHistoryRepository = require('../../../src/repositories/EventHistoryRepository');
 const EventHistory = require('../../../src/models/EventHistory');
 const User = require('../../../src/models/User');
-const { INTERNAL_HOUR, INTERVENTION } = require('../../../src/helpers/constants');
+const { INTERNAL_HOUR, INTERVENTION, EVENT_CREATION, EVENT_DELETION } = require('../../../src/helpers/constants');
 const SinonMongoose = require('../sinonMongoose');
 
 describe('getEventHistories', () => {
@@ -67,50 +67,61 @@ describe('getListQuery', () => {
   });
 
   it('should return at least company if no query', () => {
-    const credentials = { company: { _id: new ObjectID() } };
+    const companyId = new ObjectID();
+    const credentials = { company: { _id: companyId } };
     const result = EventHistoryHelper.getListQuery({}, credentials);
 
-    expect(result).toEqual({ company: credentials.company._id });
+    expect(result).toEqual({ company: companyId });
   });
 
   it('should format query with sectors', () => {
-    const credentials = { company: { _id: new ObjectID() } };
+    const companyId = new ObjectID();
+    const credentials = { company: { _id: companyId } };
     const query = { sectors: ['toto', 'tata'] };
     formatArrayOrStringQueryParam.returns([{ sectors: 'toto' }, { sectors: 'tata' }]);
     const result = EventHistoryHelper.getListQuery(query, credentials);
 
-    expect(result).toEqual({ company: credentials.company._id, $or: [{ sectors: 'toto' }, { sectors: 'tata' }] });
+    expect(result).toEqual({ company: companyId, $or: [{ sectors: 'toto' }, { sectors: 'tata' }] });
   });
 
   it('should format query with auxiliaries', () => {
-    const credentials = { company: { _id: new ObjectID() } };
+    const companyId = new ObjectID();
+    const credentials = { company: { _id: companyId } };
     const query = { auxiliaries: ['toto', 'tata'] };
     formatArrayOrStringQueryParam.returns([{ auxiliaries: 'toto' }, { auxiliaries: 'tata' }]);
     const result = EventHistoryHelper.getListQuery(query, credentials);
 
-    expect(result).toEqual({
-      company: credentials.company._id,
-      $or: [{ auxiliaries: 'toto' }, { auxiliaries: 'tata' }],
-    });
+    expect(result).toEqual({ company: companyId, $or: [{ auxiliaries: 'toto' }, { auxiliaries: 'tata' }] });
   });
 
   it('should format query with createdAt', () => {
-    const credentials = { company: { _id: new ObjectID() } };
+    const companyId = new ObjectID();
+    const credentials = { company: { _id: companyId } };
     const query = { createdAt: '2019-10-11' };
     const result = EventHistoryHelper.getListQuery(query, credentials);
 
-    expect(result).toEqual({ company: credentials.company._id, createdAt: { $lt: '2019-10-11' } });
+    expect(result).toEqual({ company: companyId, createdAt: { $lt: '2019-10-11' } });
+  });
+
+  it('should format query with action', () => {
+    const companyId = new ObjectID();
+    const credentials = { company: { _id: companyId } };
+    const query = { action: [EVENT_CREATION, EVENT_DELETION] };
+    const result = EventHistoryHelper.getListQuery(query, credentials);
+
+    expect(result).toEqual({ company: companyId, action: { $in: [EVENT_CREATION, EVENT_DELETION] } });
   });
 
   it('should format query with sectors and auxiliaries and createdAt', () => {
-    const credentials = { company: { _id: new ObjectID() } };
+    const companyId = new ObjectID();
+    const credentials = { company: { _id: companyId } };
     const query = { sectors: ['toto', 'tata'], auxiliaries: ['toto', 'tata'], createdAt: '2019-10-11' };
     formatArrayOrStringQueryParam.onCall(0).returns([{ sectors: 'toto' }, { sectors: 'tata' }]);
     formatArrayOrStringQueryParam.onCall(1).returns([{ auxiliaries: 'toto' }, { auxiliaries: 'tata' }]);
     const result = EventHistoryHelper.getListQuery(query, credentials);
 
     expect(result).toEqual({
-      company: credentials.company._id,
+      company: companyId,
       createdAt: { $lt: '2019-10-11' },
       $or: [{ sectors: 'toto' }, { sectors: 'tata' }, { auxiliaries: 'toto' }, { auxiliaries: 'tata' }],
     });


### PR DESCRIPTION
### TESTS
- [ ] Mon code est testé unitairement

- Tests intégrations :
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [x] J'ai bien fait les tests
  - ~~C'est une ancienne route utilisée par une des apps mobiles~~
    - ~~J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)~~
      - ~~[ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent~~

### FONCTIONNALITÉS APPS MOBILES
- ~~Si mes changements impactent l'application formation :~~
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- ~~Si mes changements impactent l'application erp :~~
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

~~### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME~~
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [x] Je n'ai pas changé les droits de la route
  - [x] Je n'ai pas changé les droits dans le fichier rights.js
  - [x] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [x] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- ~~J'ai supprimé une route :~~
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- ~~J'ai renommé une route :~~
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [x] J'ai géré le cas ou on ne l'envoie pas
- ~~J'ai rendu obligatoire un champs de la route :~~
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- ~~J'ai retiré un champ possible dans la route :~~
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- ~~J'ai supprimé un retour/un champs du retour de la route :~~
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES
- ~~J'ai ajouté un modèle spécifique à une structure:~~
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- ~~J'ai changé un modèle utilisé par l'app mobile:~~
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - ~~J'ai rendu obligatoire un champs :~~
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - ~~J'ai retiré un champ possible :~~
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV
- ~~J'ai changé une constante :~~

- ~~J'ai ajouté une variable d'environnement :~~


### POUR TESTER LA PR
- Périmetre interface : Client

- Périmetre roles : Auxiliaire / coach

- Cas d'usage : Sur le flux du planning, je ne recupere du back que ceux que j'affiche (plus les horodatage du coup)
