### PR TITLE
Com 2337

### DIFF
--- a/src/data/pdf/attendanceSheet/interAttendanceSheet.js
+++ b/src/data/pdf/attendanceSheet/interAttendanceSheet.js
@@ -35,11 +35,11 @@ exports.getPdfContent = async (data) => {
         { text: 'Signature de l\'intervenant(e)', style: 'header' },
       ],
     ];
-    trainee.course.slots.forEach((slot) => { body.push(getSlotTableContent(slot)); });
+    trainee.course.slots.forEach(slot => body.push(getSlotTableContent(slot)));
 
-    const table = [{ table: { body, widths: ['auto', 'auto', '*', '*'] }, marginBottom: 8 }];
+    const table = [{ table: { body, widths: ['auto', 'auto', '*', '*'], dontBreakRows: true }, marginBottom: 8 }];
 
-    const footer = UtilsPdfHelper.getFooter(i === trainees.length - 1, signature, 96);
+    const footer = UtilsPdfHelper.getFooter(i === trainees.length - 1, signature, 140);
 
     content.push(header, table, footer);
   });

--- a/src/data/pdf/attendanceSheet/interAttendanceSheet.js
+++ b/src/data/pdf/attendanceSheet/interAttendanceSheet.js
@@ -39,7 +39,7 @@ exports.getPdfContent = async (data) => {
 
     const table = [{ table: { body, widths: ['auto', 'auto', '*', '*'], dontBreakRows: true }, marginBottom: 8 }];
 
-    const footer = UtilsPdfHelper.getFooter(i === trainees.length - 1, signature, 140);
+    const footer = UtilsPdfHelper.getFooter(i === trainees.length - 1, signature, 144);
 
     content.push(header, table, footer);
   });

--- a/src/data/pdf/attendanceSheet/interAttendanceSheet.js
+++ b/src/data/pdf/attendanceSheet/interAttendanceSheet.js
@@ -39,7 +39,7 @@ exports.getPdfContent = async (data) => {
 
     const table = [{ table: { body, widths: ['auto', 'auto', '*', '*'], dontBreakRows: true }, marginBottom: 8 }];
 
-    const footer = UtilsPdfHelper.getFooter(i === trainees.length - 1, signature, 144);
+    const footer = UtilsPdfHelper.getFooter(i === trainees.length - 1, signature);
 
     content.push(header, table, footer);
   });

--- a/src/data/pdf/attendanceSheet/intraAttendanceSheet.js
+++ b/src/data/pdf/attendanceSheet/intraAttendanceSheet.js
@@ -38,7 +38,7 @@ exports.getPdfContent = async (data) => {
       marginBottom: 8,
     }];
 
-    const footer = UtilsPdfHelper.getFooter(i === dates.length - 1, signature, 140);
+    const footer = UtilsPdfHelper.getFooter(i === dates.length - 1, signature, 144);
 
     content.push(header, table, footer);
   });

--- a/src/data/pdf/attendanceSheet/intraAttendanceSheet.js
+++ b/src/data/pdf/attendanceSheet/intraAttendanceSheet.js
@@ -22,7 +22,7 @@ exports.getPdfContent = async (data) => {
 
     const body = [[{ text: 'Prénom NOM', style: 'header' }]];
     date.slots.forEach(slot => body[0].push({ text: `${slot.startHour} - ${slot.endHour}`, style: 'header' }));
-    const numberOfRows = 13;
+    const numberOfRows = 11;
     for (let row = 1; row <= numberOfRows; row++) {
       body.push([]);
       for (let column = 0; column <= date.slots.length; column++) {
@@ -38,7 +38,7 @@ exports.getPdfContent = async (data) => {
       marginBottom: 8,
     }];
 
-    const footer = UtilsPdfHelper.getFooter(i === dates.length - 1, signature, 80);
+    const footer = UtilsPdfHelper.getFooter(i === dates.length - 1, signature, 140);
 
     content.push(header, table, footer);
   });

--- a/src/data/pdf/attendanceSheet/intraAttendanceSheet.js
+++ b/src/data/pdf/attendanceSheet/intraAttendanceSheet.js
@@ -38,7 +38,7 @@ exports.getPdfContent = async (data) => {
       marginBottom: 8,
     }];
 
-    const footer = UtilsPdfHelper.getFooter(i === dates.length - 1, signature, 144);
+    const footer = UtilsPdfHelper.getFooter(i === dates.length - 1, signature);
 
     content.push(header, table, footer);
   });

--- a/src/data/pdf/attendanceSheet/utils.js
+++ b/src/data/pdf/attendanceSheet/utils.js
@@ -33,13 +33,13 @@ exports.getHeader = (compani, conscience, title, columns) => [
   },
 ];
 
