### PR TITLE
COM-2295: fix if specific transport is private car

### DIFF
--- a/src/helpers/distanceMatrix.js
+++ b/src/helpers/distanceMatrix.js
@@ -1,7 +1,7 @@
 const get = require('lodash/get');
 const DistanceMatrix = require('../models/DistanceMatrix');
 const maps = require('../models/Google/Maps');
-const { TRANSIT, WALKING } = require('./constants');
+const { TRANSIT, WALKING, DRIVING } = require('./constants');
 
 exports.getDistanceMatrices = async credentials =>
   DistanceMatrix.find({ company: get(credentials, 'company._id') }).lean();
@@ -21,12 +21,12 @@ exports.createDistanceMatrix = async (params, companyId) => {
     if (!isDistanceMatrixDefine(transitRes)) res = walkingRes;
     else if (!isDistanceMatrixDefine(walkingRes)) res = transitRes;
     else {
-      const transitDistance = transitRes.data.rows[0].elements[0].distance.value;
-      const walkingDistance = walkingRes.data.rows[0].elements[0].distance.value;
-      res = transitDistance < walkingDistance ? transitRes : walkingRes;
+      const transitDuration = transitRes.data.rows[0].elements[0].duration.value;
+      const walkingDuration = walkingRes.data.rows[0].elements[0].duration.value;
+      res = transitDuration < walkingDuration ? transitRes : walkingRes;
     }
   } else {
-    res = await maps.getDistanceMatrix(query);
+    res = await maps.getDistanceMatrix({ ...query, mode: DRIVING });
   }
 
   if (!isDistanceMatrixDefine(res)) return null;

--- a/src/helpers/distanceMatrix.js
+++ b/src/helpers/distanceMatrix.js
@@ -1,7 +1,7 @@
 const get = require('lodash/get');
 const DistanceMatrix = require('../models/DistanceMatrix');
 const maps = require('../models/Google/Maps');
-const { TRANSIT, WALKING, DRIVING } = require('./constants');
+const { TRANSIT, WALKING } = require('./constants');
 
 exports.getDistanceMatrices = async credentials =>
   DistanceMatrix.find({ company: get(credentials, 'company._id') }).lean();
@@ -26,7 +26,7 @@ exports.createDistanceMatrix = async (params, companyId) => {
       res = transitDuration < walkingDuration ? transitRes : walkingRes;
     }
   } else {
-    res = await maps.getDistanceMatrix({ ...query, mode: DRIVING });
+    res = await maps.getDistanceMatrix(query);
   }
 
   if (!isDistanceMatrixDefine(res)) return null;

--- a/src/helpers/draftPay.js
+++ b/src/helpers/draftPay.js
@@ -152,9 +152,9 @@ exports.getTransportMode = (event) => {
   let specificMode;
   if (event.transportMode) specificMode = event.transportMode === PUBLIC_TRANSPORT ? TRANSIT : DRIVING;
 
-  const shouldPayKm = defaultMode === DRIVING && (!specificMode || specificMode === PRIVATE_TRANSPORT);
+  const shouldPayKm = defaultMode === DRIVING && (!specificMode || event.transportMode === PRIVATE_TRANSPORT);
 
-  return { defalut: defaultMode, specific: specificMode, shouldPayKm };
+  return { default: defaultMode, specific: specificMode, shouldPayKm };
 };
 
 exports.getPaidTransportInfo = async (event, prevEvent, dm) => {

--- a/src/helpers/draftPay.js
+++ b/src/helpers/draftPay.js
@@ -149,7 +149,7 @@ exports.getTransportMode = event =>
     default: event.auxiliary.administrative.transportInvoice.transportType === PUBLIC_TRANSPORT
       ? TRANSIT
       : DRIVING,
-    ...(event.transportMode && { specific: event.transportMode === PUBLIC_TRANSPORT ? TRANSIT : DRIVING }),
+    ...(event.transportMode && { specific: event.transportMode === PUBLIC_TRANSPORT ? TRANSIT : event.transportMode }),
   });
 
 exports.getPaidTransportInfo = async (event, prevEvent, dm) => {

--- a/tests/unit/helpers/distanceMatrix.test.js
+++ b/tests/unit/helpers/distanceMatrix.test.js
@@ -62,7 +62,7 @@ describe('createDistanceMatrix', () => {
       rows: [{
         elements: [{
           distance: { value: 363970 },
-          duration: { value: 14790 },
+          duration: { value: 12790 },
         }],
       }],
     },
@@ -103,7 +103,7 @@ describe('createDistanceMatrix', () => {
     }));
   });
 
