### PR TITLE
COM-2341 - fix amount bill

### DIFF
--- a/src/helpers/bills.js
+++ b/src/helpers/bills.js
@@ -248,7 +248,7 @@ exports.getUnitInclTaxes = (bill, subscription) => {
 
   return funding.nature === HOURLY
     ? (version.unitTTCRate * (1 - (version.customerParticipationRate / 100)))
-    : version.amountTTC;
+    : subscription.unitInclTaxes;
 };
 
 exports.formatBillSubscriptionsForPdf = (bill) => {

--- a/tests/unit/helpers/bills.test.js
+++ b/tests/unit/helpers/bills.test.js
@@ -1700,24 +1700,24 @@ describe('getUnitInclTaxes', () => {
     sinon.assert.notCalled(getLastVersion);
   });
 
-  it('should return incl taxes amount for FIXED funding', () => {
+  it('should return subscription unitInclTaxes for FIXED funding', () => {
     const tppId = new ObjectID();
     const bill = {
       thirdPartyPayer: { _id: tppId },
       customer: { fundings: [{ thirdPartyPayer: tppId, nature: 'fixed', versions: [{ amountTTC: 14.4 }] }] },
     };
-    const subscription = { vat: 20 };
+    const subscription = { vat: 20, unitInclTaxes: 12 };
 
     getLastVersion.returns({ amountTTC: 14.4 });
 
     const result = BillHelper.getUnitInclTaxes(bill, subscription);
 
     expect(result).toBeDefined();
-    expect(result).toBe(14.4);
-    sinon.assert.called(getLastVersion);
+    expect(result).toBe(12);
+    sinon.assert.calledOnceWithExactly(getLastVersion, [{ amountTTC: 14.4 }], 'createdAt');
   });
 
-  it('should return unit incl taxes from funding if HOURLY fudning', () => {
+  it('should return unit incl taxes from funding if HOURLY funding', () => {
     const tppId = new ObjectID();
     const bill = {
       thirdPartyPayer: { _id: tppId },


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations :
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [x] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES
- Si mes changements impactent l'application formation :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- Si mes changements impactent l'application erp :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : Client

- Périmetre roles : Coach / Aidant

- Cas d'usage : Quand une facture est relié a une souscription avec un financement forfaitaire, je vois le montant de la souscription en prix unitaire
