### PR TITLE
COM-2294 - handle repetitions

### DIFF
--- a/src/helpers/events.js
+++ b/src/helpers/events.js
@@ -222,20 +222,18 @@ exports.formatEditionPayload = (event, payload, detachFromRepetition) => {
 };
 
 exports.shouldDetachFromRepetition = (event, payload) => {
-  const mainEventInfo = pick(
-    event,
-    ['isCancelled', 'startDate', 'endDate', 'internalHour.name', 'address.fullAddress']
-  );
-  if (event.auxiliary) mainEventInfo.auxiliary = event.auxiliary.toHexString();
-  if (event.sector) mainEventInfo.sector = event.sector.toHexString();
-  if (event.subscription) mainEventInfo.subscription = event.subscription.toHexString();
+  const keys = ['isCancelled', 'startDate', 'endDate', 'internalHour.name', 'address.fullAddress'];
+  const mainEventInfo = {
+    ...pick(event, keys),
+    ...(event.auxiliary && { auxiliary: event.auxiliary.toHexString() }),
+    ...(event.sector && { sector: event.sector.toHexString() }),
+    ...(event.subscription && { subscription: event.subscription.toHexString() }),
+  };
 
-  const mainPayloadInfo = pick(
-    payload,
-    ['isCancelled', 'startDate', 'endDate', 'internalHour.name', 'address.fullAddress',
-      'sector', 'auxiliary', 'subscription']
-  );
-  if (!mainPayloadInfo.isCancelled) mainPayloadInfo.isCancelled = false;
+  const mainPayloadInfo = {
+    ...pick(payload, [...keys, 'sector', 'auxiliary', 'subscription']),
+    ...(!payload.isCancelled && { isCancelled: false }),
+  };
 
   return !isEqual(mainEventInfo, mainPayloadInfo);
 };

--- a/src/routes/events.js
+++ b/src/routes/events.js
@@ -191,7 +191,7 @@ exports.plugin = {
               driveId: Joi.string(),
               link: Joi.string(),
             }).when('absence', { is: Joi.exist().valid(ILLNESS, WORK_ACCIDENT), then: Joi.required() }),