-  it('should return minimum distance between walking and transit', async () => {
+  it('should return minimum duration between walking and transit', async () => {
     getDistanceMatrix.onCall(0).returns(distanceMatrixResult);
     getDistanceMatrix.onCall(1).returns(distanceMatrixWalkingResult);
 
@@ -123,7 +123,7 @@ describe('createDistanceMatrix', () => {
       _id: expect.any(Object),
       destinations: 'New York City, NY',
       distance: 363970,
-      duration: 14790,
+      duration: 12790,
       origins: 'Washington, DC',
       mode: 'transit',
     }));

--- a/tests/unit/helpers/draftPay.test.js
+++ b/tests/unit/helpers/draftPay.test.js
@@ -607,7 +607,7 @@ describe('getPaidTransportInfo', () => {
     sinon.assert.calledOnceWithExactly(getTransportInfo, [], 'tamalou', 'jébobolà', 'transit', event.company);
   });
 
-  it('should not paid transport if transportMode is not personal car', async () => {
+  it('should not paid transport if specific transport is not personal car', async () => {
     const event = {
       hasFixedService: false,
       startDate: '2019-01-18T18:00:00',
@@ -631,6 +631,32 @@ describe('getPaidTransportInfo', () => {
     expect(result).toBeDefined();
     expect(result).toEqual({ distance: 0, duration: 40 });
     sinon.assert.calledOnceWithExactly(getTransportInfo, [], 'tamalou', 'jébobolà', 'transit', event.company);
+  });
+
+  it('should not paid transport if default transport is not personal car', async () => {
+    const event = {
+      hasFixedService: false,
+      startDate: '2019-01-18T18:00:00',
+      type: 'intervention',
+      auxiliary: {
+        administrative: { transportInvoice: { transportType: 'public' } },
+      },
+      address: { fullAddress: 'jébobolà' },
+      transportMode: 'private',
+
+    };
+    const prevEvent = {
+      hasFixedService: false,
+      type: 'intervention',
+      endDate: '2019-01-18T15:00:00',
+      address: { fullAddress: 'tamalou' },
+    };
+    getTransportInfo.resolves({ distance: 10, duration: 40 });
+    const result = await DraftPayHelper.getPaidTransportInfo(event, prevEvent, []);
+
+    expect(result).toBeDefined();
+    expect(result).toEqual({ distance: 0, duration: 40 });
+    sinon.assert.calledOnceWithExactly(getTransportInfo, [], 'tamalou', 'jébobolà', 'driving', event.company);
   });
 
   it('should compute transit transport', async () => {


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations : -np
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [ ] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES
-~~ Si mes changements impactent l'application formation :~~
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

-~~ Si mes changements impactent l'application erp :~~
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME -np
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES
- ~~J'ai ajouté un modèle spécifique à une structure:~~
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- ~~J'ai changé un modèle utilisé par l'app mobile:~~
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV
- ~~J'ai changé une constante :~~
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- ~~J'ai ajouté une variable d'environnement :~~
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : client

- Périmetre roles : admin/coach

- Cas d'usage : si le transport par défaut est voiture personnelle, et que l'auxiliaire spécifie voiture personnel comme transport spécifique celui-ci est tout de même comptabilisé
