### PR TITLE
Com 2332

### DIFF
--- a/src/data/pdf/billing/bill.js
+++ b/src/data/pdf/billing/bill.js
@@ -2,6 +2,8 @@ const { BILL, AUTOMATIC } = require('../../../helpers/constants');
 const UtilsPdfHelper = require('./utils');
 const UtilsHelper = require('../../../helpers/utils');
 
+const formatBillingPrice = price => (price === 0 || price ? UtilsHelper.formatPrice(price) : '-');
+
 exports.getPdfContent = async (data) => {
   const { bill } = data;
   const header = await UtilsPdfHelper.getHeader(bill.company, bill, BILL);
@@ -19,9 +21,9 @@ exports.getPdfContent = async (data) => {
     billDetailsTableBody.push(
       [
         { text: `${detail.name}${detail.vat ? ` (TVA ${UtilsHelper.formatPercentage(detail.vat / 100)})` : ''}` },
-        { text: detail.unitInclTaxes ? UtilsHelper.formatPrice(detail.unitInclTaxes) : '-' },
+        { text: formatBillingPrice(detail.unitInclTaxes) },
         { text: detail.volume || '-' },
-        { text: detail.total ? UtilsHelper.formatPrice(detail.total) : '-' },
+        { text: formatBillingPrice(detail.total) },
       ]
     );
   });

