### PR TITLE
Com 2297

### DIFF
--- a/src/helpers/services.js
+++ b/src/helpers/services.js
@@ -3,8 +3,10 @@ const Service = require('../models/Service');
 
 exports.list = async (credentials, query) => {
   const companyId = get(credentials, 'company._id') || '';
+
   return Service.find({ ...query, company: companyId })
     .populate({ path: 'versions.surcharge', match: { company: companyId } })
+    .populate({ path: 'versions.billingItems', select: 'name' })
     .lean();
 };
 

--- a/src/helpers/services.js
+++ b/src/helpers/services.js
@@ -5,6 +5,7 @@ exports.list = async (credentials, query) => {
   const companyId = get(credentials, 'company._id') || '';
   return Service.find({ ...query, company: companyId })
     .populate({ path: 'versions.surcharge', match: { company: companyId } })
+    .populate({ path: 'versions.billingItems', select: 'name', match: { company: companyId } })
     .lean();
 };
 

--- a/src/helpers/services.js
+++ b/src/helpers/services.js
@@ -5,7 +5,6 @@ exports.list = async (credentials, query) => {
   const companyId = get(credentials, 'company._id') || '';
   return Service.find({ ...query, company: companyId })
     .populate({ path: 'versions.surcharge', match: { company: companyId } })
-    .populate({ path: 'versions.billingItems', select: 'name', match: { company: companyId } })
     .lean();
 };
 
