### PR TITLE
COM-2353 - Fix billnumber for manual bills

### DIFF
--- a/tests/unit/helpers/bills.test.js
+++ b/tests/unit/helpers/bills.test.js
@@ -1623,7 +1623,7 @@ describe('formatAndCreateBill', () => {
     await BillHelper.formatAndCreateBill(payload, credentials);
 
     sinon.assert.calledOnceWithExactly(getBillNumber, '2021-09-01', companyId);
-    sinon.assert.calledOnceWithExactly(formatBillNumber, '101', 'FACT-101', 2);
+    sinon.assert.calledOnceWithExactly(formatBillNumber, '101', 'FACT-101', 1);
     SinonMongoose.calledWithExactly(
       findBillingItem,
       [


### PR DESCRIPTION
Comment reproduire le bug :
- Facturer un bénéficiaire pour le mois en cours (pour le 15/09 par exemple) -> tout ce passe bien
- Ajouter une facture manuelle
- Facturer un autre bénéficiaire pour le mois en cours -> vous avez l'erreur suivante en back : E11000 duplicate key error collection: local.bills index: number dup key: { number: "FACT-10109210000x"}.

Cela vient du fait que les factures manuelles avaient pour `number` (leur clé unique) le dernier billNumber + 1 alors que les factures automatiques ont pour `number` le dernier billNumber tout court.

J'ai rétabli le fait que les factures manuelles ont désormais le dernier billNumber comme number
