### PR TITLE
Com 2330

### DIFF
--- a/src/data/pdf/billing/bill.js
+++ b/src/data/pdf/billing/bill.js
@@ -20,7 +20,7 @@ exports.getPdfContent = async (data) => {
         { text: `${sub.name} (TVA ${sub.vat ? sub.vat.toString().replace(/\./g, ',') : 0} %)` },
         { text: sub.unitInclTaxes || '-' },
         { text: sub.volume || '-' },
-        { text: `${sub.total} €` },
+        { text: `${sub.total}` },
       ]
     );
   });

--- a/src/data/pdf/billing/bill.js
+++ b/src/data/pdf/billing/bill.js
@@ -15,7 +15,7 @@ exports.getPdfContent = async (data) => {
     ],
   ];
 
-  bill.formattedSubs.forEach((sub) => {
+  bill.formattedDetails.forEach((sub) => {
     serviceTableBody.push(
       [
         { text: `${sub.name} ${sub.vat ? `(TVA ${UtilsHelper.formatPercentage(sub.vat / 100)})` : ''}` },

--- a/src/data/pdf/billing/bill.js
+++ b/src/data/pdf/billing/bill.js
@@ -7,27 +7,30 @@ exports.getPdfContent = async (data) => {
 
   const serviceTableBody = [
     [
-      { text: 'Service', bold: true },
+      { text: 'Intitulé', bold: true },
       { text: 'Prix unitaire TTC', bold: true },
       { text: 'Volume', bold: true },
-      { text: 'Total TTC*', bold: true },
+      { text: 'Total TTC', bold: true },
     ],
   ];
-  bill.formattedSubs.forEach(sub => serviceTableBody.push(
-    [
-      { text: `${sub.service} (TVA ${sub.vat} %)` },
-      { text: sub.unitInclTaxes },
-      { text: sub.volume },
-      { text: sub.inclTaxes },
-    ]
-  ));
+
+  bill.formattedSubs.forEach((sub) => {
+    serviceTableBody.push(
+      [
+        { text: `${sub.name} (TVA ${sub.vat ? sub.vat.toString().replace(/\./g, ',') : 0} %)` },
+        { text: sub.unitInclTaxes || '-' },
+        { text: sub.volume || '-' },
+        { text: `${sub.total} €` },
+      ]
+    );
+  });
+
   const serviceTable = [
     {
       table: { body: serviceTableBody, widths: ['*', 'auto', 'auto', 'auto'] },
       margin: [0, 40, 0, 8],
       layout: { vLineWidth: () => 0.5, hLineWidth: () => 0.5 },
     },
-    { text: '*ce total intègre les financements, majorations et éventuelles remises.' },
   ];
 
   const priceTable = UtilsPdfHelper.getPriceTable(bill);

--- a/src/data/pdf/billing/bill.js
+++ b/src/data/pdf/billing/bill.js
@@ -18,7 +18,7 @@ exports.getPdfContent = async (data) => {
   bill.formattedDetails.forEach((sub) => {
     serviceTableBody.push(
       [
-        { text: `${sub.name} ${sub.vat ? `(TVA ${UtilsHelper.formatPercentage(sub.vat / 100)})` : ''}` },
+        { text: `${sub.name}${sub.vat ? ` (TVA ${UtilsHelper.formatPercentage(sub.vat / 100)})` : ''}` },
         { text: sub.unitInclTaxes ? UtilsHelper.formatPrice(sub.unitInclTaxes) : '-' },
         { text: sub.volume || '-' },
         { text: sub.total ? UtilsHelper.formatPrice(sub.total) : '-' },

--- a/src/data/pdf/billing/bill.js
+++ b/src/data/pdf/billing/bill.js
@@ -19,9 +19,9 @@ exports.getPdfContent = async (data) => {
     serviceTableBody.push(
       [
         { text: `${sub.name} ${sub.vat ? `(TVA ${UtilsHelper.formatPercentage(sub.vat / 100)})` : ''}` },
-        { text: sub.unitInclTaxes || '-' },
+        { text: sub.unitInclTaxes ? UtilsHelper.formatPrice(sub.unitInclTaxes) : '-' },
         { text: sub.volume || '-' },
-        { text: `${sub.total}` },
+        { text: sub.total ? UtilsHelper.formatPrice(sub.total) : '-' },
       ]
     );
   });

--- a/src/data/pdf/billing/bill.js
+++ b/src/data/pdf/billing/bill.js
@@ -6,7 +6,7 @@ exports.getPdfContent = async (data) => {
   const { bill } = data;
   const header = await UtilsPdfHelper.getHeader(bill.company, bill, BILL);
 
-  const serviceTableBody = [
+  const billDetailsTableBody = [
     [
       { text: 'Intitulé', bold: true },
       { text: 'Prix unitaire TTC', bold: true },
@@ -15,20 +15,20 @@ exports.getPdfContent = async (data) => {
     ],
   ];
 
-  bill.formattedDetails.forEach((sub) => {
-    serviceTableBody.push(
+  bill.formattedDetails.forEach((detail) => {
+    billDetailsTableBody.push(
       [
-        { text: `${sub.name}${sub.vat ? ` (TVA ${UtilsHelper.formatPercentage(sub.vat / 100)})` : ''}` },
-        { text: sub.unitInclTaxes ? UtilsHelper.formatPrice(sub.unitInclTaxes) : '-' },
-        { text: sub.volume || '-' },
-        { text: sub.total ? UtilsHelper.formatPrice(sub.total) : '-' },
+        { text: `${detail.name}${detail.vat ? ` (TVA ${UtilsHelper.formatPercentage(detail.vat / 100)})` : ''}` },
+        { text: detail.unitInclTaxes ? UtilsHelper.formatPrice(detail.unitInclTaxes) : '-' },
+        { text: detail.volume || '-' },
+        { text: detail.total ? UtilsHelper.formatPrice(detail.total) : '-' },
       ]
     );
   });
 
   const serviceTable = [
     {
-      table: { body: serviceTableBody, widths: ['*', 'auto', 'auto', 'auto'] },
+      table: { body: billDetailsTableBody, widths: ['*', 'auto', 'auto', 'auto'] },
       margin: [0, 40, 0, 8],
       layout: { vLineWidth: () => 0.5, hLineWidth: () => 0.5 },
     },

--- a/src/data/pdf/billing/bill.js
+++ b/src/data/pdf/billing/bill.js
@@ -1,5 +1,6 @@
 const { BILL } = require('../../../helpers/constants');
 const UtilsPdfHelper = require('./utils');
+const UtilsHelper = require('../../../helpers/utils');
 
 exports.getPdfContent = async (data) => {
   const { bill } = data;
@@ -17,7 +18,7 @@ exports.getPdfContent = async (data) => {
   bill.formattedSubs.forEach((sub) => {
     serviceTableBody.push(
       [
-        { text: `${sub.name} (TVA ${sub.vat ? sub.vat.toString().replace(/\./g, ',') : 0} %)` },
+        { text: `${sub.name} ${sub.vat ? `(TVA ${UtilsHelper.formatPercentage(sub.vat / 100)})` : ''}` },
         { text: sub.unitInclTaxes || '-' },
         { text: sub.volume || '-' },
         { text: `${sub.total}` },

--- a/src/helpers/bills.js
+++ b/src/helpers/bills.js
@@ -260,23 +260,38 @@ exports.getUnitInclTaxes = (bill, subscription) => {
 exports.formatBillSubscriptionsForPdf = (bill) => {
   let totalExclTaxes = 0;
   let totalVAT = 0;
+  let formattedVolume;
+  let formattedUnitPrice;
+
+  const formatVolume = volume => parseFloat(volume.replace(' h', '').replace(',', '.'), 10);
+  const formatUnitPrice = price => parseFloat(price.replace(',', '.').substring(0, 5), 10);
+  const formatTotalTTC = total => total.toFixed(2).toString().replace('.', ',');
+
   const formattedSubs = [];
 
   for (const sub of bill.subscriptions) {
     totalExclTaxes += sub.exclTaxes;
     totalVAT += sub.inclTaxes - sub.exclTaxes;
+
     const formattedSub = {
       unitInclTaxes: UtilsHelper.formatPrice(exports.getUnitInclTaxes(bill, sub)),
-      inclTaxes: UtilsHelper.formatPrice(sub.inclTaxes),
       vat: sub.vat ? sub.vat.toString().replace(/\./g, ',') : 0,
-      service: sub.service.name,
+      name: sub.service.name,
     };
+
     if (sub.service.nature === HOURLY) {
       const formattedHours = UtilsHelper.formatFloatForExport(sub.hours);
       formattedSub.volume = formattedHours === '' ? '' : `${formattedHours} h`;
     } else {
       formattedSub.volume = sub.events.length;
     }
+
+    if (typeof formattedSub.volume === 'string') formattedVolume = formatVolume(formattedSub.volume);
+    else formattedVolume = formattedSub.volume;
+    formattedUnitPrice = formatUnitPrice(formattedSub.unitInclTaxes);
+
+    formattedSub.total = formattedVolume * formattedUnitPrice;
+    formattedSub.total = formatTotalTTC(formattedSub.total);
     formattedSubs.push(formattedSub);
   }
 

--- a/src/helpers/bills.js
+++ b/src/helpers/bills.js
@@ -299,7 +299,7 @@ exports.formatBillDetailsForPdf = (bill) => {
     totalSurcharge += exports.computeSurcharge(sub);
   }
 
-  if (totalDiscount) formattedDetails.push({ name: 'Remises', total: totalDiscount });
+  if (totalDiscount) formattedDetails.push({ name: 'Remises', total: -totalDiscount });
   if (totalSurcharge) formattedDetails.push({ name: 'Majorations', total: totalSurcharge });
   totalExclTaxes = UtilsHelper.formatPrice(totalExclTaxes);
   totalVAT = UtilsHelper.formatPrice(totalVAT);

--- a/src/helpers/bills.js
+++ b/src/helpers/bills.js
@@ -293,7 +293,7 @@ exports.formatBillSubscriptionsForPdf = (bill) => {
       unitInclTaxes,
       vat: sub.vat ? sub.vat : 0,
       name: sub.service.name,
-      volume,
+      volume: sub.service.nature === HOURLY ? UtilsHelper.formatHour(volume) : volume,
       total: volume * unitInclTaxes,
     });
     totalSurcharge += exports.computeSurcharge(sub);

--- a/src/helpers/bills.js
+++ b/src/helpers/bills.js
@@ -291,7 +291,7 @@ exports.formatBillDetailsForPdf = (bill) => {
 
     formattedDetails.push({
       unitInclTaxes,
-      vat: sub.vat ? sub.vat : 0,
+      vat: sub.vat || 0,
       name: sub.service.name,
       volume: sub.service.nature === HOURLY ? UtilsHelper.formatHour(volume) : volume,
       total: volume * unitInclTaxes,

--- a/src/helpers/bills.js
+++ b/src/helpers/bills.js
@@ -274,13 +274,13 @@ exports.computeSurcharge = (subscription) => {
   return totalSurcharge;
 };
 
-exports.formatBillSubscriptionsForPdf = (bill) => {
+exports.formatBillDetailsForPdf = (bill) => {
   let totalExclTaxes = 0;
   let totalVAT = 0;
   let totalDiscount = 0;
   let totalSurcharge = 0;
 
-  const formattedSubs = [];
+  const formattedDetails = [];
 
   for (const sub of bill.subscriptions) {
     totalExclTaxes += sub.exclTaxes;
@@ -289,7 +289,7 @@ exports.formatBillSubscriptionsForPdf = (bill) => {
     const volume = sub.service.nature === HOURLY ? sub.hours : sub.events.length;
     const unitInclTaxes = exports.getUnitInclTaxes(bill, sub);
 
-    formattedSubs.push({
+    formattedDetails.push({
       unitInclTaxes,
       vat: sub.vat ? sub.vat : 0,
       name: sub.service.name,
@@ -299,12 +299,12 @@ exports.formatBillSubscriptionsForPdf = (bill) => {
     totalSurcharge += exports.computeSurcharge(sub);
   }
 
-  if (totalDiscount) formattedSubs.push({ name: 'Remises', total: totalDiscount });
-  if (totalSurcharge) formattedSubs.push({ name: 'Majorations', total: totalSurcharge });
+  if (totalDiscount) formattedDetails.push({ name: 'Remises', total: totalDiscount });
+  if (totalSurcharge) formattedDetails.push({ name: 'Majorations', total: totalSurcharge });
   totalExclTaxes = UtilsHelper.formatPrice(totalExclTaxes);
   totalVAT = UtilsHelper.formatPrice(totalVAT);
 
-  return { totalExclTaxes, totalVAT, formattedSubs };
+  return { totalExclTaxes, totalVAT, formattedDetails };
 };
 
 exports.formatEventsForPdf = (events, service) => {
@@ -342,7 +342,7 @@ exports.formatPdf = (bill, company) => {
         : UtilsHelper.formatIdentity(bill.customer.identity, 'TFL'),
     },
     forTpp: !!bill.thirdPartyPayer,
-    ...exports.formatBillSubscriptionsForPdf(bill),
+    ...exports.formatBillDetailsForPdf(bill),
   };
 
   for (const sub of bill.subscriptions) {

--- a/tests/unit/data/bill.test.js
+++ b/tests/unit/data/bill.test.js
@@ -1,17 +1,24 @@
 const sinon = require('sinon');
 const expect = require('expect');
 const FileHelper = require('../../../src/helpers/file');
+const UtilsHelper = require('../../../src/helpers/utils');
 const Bill = require('../../../src/data/pdf/billing/bill');
 
 describe('getPdfContent', () => {
   let downloadImages;
+  let formatPrice;
+  let formatPercentage;
 
   beforeEach(() => {
     downloadImages = sinon.stub(FileHelper, 'downloadImages');
+    formatPrice = sinon.stub(UtilsHelper, 'formatPrice');
+    formatPercentage = sinon.stub(UtilsHelper, 'formatPercentage');
   });
 
   afterEach(() => {
     downloadImages.restore();
+    formatPrice.restore();
+    formatPercentage.restore();
   });
 
   it('it should format and return pdf content', async () => {
@@ -67,13 +74,17 @@ describe('getPdfContent', () => {
         forTpp: false,
         totalExclTaxes: '322,52 €',
         totalVAT: '17,74 €',
-        formattedSubs: [{
-          unitInclTaxes: '19,67 €',
-          inclTaxes: '1 160,53 €',
-          vat: '5,5',
-          service: 'Temps de qualité - autonomie',
-          volume: '55,50 h',
-        }],
+        formattedDetails: [
+          {
+            unitInclTaxes: 19.67,
+            vat: 5.5,
+            name: 'Temps de qualité - autonomie',
+            volume: '55,50 h',
+            total: 1091.685,
+          },
+          { name: 'Remises', total: 5 },
+          { name: 'Majorations', total: 12.24 },
+        ],
         company: {
           rcs: '814 998 779',
           address: {
@@ -117,16 +128,28 @@ describe('getPdfContent', () => {
           table: {
             body: [
               [
-                { text: 'Service', bold: true },
+                { text: 'Intitulé', bold: true },
                 { text: 'Prix unitaire TTC', bold: true },
                 { text: 'Volume', bold: true },
-                { text: 'Total TTC*', bold: true },
+                { text: 'Total TTC', bold: true },
               ],
               [
-                { text: 'Temps de qualité - autonomie (TVA 5,5 %)' },
-                { text: '19,67 €' },
+                { text: 'Temps de qualité - autonomie (TVA 5,50 %)' },
+                { text: '19,67 €' },
                 { text: '55,50 h' },
-                { text: '1 160,53 €' },
+                { text: '1091,69 €' },
+              ],
+              [
+                { text: 'Remises' },
+                { text: '-' },
+                { text: '-' },
+                { text: '5,00 €' },
+              ],
+              [
+                { text: 'Majorations' },
+                { text: '-' },
+                { text: '-' },
+                { text: '12,24 €' },
               ],
             ],
             widths: ['*', 'auto', 'auto', 'auto'],
@@ -134,7 +157,6 @@ describe('getPdfContent', () => {
           margin: [0, 40, 0, 8],
           layout: { hLineWidth: () => 0.5, vLineWidth: () => 0.5 },
         },
-        { text: '*ce total intègre les financements, majorations et éventuelles remises.' },
         {
           columns: [
             { width: '*', text: '' },
@@ -198,6 +220,11 @@ describe('getPdfContent', () => {
     ];
 
     downloadImages.returns(paths);
+    formatPrice.onCall(0).returns('19,67 €');
+    formatPrice.onCall(1).returns('1091,69 €');
+    formatPrice.onCall(2).returns('5,00 €');
+    formatPrice.onCall(3).returns('12,24 €');
+    formatPercentage.onCall(0).returns('5,50 %');
 
     const result = await Bill.getPdfContent(data);
 

--- a/tests/unit/helpers/bills.test.js
+++ b/tests/unit/helpers/bills.test.js
@@ -1926,7 +1926,7 @@ describe('formatBillDetailsForPdf', () => {
         hours: 0,
         exclTaxes: 20.3,
         inclTaxes: 22,
-        events: [{ startDate: '2019-09-15T05:00:00.000+00:00', endDate: '2019-09-15T05:00:00.000+00:00'}],
+        events: [{ startDate: '2019-09-15T05:00:00.000+00:00', endDate: '2019-09-15T05:00:00.000+00:00' }],
       }],
     };
 

--- a/tests/unit/helpers/bills.test.js
+++ b/tests/unit/helpers/bills.test.js
@@ -1846,7 +1846,7 @@ describe('computeSurcharge', () => {
     expect(totalSurcharge).toEqual(7.646875);
   });
 
-  it('should not compute totalSurcharges if there are note surcharges in a subscription', () => {
+  it('should not compute totalSurcharges if there is no surcharge in a subscription', () => {
     const subscription = {
       unitInclTaxes: 24.47,
       vat: 5.5,

--- a/tests/unit/helpers/bills.test.js
+++ b/tests/unit/helpers/bills.test.js
@@ -1803,85 +1803,236 @@ describe('getUnitInclTaxes', () => {
   });
 });
 
-describe('formatBillSubscriptionsForPdf', () => {
+describe('computeSurcharge', () => {
+  it('should compute surcharges on an entire event', () => {
+    const subscription = {
+      unitInclTaxes: 24.47,
+      vat: 5.5,
+      service: { name: 'Temps de qualité - autonomie', nature: 'hourly' },
+      events: [{
+        _id: new ObjectID(),
+        startDate: '2019-09-15T05:00:00.000+00:00',
+        endDate: '2019-09-15T07:00:00.000+00:00',
+        surcharges: [{ _id: new ObjectID(), percentage: 25, name: 'Dimanche' }],
+      }],
+    };
+
+    const totalSurcharge = BillHelper.computeSurcharge(subscription);
+
+    expect(totalSurcharge).toEqual(12.235);
+  });
+
+  it('should compute surcharges on a part of an event', () => {
+    const subscription = {
+      unitInclTaxes: 24.47,
+      vat: 5.5,
+      service: { name: 'Temps de qualité - autonomie', nature: 'hourly' },
+      events: [{
+        _id: new ObjectID(),
+        startDate: '2019-09-15T19:00:00.000+00:00',
+        endDate: '2019-09-15T21:15:00.000+00:00',
+        surcharges: [{
+          _id: new ObjectID(),
+          startHour: '2019-09-15T20:00:00.000+00:00',
+          endHour: '2019-09-15T21:15:00.000+00:00',
+          percentage: 25,
+          name: 'Soirée',
+        }],
+      }],
+    };
+
+    const totalSurcharge = BillHelper.computeSurcharge(subscription);
+
+    expect(totalSurcharge).toEqual(7.646875);
+  });
+
+  it('should not compute totalSurcharges if there are note surcharges in a subscription', () => {
+    const subscription = {
+      unitInclTaxes: 24.47,
+      vat: 5.5,
+      service: { name: 'Temps de qualité - autonomie', nature: 'hourly' },
+      events: [{
+        _id: new ObjectID(),
+        startDate: '2019-09-15T05:00:00.000+00:00',
+        endDate: '2019-09-15T07:00:00.000+00:00',
+      }],
+    };
+
+    const totalSurcharge = BillHelper.computeSurcharge(subscription);
+
+    expect(totalSurcharge).toEqual(0);
+  });
+});
+
+describe('formatBillDetailsForPdf', () => {
   let getUnitInclTaxes;
+  let computeSurcharge;
   let formatPrice;
+  let formatHour;
   beforeEach(() => {
-    formatPrice = sinon.stub(UtilsHelper, 'formatPrice');
     getUnitInclTaxes = sinon.stub(BillHelper, 'getUnitInclTaxes');
+    computeSurcharge = sinon.stub(BillHelper, 'computeSurcharge');
+    formatPrice = sinon.stub(UtilsHelper, 'formatPrice');
+    formatHour = sinon.stub(UtilsHelper, 'formatHour');
   });
   afterEach(() => {
     getUnitInclTaxes.restore();
+    computeSurcharge.restore();
     formatPrice.restore();
-    getUnitInclTaxes.restore();
+    formatHour.restore();
   });
 
-  it('should return formatted subscriptions', () => {
-    getUnitInclTaxes.returns('24.63');
-    formatPrice.onCall(0).returns('24,64 €');
-    formatPrice.onCall(1).returns('1 074,00 €');
-    formatPrice.onCall(2).returns('1 018,01 €');
-    formatPrice.onCall(3).returns('55,99 €');
-
+  it('should return formatted details if service.nature is hourly', () => {
     const bill = {
       subscriptions: [{
-        events: [{}],
-        unitInclTaxes: 24.644549763033176,
+        unitInclTaxes: 24.47,
         vat: 5.5,
-        hours: 40,
-        exclTaxes: 1018.009,
-        inclTaxes: 1074,
         service: { name: 'Temps de qualité - autonomie', nature: 'hourly' },
+        hours: 18,
+        exclTaxes: 430.5444,
+        inclTaxes: 454.2243,
       }],
     };
 
-    const formattedBillSubscriptions = BillHelper.formatBillSubscriptionsForPdf(bill);
+    getUnitInclTaxes.returns(24.47);
+    formatHour.onCall(0).returns('18,00 h');
+    computeSurcharge.returns(0);
+    formatPrice.onCall(0).returns('430,54 €');
+    formatPrice.onCall(1).returns('23,68 €');
 
-    expect(formattedBillSubscriptions).toEqual({
-      formattedSubs: [{
-        vat: '5,5',
-        volume: '40,00 h',
-        inclTaxes: '1 074,00 €',
-        service: 'Temps de qualité - autonomie',
-        unitInclTaxes: '24,64 €',
+    const formattedBillDetails = BillHelper.formatBillDetailsForPdf(bill);
+
+    expect(formattedBillDetails).toEqual({
+      formattedDetails: [{
+        unitInclTaxes: 24.47,
+        vat: 5.5,
+        name: 'Temps de qualité - autonomie',
+        volume: '18,00 h',
+        total: 440.46,
       }],
-      totalExclTaxes: '1 018,01 €',
-      totalVAT: '55,99 €',
+      totalExclTaxes: '430,54 €',
+      totalVAT: '23,68 €',
     });
+
+    sinon.assert.calledOnceWithExactly(computeSurcharge, bill.subscriptions[0]);
   });
 
-  it('should return formatted subscriptions for fixed service', () => {
-    getUnitInclTaxes.returns('24.63');
-    formatPrice.onCall(0).returns('24,64 €');
-    formatPrice.onCall(1).returns('1 074,00 €');
-    formatPrice.onCall(2).returns('1 018,01 €');
-    formatPrice.onCall(3).returns('55,99 €');
-
+  it('should return formatted details if service.nature is fixed', () => {
     const bill = {
       subscriptions: [{
-        events: [{ id: '1234' }],
-        unitInclTaxes: 24.644549763033176,
+        unitInclTaxes: 22,
         vat: 5.5,
-        hours: 40,
-        exclTaxes: 1018.009,
-        inclTaxes: 1074,
-        service: { name: 'forfait nuit', nature: 'fixed' },
+        service: { name: 'Forfait nuit', nature: 'fixed' },
+        hours: 0,
+        exclTaxes: 20.3,
+        inclTaxes: 22,
+        events: [{ startDate: '2019-09-15T05:00:00.000+00:00', endDate: '2019-09-15T05:00:00.000+00:00'}],
       }],
     };
 
-    const formattedBillSubscriptions = BillHelper.formatBillSubscriptionsForPdf(bill);
+    getUnitInclTaxes.returns(22);
+    computeSurcharge.returns(0);
+    formatPrice.onCall(0).returns('20,30 €');
+    formatPrice.onCall(1).returns('1,70 €');
 
-    expect(formattedBillSubscriptions).toEqual({
-      formattedSubs: [{
-        vat: '5,5',
+    const formattedBillDetails = BillHelper.formatBillDetailsForPdf(bill);
+
+    expect(formattedBillDetails).toEqual({
+      formattedDetails: [{
+        unitInclTaxes: 22,
+        vat: 5.5,
+        name: 'Forfait nuit',
         volume: 1,
-        inclTaxes: '1 074,00 €',
-        service: 'forfait nuit',
-        unitInclTaxes: '24,64 €',
+        total: 22,
       }],
-      totalExclTaxes: '1 018,01 €',
-      totalVAT: '55,99 €',
+      totalExclTaxes: '20,30 €',
+      totalVAT: '1,70 €',
     });
+
+    sinon.assert.calledOnceWithExactly(computeSurcharge, bill.subscriptions[0]);
+    sinon.assert.notCalled(formatHour);
+  });
+
+  it('should return formatted details if customer has discounts', () => {
+    const bill = {
+      subscriptions: [{
+        unitInclTaxes: 24.47,
+        vat: 5.5,
+        service: { name: 'Temps de qualité - autonomie', nature: 'hourly' },
+        hours: 18,
+        exclTaxes: 430.5444,
+        inclTaxes: 454.2243,
+        discount: 5,
+      }],
+    };
+
+    getUnitInclTaxes.returns(24.47);
+    formatHour.onCall(0).returns('18,00 h');
+    computeSurcharge.returns(0);
+    formatPrice.onCall(0).returns('430,54 €');
+    formatPrice.onCall(1).returns('23,68 €');
+
+    const formattedBillDetails = BillHelper.formatBillDetailsForPdf(bill);
+
+    expect(formattedBillDetails).toEqual({
+      formattedDetails: [
+        {
+          unitInclTaxes: 24.47,
+          vat: 5.5,
+          name: 'Temps de qualité - autonomie',
+          volume: '18,00 h',
+          total: 440.46,
+        },
+        { name: 'Remises', total: 5 },
+      ],
+      totalExclTaxes: '430,54 €',
+      totalVAT: '23,68 €',
+    });
+
+    sinon.assert.calledOnceWithExactly(computeSurcharge, bill.subscriptions[0]);
+  });
+  it('should return formatted details if there are surcharged interventions', () => {
+    const bill = {
+      subscriptions: [{
+        unitInclTaxes: 24.47,
+        vat: 5.5,
+        service: { name: 'Temps de qualité - autonomie', nature: 'hourly' },
+        hours: 18,
+        exclTaxes: 430.5444,
+        inclTaxes: 454.2243,
+        events: [{
+          _id: new ObjectID(),
+          startDate: '2019-09-15T05:00:00.000+00:00',
+          endDate: '2019-09-15T07:00:00.000+00:00',
+          surcharges: [{ _id: new ObjectID(), percentage: 25, name: 'Dimanche' }],
+        }],
+      }],
+    };
+
+    getUnitInclTaxes.returns(24.47);
+    formatHour.onCall(0).returns('18,00 h');
+    computeSurcharge.returns(12.24);
+    formatPrice.onCall(0).returns('430,54 €');
+    formatPrice.onCall(1).returns('23,68 €');
+
+    const formattedBillDetails = BillHelper.formatBillDetailsForPdf(bill);
+
+    expect(formattedBillDetails).toEqual({
+      formattedDetails: [
+        {
+          unitInclTaxes: 24.47,
+          vat: 5.5,
+          name: 'Temps de qualité - autonomie',
+          volume: '18,00 h',
+          total: 440.46,
+        },
+        { name: 'Majorations', total: 12.24 },
+      ],
+      totalExclTaxes: '430,54 €',
+      totalVAT: '23,68 €',
+    });
+
+    sinon.assert.calledOnceWithExactly(computeSurcharge, bill.subscriptions[0]);
   });
 });
 
@@ -1926,22 +2077,22 @@ describe('formatEventsForPdf', () => {
 
 describe('formatPdf', () => {
   let formatEventsForPdf;
-  let formatBillSubscriptionsForPdf;
+  let formatBillDetailsForPdf;
   let formatIdentity;
   beforeEach(() => {
     formatEventsForPdf = sinon.stub(BillHelper, 'formatEventsForPdf');
-    formatBillSubscriptionsForPdf = sinon.stub(BillHelper, 'formatBillSubscriptionsForPdf');
+    formatBillDetailsForPdf = sinon.stub(BillHelper, 'formatBillDetailsForPdf');
     formatIdentity = sinon.stub(UtilsHelper, 'formatIdentity');
     formatEventsForPdf.returns(['hello']);
   });
   afterEach(() => {
     formatEventsForPdf.restore();
-    formatBillSubscriptionsForPdf.restore();
+    formatBillDetailsForPdf.restore();
     formatIdentity.restore();
   });
 
   it('should format correct bill pdf for customer', () => {
-    formatBillSubscriptionsForPdf.returns({
+    formatBillDetailsForPdf.returns({
       formattedSubs: [{ vat: '5,5' }],
       totalExclTaxes: '1 018,01 €',
       totalVAT: '55,99 €',
@@ -2013,7 +2164,7 @@ describe('formatPdf', () => {
   });
 
   it('should format correct bill pdf for third party payer', () => {
-    formatBillSubscriptionsForPdf.returns({
+    formatBillDetailsForPdf.returns({
       formattedSubs: [{ vat: '5,5' }],
       totalExclTaxes: '1 018,01 €',
       totalVAT: '55,99 €',

--- a/tests/unit/helpers/bills.test.js
+++ b/tests/unit/helpers/bills.test.js
@@ -1962,7 +1962,7 @@ describe('formatBillDetailsForPdf', () => {
         hours: 18,
         exclTaxes: 430.5444,
         inclTaxes: 454.2243,
-        discount: 5,
+        discount: -5,
       }],
     };
 


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations : -np
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [ ] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES -np
- Si mes changements impactent l'application formation :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- Si mes changements impactent l'application erp :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME -np
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV -np
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : client

- Périmetre roles : coach/ aidant

- Cas d'usage : lorsque je telecharge une facture, le nouveau template est visible: detail des souscriptions, remises et majorations (si il y en a ). La partie sur le détail du montant prix en charge par le tiers payeur n'est pas traite dans cette PR