-            misc: Joi.string().allow(null, '').default('')
+            misc: Joi.string().allow(null, '')
               .when('absence', { is: Joi.exist().valid(OTHER), then: Joi.required() })
               .when('isCancelled', { is: Joi.exist().valid(true), then: Joi.required() }),
             repetition: Joi.object().keys({

--- a/src/routes/preHandlers/events.js
+++ b/src/routes/preHandlers/events.js
@@ -27,7 +27,7 @@ const {
 const { language } = translate;
 
 exports.getEvent = async (req) => {
-  const event = await Event.findById(req.params._id)
+  const event = await Event.findOne({ _id: req.params._id, company: get(req, 'auth.credentials.company._id') })
     .populate('startDateTimeStampedCount')
     .populate('endDateTimeStampedCount')
     .lean();
@@ -133,11 +133,8 @@ exports.authorizeEventUpdate = async (req) => {
 };
 
 exports.checkEventCreationOrUpdate = async (req) => {
-  const { credentials } = req.auth;
   const event = req.pre.event || req.payload;
-  const companyId = get(credentials, 'company._id', null);
-
-  if (req.pre.event && !UtilsHelper.areObjectIdsEquals(event.company, companyId)) throw Boom.forbidden();
+  const companyId = get(req, 'auth.credentials.company._id');
 
   if (req.payload.customer || (event.customer && req.payload.subscription)) {
     const customerId = req.payload.customer || event.customer;

--- a/tests/integration/events.test.js
+++ b/tests/integration/events.test.js
@@ -1605,6 +1605,7 @@ describe('PUT /events/{_id}', () => {
     const roles = [
       { name: 'helper', expectedCode: 403 },
       { name: 'auxiliary', expectedCode: 403 },
+      { name: 'planning_referent', expectedCode: 200 },
       { name: 'auxiliary event', expectedCode: 200, customCredentials: auxiliaries[0].local },
       { name: 'vendor_admin', expectedCode: 403 },
       { name: 'coach', expectedCode: 200 },

--- a/tests/integration/events.test.js
+++ b/tests/integration/events.test.js
@@ -1225,6 +1225,7 @@ describe('POST /events', () => {
 
 describe('PUT /events/{_id}', () => {
   let authToken;
+
   describe('PLANNING_REFERENT', () => {
     beforeEach(populateDB);
     beforeEach(async () => {
@@ -1273,24 +1274,6 @@ describe('PUT /events/{_id}', () => {
       expect(response.result.data.event._id).toEqual(event._id);
       expect(moment(response.result.data.event.startDate).isSame(moment(payload.startDate))).toBeTruthy();
       expect(moment(response.result.data.event.endDate).isSame(moment(payload.endDate))).toBeTruthy();
-    });
-
-    it('should update intervention with auxiliary', async () => {
-      const event = eventsList[2];
-      const payload = {
-        startDate: '2019-01-23T10:00:00.000Z',
-        endDate: '2019-01-23T12:00:00.000Z',
-        auxiliary: auxiliaries[1]._id.toHexString(),
-      };
-
-      const response = await app.inject({
-        method: 'PUT',
-        url: `/events/${event._id.toHexString()}`,
-        payload,
-        headers: { Cookie: `alenvi_token=${authToken}` },
-      });
-
-      expect(response.statusCode).toBe(200);
     });
 
     it('should update intervention with other subscription', async () => {
@@ -1360,20 +1343,6 @@ describe('PUT /events/{_id}', () => {
       expect(response.statusCode).toBe(400);
     });
 
-    it('should return a 400 error as payload is invalid', async () => {
-      const payload = { beginDate: '2019-01-23T10:00:00.000Z', sector: new ObjectID() };
-      const event = eventsList[0];
-
-      const response = await app.inject({
-        method: 'PUT',
-        url: `/events/${event._id.toHexString()}`,
-        payload,
-        headers: { Cookie: `alenvi_token=${authToken}` },
-      });
-
-      expect(response.statusCode).toBe(400);
-    });
-
     it('should return a 400 error as startDate and endDate are not on the same day', async () => {
       const payload = {
         startDate: '2019-01-23T10:00:00.000Z',
@@ -1403,23 +1372,6 @@ describe('PUT /events/{_id}', () => {
       const response = await app.inject({
         method: 'PUT',
         url: `/events/${event._id.toHexString()}`,
-        payload,
-        headers: { Cookie: `alenvi_token=${authToken}` },
-      });
-
-      expect(response.statusCode).toBe(404);
-    });
-
-    it('should return a 404 error as event is not found', async () => {
-      const payload = {
-        startDate: '2019-01-23T10:00:00.000Z',
-        endDate: '2019-02-23T12:00:00.000Z',
-        sector: sectors[0]._id,
-      };
-
-      const response = await app.inject({
-        method: 'PUT',
-        url: `/events/${new ObjectID()}`,
         payload,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
@@ -1508,7 +1460,7 @@ describe('PUT /events/{_id}', () => {
       expect(response.statusCode).toEqual(403);
     });
 
-    it('should return a 403 if event is not from the same company', async () => {
+    it('should return a 404 if event is not from the same company', async () => {
       const event = eventFromOtherCompany;
       const payload = {
         startDate: '2019-01-23T10:00:00.000Z',
@@ -1523,7 +1475,7 @@ describe('PUT /events/{_id}', () => {
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
-      expect(response.statusCode).toEqual(403);
+      expect(response.statusCode).toEqual(404);
     });
 
     it('should return a 403 if service is archived', async () => {
@@ -1653,12 +1605,10 @@ describe('PUT /events/{_id}', () => {
     const roles = [
       { name: 'helper', expectedCode: 403 },
       { name: 'auxiliary', expectedCode: 403 },
-      { name: 'auxiliary_without_company', expectedCode: 403 },
       { name: 'auxiliary event', expectedCode: 200, customCredentials: auxiliaries[0].local },
       { name: 'vendor_admin', expectedCode: 403 },
       { name: 'coach', expectedCode: 200 },
     ];
-
     roles.forEach((role) => {
       it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
         authToken = role.customCredentials ? await getUserToken(role.customCredentials) : await getToken(role.name);
@@ -1704,7 +1654,7 @@ describe('DELETE /events/{_id}', () => {
       expect(response.statusCode).toBe(404);
     });
 
-    it('should return a 403 if event is not from the same company', async () => {
+    it('should return a 404 if event is not from the same company', async () => {
       const event = eventFromOtherCompany;
 
       const response = await app.inject({
@@ -1713,7 +1663,7 @@ describe('DELETE /events/{_id}', () => {
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
-      expect(response.statusCode).toEqual(403);
+      expect(response.statusCode).toEqual(404);
     });
   });
 

--- a/tests/unit/helpers/events.test.js
+++ b/tests/unit/helpers/events.test.js
@@ -345,7 +345,7 @@ describe('updateEvent', () => {
     sinon.assert.calledOnceWithExactly(formatEditionPayload, event, payload, true);
   });
 
-  it('should update event when only misc is updated', async () => {
+  it('should update event and not detach it from repetition if main fields are not updated', async () => {
     const companyId = new ObjectID();
     const credentials = { _id: new ObjectID(), company: { _id: companyId } };
     const eventId = new ObjectID();


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations :
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [x] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES
- Si mes changements impactent l'application formation :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- Si mes changements impactent l'application erp :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [x] Je n'ai pas changé les droits de la route
  - [x] Je n'ai pas changé les droits dans le fichier rights.js
  - [x] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [x] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- ~~J'ai supprimé une route :~~
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- ~~J'ai renommé une route :~~
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- ~~J'ai ajouté un champ possible dans la route :~~
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- ~~J'ai rendu obligatoire un champs de la route :~~
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- ~~J'ai retiré un champ possible dans la route :~~
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- ~~J'ai supprimé un retour/un champs du retour de la route :~~
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES
- ~~J'ai ajouté un modèle spécifique à une structure:~~
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- ~~J'ai changé un modèle utilisé par l'app mobile:~~
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV
- ~~J'ai changé une constante :~~
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- ~~J'ai ajouté une variable d'environnement :~~
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : Client

- Périmetre roles : Auxiliaire / Coach

- Cas d'usage : Pour un évènement relié a une intervention :
si je modifie la note ou le champ transport specifique, ca ne retire pas l'intervention de la repetition
si je modifie ensuite cette evenement en cochant Appliquer a la repetition la note et le transport specifique ne sont pas supprimés
