### PR TITLE
Com 2328

### DIFF
--- a/src/helpers/draftBills.js
+++ b/src/helpers/draftBills.js
@@ -1,5 +1,4 @@
 const get = require('lodash/get');
-const mergeWith = require('lodash/mergeWith');
 const { ObjectID } = require('mongodb');
 const moment = require('../extensions/moment');
 const EventRepository = require('../repositories/EventRepository');
@@ -350,8 +349,13 @@ exports.getDraftBillsPerSubscription = (events, subscription, fundings, billingS
 const formatEventsByBillingItem = (eventsByBillingItemBySubscriptions) => {
   const eventsByBillingItem = {};
   for (const eventsByBillingItemInSubscription of eventsByBillingItemBySubscriptions) {
-    // eslint-disable-next-line consistent-return
-    mergeWith(eventsByBillingItem, eventsByBillingItemInSubscription, (a, b) => { if (a) return a.concat(b); });
+    for (const [billingItemId, eventsList] of Object.entries(eventsByBillingItemInSubscription)) {
+      if (eventsByBillingItem[billingItemId]) {
+        eventsByBillingItem[billingItemId] = eventsByBillingItem[billingItemId].concat(eventsList);
+      } else {
+        eventsByBillingItem[billingItemId] = eventsList;
+      }
+    }
   }
 
   return eventsByBillingItem;

--- a/src/helpers/draftBills.js
+++ b/src/helpers/draftBills.js
@@ -429,12 +429,13 @@ exports.getDraftBillsList = async (dates, billingStartDate, credentials, custome
       billingStartDate,
       dates.endDate
     );
+    const customerBills = [...subscriptionsDraftBills, ...formattedBillingItems];
     const groupedByCustomerBills = {
       customer,
       endDate: dates.endDate,
       customerBills: {
-        bills: [...subscriptionsDraftBills, ...formattedBillingItems],
-        total: [...subscriptionsDraftBills, ...formattedBillingItems].reduce((sum, b) => sum + (b.inclTaxes || 0), 0),
+        bills: customerBills,
+        total: customerBills.reduce((sum, b) => sum + (b.inclTaxes || 0), 0),
       },
     };
     if (Object.values(tppBills).length > 0) {

--- a/src/helpers/draftBills.js
+++ b/src/helpers/draftBills.js
@@ -344,7 +344,7 @@ exports.getDraftBillsPerSubscription = (events, subscription, fundings, billingS
     );
   }
 
-  return draftBillsPerSubscription;
+  return { ...draftBillsPerSubscription, billingItems };
 };
 
 exports.getDraftBillsList = async (dates, billingStartDate, credentials, customerId = null) => {

--- a/src/helpers/historyExport.js
+++ b/src/helpers/historyExport.js
@@ -76,7 +76,8 @@ const getServiceName = (service) => {
   return lastVersion.name;
 };
 
-const getMatchingSector = (histories, event) => histories.filter(sh => moment(sh.startDate).isBefore(event.startDate))
+const getMatchingSector = (histories, event) => histories
+  .filter(sh => moment(sh.startDate).isBefore(event.startDate))
   .sort(DatesHelper.descendingSort('startDate'))[0];
 
 const displayDate = (timestamp = null, path, scheduledDate = null) => {

--- a/src/helpers/historyExport.js
+++ b/src/helpers/historyExport.js
@@ -77,7 +77,7 @@ const getServiceName = (service) => {
 };
 
 const getMatchingSector = (histories, event) => histories.filter(sh => moment(sh.startDate).isBefore(event.startDate))
-  .sort((a, b) => new Date(b.startDate) - new Date(a.startDate))[0];
+  .sort(DatesHelper.descendingSort('startDate'))[0];
 
 const displayDate = (timestamp = null, path, scheduledDate = null) => {
   if (timestamp) return DatesHelper.formatDateAndTime(get(timestamp, path), 'DDMMMMYYYYhhmmss');

--- a/tests/unit/helpers/draftbills.test.js
+++ b/tests/unit/helpers/draftbills.test.js
@@ -1163,7 +1163,7 @@ describe('formatBillingItems', () => {
 
   it('should return formatted billing items', async () => {
     const eventsByBillingItemBySubscriptions = [
-      { d00000000000000000000001: ['eventId1', 'eventId2'], d00000000000000000000002: ['eventId1, eventId2'] },
+      { d00000000000000000000001: ['eventId1', 'eventId2'], d00000000000000000000002: ['eventId1', 'eventId2'] },
       { d00000000000000000000001: ['eventId3'] },
     ];
     const endDate = '2019-12-25T07:00:00';
@@ -1210,9 +1210,9 @@ describe('formatBillingItems', () => {
         unitExclTaxes: 4.545454545454545,
         unitInclTaxes: 5,
         vat: 10,
-        eventsList: ['eventId1, eventId2'],
-        exclTaxes: 4.545454545454545,
-        inclTaxes: 5,
+        eventsList: ['eventId1', 'eventId2'],
+        exclTaxes: 9.09090909090909,
+        inclTaxes: 10,
         startDate: '2019-12-31T07:00:00',
         endDate: '2019-12-25T07:00:00',
       }),

--- a/tests/unit/helpers/draftbills.test.js
+++ b/tests/unit/helpers/draftbills.test.js
@@ -986,16 +986,23 @@ describe('getDraftBillsPerSubscription', () => {
     ];
     const subscription = {
       versions: [{ startDate: new Date('2019/01/01'), unitTTCRate: 21 }],
-      service: { versions: [{ startDate: new Date('2019/01/01'), vat: 20 }] },
+      service: {
+        versions: [
+          { startDate: new Date('2019/01/01'), vat: 20, billingItems: [new ObjectID('d00000000000000000000001')] },
+        ],
+      },
     };
 
     getLastVersion.returns({ startDate: new Date('2019/01/01'), unitTTCRate: 21 });
     getMatchingVersion.returns({ startDate: new Date('2019/01/01'), vat: 20 });
     getExclTaxes.returns(70);
     computeBillingInfoForEvents.returns({
-      customerPrices: { exclTaxes: 35 },
-      thirdPartyPayerPrices: { [tppId]: { hours: 3 } },
-      startDate: moment('2019/02/01', 'YY/MM/DD'),
+      prices: {
+        customerPrices: { exclTaxes: 35 },
+        thirdPartyPayerPrices: { [tppId]: { hours: 3 } },
+        startDate: moment('2019/02/01', 'YY/MM/DD'),
+      },
+      billingItems: [{ d00000000000000000000001: [events[0]._id] }],
     });
 
     const result =
@@ -1005,6 +1012,7 @@ describe('getDraftBillsPerSubscription', () => {
     expect(result.customer.unitExclTaxes).toEqual(70);
     expect(result.customer.unitInclTaxes).toEqual(21);
     expect(result.thirdPartyPayer[tppId].hours).toEqual(3);
+    expect(result.billingItems).toEqual([{ d00000000000000000000001: [events[0]._id] }]);
     sinon.assert.calledOnceWithExactly(
       getLastVersion,
       [{ startDate: new Date('2019/01/01'), unitTTCRate: 21 }],
@@ -1035,8 +1043,11 @@ describe('getDraftBillsPerSubscription', () => {
     getMatchingVersion.returns({ startDate: new Date('2019/01/01'), vat: 20 });
     getExclTaxes.returns(70);
     computeBillingInfoForEvents.returns({
-      customerPrices: { exclTaxes: 35 },
-      startDate: moment('2019/02/01', 'YY/MM/DD'),
+      prices: {
+        customerPrices: { exclTaxes: 35 },
+        startDate: moment('2019/02/01', 'YY/MM/DD'),
+      },
+      billingItems: [],
     });
 
     const result =
@@ -1045,6 +1056,7 @@ describe('getDraftBillsPerSubscription', () => {
     expect(result.customer.exclTaxes).toEqual(35);
     expect(result.customer.unitExclTaxes).toEqual(70);
     expect(result.customer.unitInclTaxes).toEqual(21);
+    expect(result.billingItems).toEqual([]);
     sinon.assert.calledOnceWithExactly(
       getLastVersion,
       [{ startDate: new Date('2019/01/01'), unitTTCRate: 21 }],
@@ -1077,9 +1089,12 @@ describe('getDraftBillsPerSubscription', () => {
     getMatchingVersion.returns({ startDate: new Date('2019/01/01'), vat: 20 });
     getExclTaxes.returns(70);
     computeBillingInfoForEvents.returns({
-      customerPrices: { exclTaxes: 0 },
-      thirdPartyPayerPrices: { [tppId]: { hours: 3 } },
-      startDate: moment('2019/02/01', 'YY/MM/DD'),
+      prices: {
+        customerPrices: { exclTaxes: 0 },
+        thirdPartyPayerPrices: { [tppId]: { hours: 3 } },
+        startDate: moment('2019/02/01', 'YY/MM/DD'),
+      },
+      billingItems: [],
     });
 
     const result =
@@ -1087,6 +1102,7 @@ describe('getDraftBillsPerSubscription', () => {
 
     expect(result.customer).toBeUndefined();
     expect(result.thirdPartyPayer[tppId].hours).toEqual(3);
+    expect(result.billingItems).toEqual([]);
     sinon.assert.calledOnceWithExactly(
       getLastVersion,
       [{ startDate: new Date('2019/01/01'), unitTTCRate: 21 }],

--- a/tests/unit/helpers/draftbills.test.js
+++ b/tests/unit/helpers/draftbills.test.js
@@ -740,12 +740,21 @@ describe('computeBillingInfoForEvents', () => {
   });
 
   it('should compute info for each event', () => {
-    const events = [{ startDate: '2021-02-04T12:00:00.000Z' }, { startDate: '2021-03-05T10:00:00.000Z' }];
-    const service = { _id: new ObjectID() };
+    const events = [
+      { _id: new ObjectID(), startDate: '2021-02-04T12:00:00.000Z' },
+      { _id: new ObjectID(), startDate: '2021-03-05T10:00:00.000Z' },
+    ];
+    const service = {
+      _id: new ObjectID(),
+      billingItems: [
+        { _id: new ObjectID('d00000000000000000000000'), name: 'skusku' },
+        { _id: new ObjectID('d00000000000000000000001'), name: 'skusku 2' },
+      ],
+    };
     const fundings = [];
     const startDate = moment('2021/03/01', 'YYYY/MM/DD');
-
     const matchingService = { ...service, name: 'test' };
+
     getMatchingVersion.returns(matchingService);
     getEventBilling.onCall(0).returns({ customerPrice: 20 });
     getEventBilling.onCall(1).returns({ customerPrice: 15 });
@@ -755,9 +764,15 @@ describe('computeBillingInfoForEvents', () => {
     const result = DraftBillsHelper.computeBillingInfoForEvents(events, service, fundings, startDate, 12);
 
     expect(result).toEqual({
-      customerPrices: { exclTaxes: 45, inclTaxes: 50, hours: 6, eventsList: events },
-      thirdPartyPayerPrices: {},
-      startDate: moment('2021-02-04T12:00:00.000Z'),
+      prices: {
+        customerPrices: { exclTaxes: 45, inclTaxes: 50, hours: 6, eventsList: events },
+        thirdPartyPayerPrices: {},
+        startDate: moment('2021-02-04T12:00:00.000Z'),
+      },
+      billingItems: {
+        d00000000000000000000000: [events[0]._id, events[1]._id],
+        d00000000000000000000001: [events[0]._id, events[1]._id],
+      },
     });
     sinon.assert.calledWithExactly(getMatchingVersion.getCall(0), events[0].startDate, service, 'startDate');
     sinon.assert.calledWithExactly(getMatchingVersion.getCall(1), events[1].startDate, service, 'startDate');
@@ -787,13 +802,13 @@ describe('computeBillingInfoForEvents', () => {
       { startDate: '2021-03-05T10:00:00.000Z' },
       { startDate: '2021-03-06T10:00:00.000Z' },
     ];
-    const service = { _id: new ObjectID() };
+    const service = { _id: new ObjectID(), billingItems: [{ _id: new ObjectID(), name: 'skusku' }] };
+    const matchingService = { ...service, name: 'test' };
     const fundings = [{ _id: new ObjectID() }];
+    const matchingFunding = { ...fundings[0], thirdPartyPayer: 'tpp' };
     const startDate = moment('2021/03/01', 'YYYY/MM/DD');
 
-    const matchingService = { ...service, name: 'test' };
     getMatchingVersion.returns(matchingService);
-    const matchingFunding = { ...fundings[0], thirdPartyPayer: 'tpp' };
     getMatchingFunding.onCall(0).returns(null);
     getMatchingFunding.onCall(1).returns(matchingFunding);
     getMatchingFunding.onCall(2).returns(matchingFunding);
@@ -818,11 +833,14 @@ describe('computeBillingInfoForEvents', () => {
     const result = DraftBillsHelper.computeBillingInfoForEvents(events, service, fundings, startDate, 12);
 
     expect(result).toEqual({
-      customerPrices: { exclTaxes: 60, inclTaxes: 75, hours: 8, eventsList: events },
-      thirdPartyPayerPrices: {
-        [fundings[0]._id]: { exclTaxes: 42, inclTaxes: 46, hours: 4, eventsList: [events[1], events[2]] },
+      prices: {
+        customerPrices: { exclTaxes: 60, inclTaxes: 75, hours: 8, eventsList: events },
+        thirdPartyPayerPrices: {
+          [fundings[0]._id]: { exclTaxes: 42, inclTaxes: 46, hours: 4, eventsList: [events[1], events[2]] },
+        },
+        startDate,
       },
-      startDate,
+      billingItems: {},
     });
     sinon.assert.calledWithExactly(getMatchingVersion.getCall(0), events[0].startDate, service, 'startDate');
     sinon.assert.calledWithExactly(getMatchingVersion.getCall(1), events[1].startDate, service, 'startDate');
@@ -874,12 +892,16 @@ describe('computeBillingInfoForEvents', () => {
 
   it('should return empty infos if no event', () => {
     const startDate = moment('2021/01/01', 'YYYY/MM/DD');
+
     const result = DraftBillsHelper.computeBillingInfoForEvents([], { _id: new ObjectID() }, [], startDate, 0);
 
     expect(result).toEqual({
-      customerPrices: { exclTaxes: 0, inclTaxes: 0, hours: 0, eventsList: [] },
-      thirdPartyPayerPrices: {},
-      startDate,
+      prices: {
+        customerPrices: { exclTaxes: 0, inclTaxes: 0, hours: 0, eventsList: [] },
+        thirdPartyPayerPrices: {},
+        startDate,
+      },
+      billingItems: {},
     });
     sinon.assert.notCalled(getMatchingVersion);
     sinon.assert.notCalled(getMatchingFunding);

--- a/tests/unit/helpers/draftbills.test.js
+++ b/tests/unit/helpers/draftbills.test.js
@@ -15,7 +15,7 @@ const EventRepository = require('../../../src/repositories/EventRepository');
 const { BILLING_DIRECT, BILLING_INDIRECT } = require('../../../src/helpers/constants');
 
 describe('populateAndFormatSubscription', () => {
-  it('should populate surcharge and billing items and order versions', async () => {
+  it('should populate surcharge and billing items and sort versions', async () => {
     const surchargeId = new ObjectID();
     const bddSurcharges = [{ _id: surchargeId, sundaySurcharge: 10 }];
     const billingItemId1 = new ObjectID();

--- a/tests/unit/helpers/draftbills.test.js
+++ b/tests/unit/helpers/draftbills.test.js
@@ -1141,7 +1141,7 @@ describe('formatBillingItems', () => {
   });
 
   it('should return formatted billing items', async () => {
-    const eventsGroupedByBillingItemList = [
+    const eventsByBillingItemBySubscriptions = [
       { d00000000000000000000001: ['eventId1', 'eventId2'], d00000000000000000000002: ['eventId1, eventId2'] },
       { d00000000000000000000001: ['eventId3'] },
     ];
@@ -1164,7 +1164,7 @@ describe('formatBillingItems', () => {
     const bddBillingItems = [billingItem1, billingItem2, billingItem1];
 
     const result = await DraftBillsHelper.formatBillingItems(
-      eventsGroupedByBillingItemList,
+      eventsByBillingItemBySubscriptions,
       bddBillingItems,
       billingStartDate,
       endDate


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations :
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [x] J'ai bien fait les tests
  - ~~C'est une ancienne route utilisée par une des apps mobiles~~
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### ~~FONCTIONNALITÉS APPS MOBILES~~
- Si mes changements impactent l'application formation :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- Si mes changements impactent l'application erp :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### ~~MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME~~
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### ~~MODIFICATIONS SUR LES MODÈLES~~
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### ~~CONSTANTES ET VARIABLE D'ENV~~
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : client

- Périmetre roles : admin

- Cas d'usage : 
Sur la page 'A Facturer', je vois les articles de facturation lorsqu'une intervention est liée à un article de facturation.

Pour tester : 
  - ajouter 2 - 3 articles de facturation par intervention
  - lier ces facturations avec des services (penser à varier les dates d'effet, pour vérifier qu'elles sont bien prises en compte)
  - ajouter des interventions à un bénéficiaire en variant : le service, la date, ...
  - Regarder sur la page 'A facturer' que vous voyez bien les articles liés aux interventions avec le bon prix pour chaque intervention


Bug rencontré que je n'explique pas :
- J'ai 3 évènements pour mon bénéficiaire : le 10, 11 et 12 septembre
- Les 3 évènements ont un service qui est lié à un article de facturation
- Sur la page A Facturer, je vois bien un décompte de 3 pour l'article en question
- Si je supprime les articles du service avec une date d'effet le 11/09 et que je reviens sur la page A Facturer, j'ai toujours un décompte de 3 pour l'article en question.
Hors selon moi, je devrais n'avoir qu'un décompte de 1, car seul l'évènement du 10/09 à un article lié. Les évènements  du 11/09 et du 12/09 n'ont pas d'articles lié à leur service.
Est-ce un bug ou bien est-ce que j'ai mal compris le fonctionnement de la date d'effet ?