@@ -17,6 +16,7 @@ exports.create = async (companyId, payload) => {
 
 exports.update = async (id, payload) => {
   if (payload.isArchived) return Service.updateOne({ _id: id }, payload);
+
   return Service.updateOne({ _id: id }, { $push: { versions: payload } });
 };
 

--- a/src/helpers/translate.js
+++ b/src/helpers/translate.js
@@ -161,7 +161,6 @@ module.exports = {
     serviceCreated: 'Service created.',
     serviceDeleted: 'Service deleted.',
     servicesNotFound: 'Services not found.',
-    serviceNotFound: 'Service not found.',
     servicesUpdated: 'Services updated.',
     /* Surcharges */
     surchargesFound: 'Surcharges found.',
@@ -495,7 +494,6 @@ module.exports = {
     serviceCreated: 'Service créé.',
     serviceDeleted: 'Service supprimé.',
     servicesNotFound: 'Services non trouvés.',
-    serviceNotFound: 'Service non trouvé.',
     servicesUpdated: 'Service modifié.',
     /* Surcharges */
     surchargesFound: 'Plans de majorations trouvés.',

--- a/src/helpers/translate.js
+++ b/src/helpers/translate.js
@@ -161,6 +161,7 @@ module.exports = {
     serviceCreated: 'Service created.',
     serviceDeleted: 'Service deleted.',
     servicesNotFound: 'Services not found.',
+    serviceNotFound: 'Service not found.',
     servicesUpdated: 'Services updated.',
     /* Surcharges */
     surchargesFound: 'Surcharges found.',
@@ -494,6 +495,7 @@ module.exports = {
     serviceCreated: 'Service créé.',
     serviceDeleted: 'Service supprimé.',
     servicesNotFound: 'Services non trouvés.',
+    serviceNotFound: 'Service non trouvé.',
     servicesUpdated: 'Service modifié.',
     /* Surcharges */
     surchargesFound: 'Plans de majorations trouvés.',

--- a/src/models/Service.js
+++ b/src/models/Service.js
@@ -17,6 +17,7 @@ const ServiceSchema = mongoose.Schema({
     startDate: { type: Date, required: true },
     createdAt: { type: Date, default: Date.now },
     exemptFromCharges: { type: Boolean, required: true },
+    billingItems: [{ type: mongoose.Schema.Types.ObjectId, ref: 'BillingItem' }],
   }],
   isArchived: { type: Boolean, default: false },
 }, { timestamps: true });

--- a/src/routes/preHandlers/services.js
+++ b/src/routes/preHandlers/services.js
@@ -1,4 +1,5 @@
 const Boom = require('@hapi/boom');
+const { PER_INTERVENTION } = require('../../helpers/constants');
 const BillingItem = require('../../models/BillingItem');
 const Customer = require('../../models/Customer');
 const Service = require('../../models/Service');
@@ -10,10 +11,11 @@ const authorizeServiceEdit = async (req) => {
   if (!service) throw Boom.forbidden();
 
   if (req.payload && req.payload.billingItems) {
-    for (const bi of req.payload.billingItems) {
-      const billingItem = await BillingItem.countDocuments({ _id: bi, company: companyId });
-      if (!billingItem) throw Boom.forbidden();
-    }
+    const billingItems = await BillingItem
+      .find({ _id: { $in: req.payload.billingItems }, company: companyId, type: PER_INTERVENTION })
+      .lean();
+    if (!billingItems) throw Boom.forbidden();
+    if (billingItems.length !== req.payload.billingItems.length) throw Boom.forbidden();
   }
 };
 

--- a/src/routes/preHandlers/services.js
+++ b/src/routes/preHandlers/services.js
@@ -1,21 +1,24 @@
 const Boom = require('@hapi/boom');
+const get = require('lodash/get');
 const { PER_INTERVENTION } = require('../../helpers/constants');
 const BillingItem = require('../../models/BillingItem');
 const Customer = require('../../models/Customer');
 const Service = require('../../models/Service');
+const translate = require('../../helpers/translate');
+
+const { language } = translate;
 
 const authorizeServiceEdit = async (req) => {
   const serviceId = req.params._id;
   const companyId = req.auth.credentials.company._id;
-  const service = await Service.findOne({ _id: serviceId, company: companyId, isArchived: false }).lean();
-  if (!service) throw Boom.forbidden();
+  const service = await Service.findOne({ _id: serviceId, company: companyId }, { isArchived: 1 }).lean();
+  if (!service) throw Boom.notFound(translate[language].serviceNotFound);
+  if (service.isArchived) throw Boom.forbidden();
 
-  if (req.payload && req.payload.billingItems) {
-    const billingItems = await BillingItem
-      .find({ _id: { $in: req.payload.billingItems }, company: companyId, type: PER_INTERVENTION })
-      .lean();
-    if (!billingItems) throw Boom.forbidden();
-    if (billingItems.length !== req.payload.billingItems.length) throw Boom.forbidden();
+  if (get(req, 'payload.billingItems')) {
+    const billingItemsCount = await BillingItem
+      .countDocuments({ _id: { $in: req.payload.billingItems }, company: companyId, type: PER_INTERVENTION });
+    if (billingItemsCount !== req.payload.billingItems.length) throw Boom.forbidden();
   }
 };
 

--- a/src/routes/services.js
+++ b/src/routes/services.js
@@ -80,6 +80,7 @@ exports.plugin = {
               vat: Joi.number(),
               surcharge: Joi.objectId(),
               exemptFromCharges: Joi.boolean(),
+              billingItems: Joi.array().items(Joi.objectId()),
             }),
             Joi.object().keys({ isArchived: Joi.boolean().required() })
           ),

--- a/tests/integration/seed/servicesSeed.js
+++ b/tests/integration/seed/servicesSeed.js
@@ -94,8 +94,16 @@ const customer = {
 };
 
 const billingItemList = [
-  { _id: new ObjectID(), name: 'Kill Billing', type: 'manual', defaultUnitAmount: 2, company: authCompany._id, vat: 2 },
+  {
+    _id: new ObjectID(),
+    name: 'Kill Billing',
+    type: 'per_intervention',
+    defaultUnitAmount: 2,
+    company: authCompany._id,
+    vat: 2,
+  },
   { _id: new ObjectID(), name: 'Bill', type: 'manual', defaultUnitAmount: 25, company: otherCompany._id, vat: 2 },
+  { _id: new ObjectID(), name: 'bil', type: 'manual', defaultUnitAmount: 25, company: authCompany._id, vat: 2 },
 ];
 
 const populateDB = async () => {

--- a/tests/integration/seed/servicesSeed.js
+++ b/tests/integration/seed/servicesSeed.js
@@ -109,10 +109,10 @@ const billingItemList = [
 const populateDB = async () => {
   await deleteNonAuthenticationSeeds();
 
-  Promise.all([
-    await Service.create([...servicesList, serviceFromOtherCompany]),
-    await Customer.create(customer),
-    await BillingItem.create(billingItemList),
+  await Promise.all([
+    Service.create([...servicesList, serviceFromOtherCompany]),
+    Customer.create(customer),
+    BillingItem.create(billingItemList),
   ]);
 };
 

--- a/tests/integration/seed/servicesSeed.js
+++ b/tests/integration/seed/servicesSeed.js
@@ -1,6 +1,7 @@
 const { ObjectID } = require('mongodb');
 const Service = require('../../../src/models/Service');
 const Customer = require('../../../src/models/Customer');
+const BillingItem = require('../../../src/models/BillingItem');
 const { HOURLY, FIXED } = require('../../../src/helpers/constants');
 const { authCompany, otherCompany } = require('../../seed/authCompaniesSeed');
 const { deleteNonAuthenticationSeeds } = require('../helpers/authentication');
@@ -92,11 +93,17 @@ const customer = {
   },
 };
 
+const billingItemList = [
+  { _id: new ObjectID(), name: 'Kill Billing', type: 'manual', defaultUnitAmount: 2, company: authCompany._id, vat: 2 },
+  { _id: new ObjectID(), name: 'Bill', type: 'manual', defaultUnitAmount: 25, company: otherCompany._id, vat: 2 },
+];
+
 const populateDB = async () => {
   await deleteNonAuthenticationSeeds();
 
   await Service.insertMany([...servicesList, serviceFromOtherCompany]);
   await Customer.create(customer);
+  await BillingItem.create(billingItemList);
 };
 
-module.exports = { servicesList, populateDB, serviceFromOtherCompany };
+module.exports = { servicesList, populateDB, serviceFromOtherCompany, billingItemList };

--- a/tests/integration/seed/servicesSeed.js
+++ b/tests/integration/seed/servicesSeed.js
@@ -109,9 +109,11 @@ const billingItemList = [
 const populateDB = async () => {
   await deleteNonAuthenticationSeeds();
 
-  await Service.insertMany([...servicesList, serviceFromOtherCompany]);
-  await Customer.create(customer);
-  await BillingItem.create(billingItemList);
+  Promise.all([
+    await Service.create([...servicesList, serviceFromOtherCompany]),
+    await Customer.create(customer),
+    await BillingItem.create(billingItemList),
+  ]);
 };
 
 module.exports = { servicesList, populateDB, serviceFromOtherCompany, billingItemList };

--- a/tests/integration/services.test.js
+++ b/tests/integration/services.test.js
@@ -1,6 +1,6 @@
 const expect = require('expect');
 const omit = require('lodash/omit');
-const { servicesList, serviceFromOtherCompany, populateDB } = require('./seed/servicesSeed');
+const { servicesList, serviceFromOtherCompany, populateDB, billingItemList } = require('./seed/servicesSeed');
 const Service = require('../../src/models/Service');
 const app = require('../../server');
 const { HOURLY } = require('../../src/helpers/constants');
@@ -166,7 +166,13 @@ describe('PUT /services/:id', () => {
     });
 
     it('should update service', async () => {
-      const payload = { defaultUnitAmount: 15, name: 'Service bis', startDate: '2019-01-16 17:58:15.519', vat: 12 };
+      const payload = {
+        defaultUnitAmount: 15,
+        name: 'Service bis',
+        startDate: '2019-01-16 17:58:15.519',
+        vat: 12,
+        billingItems: [billingItemList[0]._id],
+      };
       const response = await app.inject({
         method: 'PUT',
         url: `/services/${servicesList[0]._id.toHexString()}`,
@@ -221,7 +227,7 @@ describe('PUT /services/:id', () => {
       expect(response.statusCode).toBe(400);
     });
 
-    it('should return 404 if service isArchived', async () => {
+    it('should return 403 if service isArchived', async () => {
       const payload = { defaultUnitAmount: 15, startDate: '2019-01-16 17:58:15.519', vat: 12 };
       const response = await app.inject({
         method: 'PUT',
@@ -230,10 +236,10 @@ describe('PUT /services/:id', () => {
         payload,
       });
 
-      expect(response.statusCode).toBe(404);
+      expect(response.statusCode).toBe(403);
     });
 
-    it('should return a 404 error if user is not from the same company', async () => {
+    it('should return a 403 error if user is not from the same company', async () => {
       const payload = { defaultUnitAmount: 15, name: 'Service bis', startDate: '2019-01-16 17:58:15.519', vat: 12 };
       const response = await app.inject({
         method: 'PUT',
@@ -242,7 +248,25 @@ describe('PUT /services/:id', () => {
         payload,
       });
 
-      expect(response.statusCode).toBe(404);
+      expect(response.statusCode).toBe(403);
+    });
+
+    it('should return a 403 error some billingItem doesn\'t exists in company', async () => {
+      const payload = {
+        defaultUnitAmount: 15,
+        name: 'Service bis',
+        startDate: '2019-01-16 17:58:15.519',
+        vat: 12,
+        billingItems: [billingItemList[0]._id, billingItemList[1]._id],
+      };
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/services/${serviceFromOtherCompany._id.toHexString()}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+        payload,
+      });
+
+      expect(response.statusCode).toBe(403);
     });
   });
 
@@ -291,24 +315,24 @@ describe('DELETE /services/:id', () => {
     expect(serviceCount).toBe(3);
   });
 
-  it('should return a 404 error if user is not from the same company', async () => {
+  it('should return a 403 error if user is not from the same company', async () => {
     const response = await app.inject({
       method: 'DELETE',
       url: `/services/${serviceFromOtherCompany._id.toHexString()}`,
       headers: { Cookie: `alenvi_token=${authToken}` },
     });
 
-    expect(response.statusCode).toBe(404);
+    expect(response.statusCode).toBe(403);
   });
 
-  it('should return a 404 error if service is archived', async () => {
+  it('should return a 403 error if service is archived', async () => {
     const response = await app.inject({
       method: 'DELETE',
       url: `/services/${servicesList[3]._id.toHexString()}`,
       headers: { Cookie: `alenvi_token=${authToken}` },
     });
 
-    expect(response.statusCode).toBe(404);
+    expect(response.statusCode).toBe(403);
   });
 
   it('should return a 403 error if service has subscriptions linked', async () => {

--- a/tests/integration/services.test.js
+++ b/tests/integration/services.test.js
@@ -175,7 +175,7 @@ describe('PUT /services/:id', () => {
       };
       const response = await app.inject({
         method: 'PUT',
-        url: `/services/${servicesList[0]._id.toHexString()}`,
+        url: `/services/${servicesList[0]._id}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
         payload,
       });
@@ -188,7 +188,7 @@ describe('PUT /services/:id', () => {
     it('should archive service', async () => {
       const response = await app.inject({
         method: 'PUT',
-        url: `/services/${servicesList[0]._id.toHexString()}`,
+        url: `/services/${servicesList[0]._id}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
         payload: { isArchived: true },
       });
@@ -202,7 +202,7 @@ describe('PUT /services/:id', () => {
       const payload = { vat: 12 };
       const response = await app.inject({
         method: 'PUT',
-        url: `/services/${servicesList[0]._id.toHexString()}`,
+        url: `/services/${servicesList[0]._id}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
         payload,
       });
@@ -219,7 +219,7 @@ describe('PUT /services/:id', () => {
       };
       const response = await app.inject({
         method: 'PUT',
-        url: `/services/${servicesList[0]._id.toHexString()}`,
+        url: `/services/${servicesList[0]._id}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
         payload,
       });
@@ -231,7 +231,7 @@ describe('PUT /services/:id', () => {
       const payload = { defaultUnitAmount: 15, startDate: '2019-01-16 17:58:15.519', vat: 12 };
       const response = await app.inject({
         method: 'PUT',
-        url: `/services/${servicesList[3]._id.toHexString()}`,
+        url: `/services/${servicesList[3]._id}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
         payload,
       });
@@ -243,7 +243,7 @@ describe('PUT /services/:id', () => {
       const payload = { defaultUnitAmount: 15, name: 'Service bis', startDate: '2019-01-16 17:58:15.519', vat: 12 };
       const response = await app.inject({
         method: 'PUT',
-        url: `/services/${serviceFromOtherCompany._id.toHexString()}`,
+        url: `/services/${serviceFromOtherCompany._id}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
         payload,
       });
@@ -251,7 +251,7 @@ describe('PUT /services/:id', () => {
       expect(response.statusCode).toBe(403);
     });
 
-    it('should return a 403 error some billingItem doesn\'t exists in company', async () => {
+    it('should return a 403 error if some billingItem doesn\'t exists in company', async () => {
       const payload = {
         defaultUnitAmount: 15,
         name: 'Service bis',
@@ -261,7 +261,25 @@ describe('PUT /services/:id', () => {
       };
       const response = await app.inject({
         method: 'PUT',
-        url: `/services/${serviceFromOtherCompany._id.toHexString()}`,
+        url: `/services/${servicesList[0]._id}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+        payload,
+      });
+
+      expect(response.statusCode).toBe(403);
+    });
+
+    it('should return a 403 error if some billingItem are manual type', async () => {
+      const payload = {
+        defaultUnitAmount: 15,
+        name: 'Service bis',
+        startDate: '2019-01-16 17:58:15.519',
+        vat: 12,
+        billingItems: [billingItemList[0]._id, billingItemList[2]._id],
+      };
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/services/${servicesList[0]._id}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
         payload,
       });
@@ -284,7 +302,7 @@ describe('PUT /services/:id', () => {
         authToken = await getToken(role.name);
         const response = await app.inject({
           method: 'PUT',
-          url: `/services/${servicesList[0]._id.toHexString()}`,
+          url: `/services/${servicesList[0]._id}`,
           headers: { Cookie: `alenvi_token=${authToken}` },
           payload,
         });
@@ -305,7 +323,7 @@ describe('DELETE /services/:id', () => {
   it('should delete service', async () => {
     const response = await app.inject({
       method: 'DELETE',
-      url: `/services/${servicesList[0]._id.toHexString()}`,
+      url: `/services/${servicesList[0]._id}`,
       headers: { Cookie: `alenvi_token=${authToken}` },
     });
 
@@ -318,7 +336,7 @@ describe('DELETE /services/:id', () => {
   it('should return a 403 error if user is not from the same company', async () => {
     const response = await app.inject({
       method: 'DELETE',
-      url: `/services/${serviceFromOtherCompany._id.toHexString()}`,
+      url: `/services/${serviceFromOtherCompany._id}`,
       headers: { Cookie: `alenvi_token=${authToken}` },
     });
 
@@ -328,7 +346,7 @@ describe('DELETE /services/:id', () => {
   it('should return a 403 error if service is archived', async () => {
     const response = await app.inject({
       method: 'DELETE',
-      url: `/services/${servicesList[3]._id.toHexString()}`,
+      url: `/services/${servicesList[3]._id}`,
       headers: { Cookie: `alenvi_token=${authToken}` },
     });
 
@@ -338,7 +356,7 @@ describe('DELETE /services/:id', () => {
   it('should return a 403 error if service has subscriptions linked', async () => {
     const response = await app.inject({
       method: 'DELETE',
-      url: `/services/${servicesList[2]._id.toHexString()}`,
+      url: `/services/${servicesList[2]._id}`,
       headers: { Cookie: `alenvi_token=${authToken}` },
     });
 
@@ -358,7 +376,7 @@ describe('DELETE /services/:id', () => {
         authToken = await getToken(role.name);
         const response = await app.inject({
           method: 'DELETE',
-          url: `/services/${servicesList[0]._id.toHexString()}`,
+          url: `/services/${servicesList[0]._id}`,
           headers: { Cookie: `alenvi_token=${authToken}` },
         });
 

--- a/tests/integration/services.test.js
+++ b/tests/integration/services.test.js
@@ -239,7 +239,7 @@ describe('PUT /services/:id', () => {
       expect(response.statusCode).toBe(403);
     });
 
-    it('should return a 403 error if user is not from the same company', async () => {
+    it('should return a 404 error if service is not from the same company', async () => {
       const payload = { defaultUnitAmount: 15, name: 'Service bis', startDate: '2019-01-16 17:58:15.519', vat: 12 };
       const response = await app.inject({
         method: 'PUT',
@@ -248,10 +248,10 @@ describe('PUT /services/:id', () => {
         payload,
       });
 
-      expect(response.statusCode).toBe(403);
+      expect(response.statusCode).toBe(404);
     });
 
-    it('should return a 403 error if some billingItem doesn\'t exists in company', async () => {
+    it('should return a 403 error if some billingItem doesn\'t exist in company', async () => {
       const payload = {
         defaultUnitAmount: 15,
         name: 'Service bis',
@@ -333,14 +333,14 @@ describe('DELETE /services/:id', () => {
     expect(serviceCount).toBe(3);
   });
 
-  it('should return a 403 error if user is not from the same company', async () => {
+  it('should return a 404 error if service is not from the same company', async () => {
     const response = await app.inject({
       method: 'DELETE',
       url: `/services/${serviceFromOtherCompany._id}`,
       headers: { Cookie: `alenvi_token=${authToken}` },
     });
 
-    expect(response.statusCode).toBe(403);
+    expect(response.statusCode).toBe(404);
   });
 
   it('should return a 403 error if service is archived', async () => {

--- a/tests/unit/helpers/services.test.js
+++ b/tests/unit/helpers/services.test.js
@@ -27,6 +27,7 @@ describe('list', () => {
     SinonMongoose.calledWithExactly(find, [
       { query: 'find', args: [{ company: companyId, isArchived: true }] },
       { query: 'populate', args: [{ path: 'versions.surcharge', match: { company: companyId } }] },
+      { query: 'populate', args: [{ path: 'versions.billingItems', select: 'name' }] },
       { query: 'lean' },
     ]);
   });

--- a/tests/unit/helpers/services.test.js
+++ b/tests/unit/helpers/services.test.js
@@ -27,6 +27,7 @@ describe('list', () => {
     SinonMongoose.calledWithExactly(find, [
       { query: 'find', args: [{ company: companyId, isArchived: true }] },
       { query: 'populate', args: [{ path: 'versions.surcharge', match: { company: companyId } }] },
+      { query: 'populate', args: [{ path: 'versions.billingItems', select: 'name', match: { company: companyId } }] },
       { query: 'lean' },
     ]);
   });

--- a/tests/unit/helpers/services.test.js
+++ b/tests/unit/helpers/services.test.js
@@ -27,7 +27,6 @@ describe('list', () => {
     SinonMongoose.calledWithExactly(find, [
       { query: 'find', args: [{ company: companyId, isArchived: true }] },
       { query: 'populate', args: [{ path: 'versions.surcharge', match: { company: companyId } }] },
-      { query: 'populate', args: [{ path: 'versions.billingItems', select: 'name', match: { company: companyId } }] },
       { query: 'lean' },
     ]);
   });


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations :
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [x] J'ai bien fait les tests
  - ~~C'est une ancienne route utilisée par une des apps mobiles~~
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### ~~FONCTIONNALITÉS APPS MOBILES~~
- Si mes changements impactent l'application formation :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- Si mes changements impactent l'application erp :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### ~~MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME~~
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES
- ~~J'ai ajouté un modèle spécifique à une structure:~~
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- ~~J'ai changé un modèle utilisé par l'app mobile:~~
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### ~~CONSTANTES ET VARIABLE D'ENV~~
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- ~~J'ai ajouté une variable d'environnement :~~
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : client

- Périmetre roles : admin

- Cas d'usage : 
  Dans la config bénéficiaire, dans la modale d'édition, je peux lier un article avec un service.

 2 choses :
 - Le ticket fait mention d'une colonne à ajouter avec les tags des différents articles mais la stratégie technique n'en fait pas mention, est-ce que c'est un oubli ou bien il ne faut pas le faire dans ce sprint ?
- Est-ce qu'il faudrait supprimer la possibilité d'ajouter deux fois le même article ? Ce n'est pas mentionné dans le ticket