--- a/src/data/pdf/billing/bill.js
+++ b/src/data/pdf/billing/bill.js
@@ -37,7 +37,9 @@ exports.getPdfContent = async (data) => {
   const priceTable = UtilsPdfHelper.getPriceTable(bill);
   const eventsTable = UtilsPdfHelper.getEventsTable(bill, !bill.forTpp);
 
-  const content = [header, serviceTable, priceTable, eventsTable];
+  const content = bill.type === 'automatic'
+    ? [header, serviceTable, priceTable, eventsTable]
+    : [header, serviceTable, priceTable];
 
   return {
     content: content.flat(),

--- a/src/data/pdf/billing/bill.js
+++ b/src/data/pdf/billing/bill.js
@@ -1,4 +1,4 @@
-const { BILL } = require('../../../helpers/constants');
+const { BILL, AUTOMATIC } = require('../../../helpers/constants');
 const UtilsPdfHelper = require('./utils');
 const UtilsHelper = require('../../../helpers/utils');
 
@@ -37,7 +37,7 @@ exports.getPdfContent = async (data) => {
   const priceTable = UtilsPdfHelper.getPriceTable(bill);
   const eventsTable = UtilsPdfHelper.getEventsTable(bill, !bill.forTpp);
 
-  const content = bill.type === 'automatic'
+  const content = bill.type === AUTOMATIC
     ? [header, serviceTable, priceTable, eventsTable]
     : [header, serviceTable, priceTable];
 

--- a/src/helpers/bills.js
+++ b/src/helpers/bills.js
@@ -299,8 +299,23 @@ exports.formatBillDetailsForPdf = (bill) => {
     totalSurcharge += exports.computeSurcharge(sub);
   }
 
-  if (totalDiscount) formattedDetails.push({ name: 'Remises', total: -totalDiscount });
   if (totalSurcharge) formattedDetails.push({ name: 'Majorations', total: totalSurcharge });
+
+  if (bill.billingItemList) {
+    for (const bi of bill.billingItemList) {
+      totalExclTaxes += bi.exclTaxes;
+      totalVAT += bi.inclTaxes - bi.exclTaxes;
+
+      formattedDetails.push({
+        name: bi.name,
+        unitInclTaxes: bi.unitInclTaxes,
+        volume: bi.count,
+        total: bi.inclTaxes,
+      });
+    }
+  }
+
+  if (totalDiscount) formattedDetails.push({ name: 'Remises', total: -totalDiscount });
   totalExclTaxes = UtilsHelper.formatPrice(totalExclTaxes);
   totalVAT = UtilsHelper.formatPrice(totalVAT);
 
@@ -352,6 +367,7 @@ exports.formatPdf = (bill, company) => {
 
   return {
     bill: {
+      type: bill.type,
       number: bill.number,
       customer: {
         identity: { ...get(bill, 'customer.identity'), title: CIVILITY_LIST[get(bill, 'customer.identity.title')] },

--- a/src/helpers/bills.js
+++ b/src/helpers/bills.js
@@ -306,12 +306,7 @@ exports.formatBillDetailsForPdf = (bill) => {
       totalExclTaxes += bi.exclTaxes;
       totalVAT += bi.inclTaxes - bi.exclTaxes;
 
-      formattedDetails.push({
-        name: bi.name,
-        unitInclTaxes: bi.unitInclTaxes,
-        volume: bi.count,
-        total: bi.inclTaxes,
-      });
+      formattedDetails.push({ name: bi.name, unitInclTaxes: bi.unitInclTaxes, volume: bi.count, total: bi.inclTaxes });
     }
   }
 

--- a/tests/unit/data/bill.test.js
+++ b/tests/unit/data/bill.test.js
@@ -272,6 +272,7 @@ describe('getPdfContent', () => {
         formattedDetails: [
           { name: 'Frais de dossier', unitInclTaxes: 30, volume: 1, total: 30, vat: 20 },
           { name: 'Equipement de protection individuel', unitInclTaxes: 2, volume: 5, total: 10, vat: 20 },
+          { name: 'Article offert', unitInclTaxes: 0, volume: 5, total: 0, vat: 20 },
         ],
         company: {
           rcs: '814 998 779',
@@ -333,6 +334,12 @@ describe('getPdfContent', () => {
                 { text: 5 },
                 { text: '10,00 €' },
               ],
+              [
+                { text: 'Article offert (TVA 20 %)' },
+                { text: '0,00 €' },
+                { text: 5 },
+                { text: '0,00 €' },
+              ],
             ],
             widths: ['*', 'auto', 'auto', 'auto'],
           },
@@ -372,8 +379,11 @@ describe('getPdfContent', () => {
     formatPrice.onCall(1).returns('30,00 €');
     formatPrice.onCall(2).returns('2,00 €');
     formatPrice.onCall(3).returns('10,00 €');
+    formatPrice.onCall(4).returns('0,00 €');
+    formatPrice.onCall(5).returns('0,00 €');
     formatPercentage.onCall(0).returns('20 %');
     formatPercentage.onCall(1).returns('20 %');
+    formatPercentage.onCall(2).returns('20 %');
 
     const result = await Bill.getPdfContent(data);
 

--- a/tests/unit/data/bill.test.js
+++ b/tests/unit/data/bill.test.js
@@ -21,7 +21,7 @@ describe('getPdfContent', () => {
     formatPercentage.restore();
   });
 
-  it('it should format and return pdf content', async () => {
+  it('it should format and return pdf content with eventsTable details', async () => {
     const paths = ['src/data/pdf/tmp/logo.png'];
 
     const formattedEvents = [
@@ -45,6 +45,7 @@ describe('getPdfContent', () => {
     const data = {
       bill: {
         number: 'FACT-101042100271',
+        type: 'automatic',
         customer: {
           identity: { title: 'mr', lastname: 'TERIEUR', firstname: 'Alain' },
           contact: {
@@ -225,6 +226,154 @@ describe('getPdfContent', () => {
     formatPrice.onCall(2).returns('5,00 €');
     formatPrice.onCall(3).returns('12,24 €');
     formatPercentage.onCall(0).returns('5,50 %');
+
+    const result = await Bill.getPdfContent(data);
+
+    expect(JSON.stringify(result)).toEqual(JSON.stringify(pdf));
+    sinon.assert.calledOnceWithExactly(downloadImages, imageList);
+  });
+
+  it('it should format and return pdf content without eventsTable details', async () => {
+    const paths = ['src/data/pdf/tmp/logo.png'];
+
+    const data = {
+      bill: {
+        number: 'FACT-101042100271',
+        type: 'manual',
+        customer: {
+          identity: { title: 'mr', lastname: 'TERIEUR', firstname: 'Alain' },
+          contact: {
+            primaryAddress: {
+              fullAddress: '124 Avenue Daumesnil 75012 Paris',
+              street: '124 Avenue Daumesnil',
+              city: 'Paris',
+              zipCode: '75012',
+            },
+            accessCodes: 'au fond du Kawaa',
+            phone: '',
+            others: '',
+          },
+        },
+        netInclTaxes: '40,00 €',
+        date: '30/04/2021',
+        formattedEvents: [],
+        recipient: {
+          address: {
+            fullAddress: '124 Avenue Daumesnil 75012 Paris',
+            street: '124 Avenue Daumesnil',
+            city: 'Paris',
+            zipCode: '75012',
+          },
+          name: 'M. Alain TERIEUR',
+        },
+        forTpp: false,
+        totalExclTaxes: '35,61 €',
+        totalVAT: '4,39 €',
+        formattedDetails: [
+          { name: 'Frais de dossier', unitInclTaxes: 30, volume: 1, total: 30, vat: 20 },
+          { name: 'Equipement de protection individuel', unitInclTaxes: 2, volume: 5, total: 10, vat: 20 },
+        ],
+        company: {
+          rcs: '814 998 779',
+          address: {
+            city: 'Paris',
+            fullAddress: '24 Avenue Daumesnil 75012 Paris',
+            street: '24 Avenue Daumesnil',
+            zipCode: '75012',
+          },
+          logo: 'https://storage.googleapis.com/compani-main/alenvi_logo_183x50.png',
+          name: 'Alenvi Home SAS',
+        },
+      },
+
+    };
+
+    const pdf = {
+      content: [
+        {
+          columns: [
+            [
+              { image: paths[0], fit: [160, 40], margin: [0, 0, 0, 40] },
+              { text: 'Alenvi Home SAS' },
+              { text: '24 Avenue Daumesnil' },
+              { text: '75012 Paris' },
+              { text: 'RCS : 814 998 779' },
+              { text: '' },
+            ],
+            [
+              { text: 'Facture', alignment: 'right' },
+              { text: 'FACT-101042100271', alignment: 'right' },
+              { text: '30/04/2021', alignment: 'right' },
+              { text: 'Paiement à réception', alignment: 'right', marginBottom: 20 },
+              { text: 'M. Alain TERIEUR', alignment: 'right' },
+              { text: '124 Avenue Daumesnil', alignment: 'right' },
+              { text: '75012 Paris', alignment: 'right' },
+            ],
+          ],
+          marginBottom: 20,
+        },
+        {
+          table: {
+            body: [
+              [
+                { text: 'Intitulé', bold: true },
+                { text: 'Prix unitaire TTC', bold: true },
+                { text: 'Volume', bold: true },
+                { text: 'Total TTC', bold: true },
+              ],
+              [
+                { text: 'Frais de dossier (TVA 20 %)' },
+                { text: '30,00 €' },
+                { text: 1 },
+                { text: '30,00 €' },
+              ],
+              [
+                { text: 'Equipement de protection individuel (TVA 20 %)' },
+                { text: '2,00 €' },
+                { text: 5 },
+                { text: '10,00 €' },
+              ],
+            ],
+            widths: ['*', 'auto', 'auto', 'auto'],
+          },
+          margin: [0, 40, 0, 8],
+          layout: { hLineWidth: () => 0.5, vLineWidth: () => 0.5 },
+        },
+        {
+          columns: [
+            { width: '*', text: '' },
+            {
+              table: {
+                body: [
+                  [{ text: 'Total HT', bold: true }, { text: 'TVA', bold: true }, { text: 'Total TTC', bold: true }],
+                  [
+                    { text: '35,61 €', style: 'marginRightLarge' },
+                    { text: '4,39 €', style: 'marginRightLarge' },
+                    { text: '40,00 €', style: 'marginRightLarge' },
+                  ],
+                ],
+              },
+              width: 'auto',
+              margin: [0, 8, 0, 40],
+              layout: { hLineWidth: () => 0.5, vLineWidth: () => 0.5 },
+            },
+          ],
+        },
+      ],
+      defaultStyle: { font: 'SourceSans', fontSize: 12 },
+      styles: { marginRightLarge: { marginRight: 40 } },
+    };
+    const imageList = [
+      { url: 'https://storage.googleapis.com/compani-main/alenvi_logo_183x50.png', name: 'logo.png' },
+    ];
+
+    downloadImages.returns(paths);
+    formatPrice.onCall(0).returns('30,00 €');
+    formatPrice.onCall(1).returns('30,00 €');
+    formatPrice.onCall(2).returns('2,00 €');
+    formatPrice.onCall(3).returns('10,00 €');
+    formatPercentage.onCall(0).returns('20 %');
+    formatPercentage.onCall(1).returns('20 %');
 
     const result = await Bill.getPdfContent(data);
 

--- a/tests/unit/helpers/bills.test.js
+++ b/tests/unit/helpers/bills.test.js
@@ -2034,6 +2034,39 @@ describe('formatBillDetailsForPdf', () => {
 
     sinon.assert.calledOnceWithExactly(computeSurcharge, bill.subscriptions[0]);
   });
+
+  it('should return formatted details if there are billItems #tag', () => {
+    const bill = {
+      _id: new ObjectID(),
+      origin: 'compani',
+      type: 'manual',
+      billingItemList: [
+        { name: 'Frais de dossier', unitInclTaxes: 30, count: 1, inclTaxes: 30, exclTaxes: 27.27272727272727 },
+        {
+          name: 'Equipement de protection individuel',
+          unitInclTaxes: 2,
+          count: 5,
+          inclTaxes: 10,
+          exclTaxes: 8.333333333333334,
+        },
+      ],
+      subscriptions: [],
+    };
+
+    formatPrice.onCall(0).returns('35,61 €');
+    formatPrice.onCall(1).returns('4,45 €');
+
+    const formattedBillDetails = BillHelper.formatBillDetailsForPdf(bill);
+
+    expect(formattedBillDetails).toEqual({
+      formattedDetails: [
+        { name: 'Frais de dossier', unitInclTaxes: 30, volume: 1, total: 30 },
+        { name: 'Equipement de protection individuel', unitInclTaxes: 2, volume: 5, total: 10 },
+      ],
+      totalExclTaxes: '35,61 €',
+      totalVAT: '4,45 €',
+    });
+  });
 });
 
 describe('formatEventsForPdf', () => {

--- a/tests/unit/helpers/bills.test.js
+++ b/tests/unit/helpers/bills.test.js
@@ -2035,7 +2035,7 @@ describe('formatBillDetailsForPdf', () => {
     sinon.assert.calledOnceWithExactly(computeSurcharge, bill.subscriptions[0]);
   });
 
-  it('should return formatted details if there are billItems #tag', () => {
+  it('should return formatted details if there are billingItems', () => {
     const bill = {
       _id: new ObjectID(),
       origin: 'compani',

--- a/tests/unit/helpers/bills.test.js
+++ b/tests/unit/helpers/bills.test.js
@@ -2041,13 +2041,13 @@ describe('formatBillDetailsForPdf', () => {
       origin: 'compani',
       type: 'manual',
       billingItemList: [
-        { name: 'Frais de dossier', unitInclTaxes: 30, count: 1, inclTaxes: 30, exclTaxes: 27.27272727272727 },
+        { name: 'Frais de dossier', unitInclTaxes: 30, count: 1, inclTaxes: 30, exclTaxes: 27.27 },
         {
           name: 'Equipement de protection individuel',
           unitInclTaxes: 2,
           count: 5,
           inclTaxes: 10,
-          exclTaxes: 8.333333333333334,
+          exclTaxes: 8.33,
         },
       ],
       subscriptions: [],


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations : -np
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [ ] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES -np
- Si mes changements impactent l'application formation :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- Si mes changements impactent l'application erp :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME -np
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES -np
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV -np
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : client

- Périmetre roles : coach/aidant 

- Cas d'usage : 
      - ETQ coach, depuis la page profile du beneficiaire, je peux telecharger une facture manuelle
      - ETQ aidant, depuis la page facturation, je peux télécharger une facture manuelle

Vérifier l'affichage d'une facture automatique ( par exemple pour un beneficiaire ayant plusieurs souscriptions) 