-exports.getFooter = (pageBreak, signature, width) => [
+exports.getFooter = (pageBreak, signature) => [
   {
     columns: [
       { text: 'Signature et tampon de l\'organisme de formation :', bold: true },
       {
         image: signature,
-        width,
+        width: 144,
         marginTop: 8,
         alignment: 'right',
       },

--- a/src/data/pdf/attendanceSheet/utils.js
+++ b/src/data/pdf/attendanceSheet/utils.js
@@ -40,10 +40,11 @@ exports.getFooter = (pageBreak, signature, width) => [
       {
         image: signature,
         width,
-        pageBreak: pageBreak ? 'none' : 'after',
         marginTop: 8,
         alignment: 'right',
       },
     ],
+    pageBreak: pageBreak ? 'none' : 'after',
+    unbreakable: true,
   },
 ];

--- a/tests/unit/data/interAttendanceSheet.test.js
+++ b/tests/unit/data/interAttendanceSheet.test.js
@@ -106,7 +106,7 @@ describe('getPdfContent', () => {
         {
           columns: [
             { text: 'Signature et tampon de l\'organisme de formation :', bold: true },
-            { image: paths[3], width: 140, marginTop: 8, alignment: 'right' },
+            { image: paths[3], width: 144, marginTop: 8, alignment: 'right' },
           ],
           unbreakable: true,
           pageBreak: 'after',
@@ -142,7 +142,7 @@ describe('getPdfContent', () => {
         {
           columns: [
             { text: 'Signature et tampon de l\'organisme de formation :', bold: true },
-            { image: paths[3], width: 140, marginTop: 8, alignment: 'right' },
+            { image: paths[3], width: 144, marginTop: 8, alignment: 'right' },
           ],
           pageBreak: 'none',
           unbreakable: true,

--- a/tests/unit/data/interAttendanceSheet.test.js
+++ b/tests/unit/data/interAttendanceSheet.test.js
@@ -106,8 +106,10 @@ describe('getPdfContent', () => {
         {
           columns: [
             { text: 'Signature et tampon de l\'organisme de formation :', bold: true },
-            { image: paths[3], width: 96, pageBreak: 'after', marginTop: 8, alignment: 'right' },
+            { image: paths[3], width: 140, marginTop: 8, alignment: 'right' },
           ],
+          unbreakable: true,
+          pageBreak: 'after',
         },
         {
           columns: [
@@ -140,8 +142,10 @@ describe('getPdfContent', () => {
         {
           columns: [
             { text: 'Signature et tampon de l\'organisme de formation :', bold: true },
-            { image: paths[3], width: 96, pageBreak: 'none', marginTop: 8, alignment: 'right' },
+            { image: paths[3], width: 140, marginTop: 8, alignment: 'right' },
           ],
+          pageBreak: 'none',
+          unbreakable: true,
         },
       ],
       defaultStyle: { font: 'SourceSans', fontSize: 10 },

--- a/tests/unit/data/intraAttendanceSheet.test.js
+++ b/tests/unit/data/intraAttendanceSheet.test.js
@@ -56,8 +56,6 @@ describe('getPdfContent', () => {
         [{ text: '' }, { text: '' }],
         [{ text: '' }, { text: '' }],
         [{ text: '' }, { text: '' }],
-        [{ text: '' }, { text: '' }],
-        [{ text: '' }, { text: '' }],
         [{ text: 'Signature de l\'intervenant(e)', italics: true, margin: [0, 8, 0, 0] }, { text: '' }],
       ],
       widths: ['*', '*'],
@@ -93,10 +91,14 @@ describe('getPdfContent', () => {
           margin: [16, 0, 24, 16],
         },
         { table, marginBottom: 8 },
-        { columns: [
-          { text: 'Signature et tampon de l\'organisme de formation :', bold: true },
-          { image: paths[3], width: 80, pageBreak: 'after', marginTop: 8, alignment: 'right' },
-        ] },
+        {
+          columns: [
+            { text: 'Signature et tampon de l\'organisme de formation :', bold: true },
+            { image: paths[3], width: 140, marginTop: 8, alignment: 'right' },
+          ],
+          pageBreak: 'after',
+          unbreakable: true,
+        },
         {
           columns: [
             { image: paths[0], width: 64 },
@@ -125,10 +127,14 @@ describe('getPdfContent', () => {
           margin: [16, 0, 24, 16],
         },
         { table, marginBottom: 8 },
-        { columns: [
-          { text: 'Signature et tampon de l\'organisme de formation :', bold: true },
-          { image: paths[3], width: 80, pageBreak: 'none', marginTop: 8, alignment: 'right' },
-        ] },
+        {
+          columns: [
+            { text: 'Signature et tampon de l\'organisme de formation :', bold: true },
+            { image: paths[3], width: 140, marginTop: 8, alignment: 'right' },
+          ],
+          pageBreak: 'none',
+          unbreakable: true,
+        },
       ],
       defaultStyle: { font: 'SourceSans', fontSize: 10 },
       styles: {

--- a/tests/unit/data/intraAttendanceSheet.test.js
+++ b/tests/unit/data/intraAttendanceSheet.test.js
@@ -94,7 +94,7 @@ describe('getPdfContent', () => {
         {
           columns: [
             { text: 'Signature et tampon de l\'organisme de formation :', bold: true },
-            { image: paths[3], width: 140, marginTop: 8, alignment: 'right' },
+            { image: paths[3], width: 144, marginTop: 8, alignment: 'right' },
           ],
           pageBreak: 'after',
           unbreakable: true,
@@ -130,7 +130,7 @@ describe('getPdfContent', () => {
         {
           columns: [
             { text: 'Signature et tampon de l\'organisme de formation :', bold: true },
-            { image: paths[3], width: 140, marginTop: 8, alignment: 'right' },
+            { image: paths[3], width: 144, marginTop: 8, alignment: 'right' },
           ],
           pageBreak: 'none',
           unbreakable: true,


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations :
  - ~Ce n'est pas une ancienne route utilisée par les apps mobiles~
      - [ ] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### ~FONCTIONNALITÉS APPS MOBILES~
- Si mes changements impactent l'application formation:
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- Si mes changements impactent l'application erp :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### ~MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME~
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### ~MODIFICATIONS SUR LES MODÈLES~
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### ~CONSTANTES ET VARIABLE D'ENV~
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : vendeur formation

- Périmetre roles : admin

- Cas d'usage : Les feuilles d'emargement intra ont une plus grosse signature et 10 lignes pour les stagiaires. Les feuilles d'emargement inter ont une plus grosse signature et si il y a trop de créneaux (plus que 15) le footer apparait sur la page suivante
