### PR TITLE
COM-2330 - Add TPP to bill pdf

### DIFF
--- a/tests/unit/helpers/bills.test.js
+++ b/tests/unit/helpers/bills.test.js
@@ -2106,7 +2106,7 @@ describe('formatBillDetailsForPdf', () => {
         service: { name: 'Temps de qualité - autonomie', nature: 'hourly' },
         hours: 18,
         exclTaxes: 430.5444,
-        inclTaxes: 454.2243,
+        inclTaxes: 440.46,
         discount: 0,
       }],
     };
@@ -2144,7 +2144,7 @@ describe('formatBillDetailsForPdf', () => {
         hours: 0,
         exclTaxes: 20.3,
         inclTaxes: 22,
-        discount: -5,
+        discount: 5,
         events: [{
           _id: new ObjectID(),
           startDate: '2019-09-15T05:00:00.000+00:00',
@@ -2153,13 +2153,14 @@ describe('formatBillDetailsForPdf', () => {
         }],
       }],
       billingItemList: [
-        { name: 'Frais de dossier', unitInclTaxes: 30, count: 1, inclTaxes: 30, exclTaxes: 27.27 },
+        { name: 'Frais de dossier', unitInclTaxes: 30, count: 1, inclTaxes: 30, exclTaxes: 27.27, discount: 10 },
         {
           name: 'Equipement de protection individuel',
           unitInclTaxes: 2,
           count: 5,
           inclTaxes: 10,
           exclTaxes: 8.33,
+          discount: 0,
         },
       ],
     };
@@ -2177,8 +2178,8 @@ describe('formatBillDetailsForPdf', () => {
         { name: 'Majorations', total: 12.24 },
         { name: 'Frais de dossier', unitInclTaxes: 30, volume: 1, total: 30 },
         { name: 'Equipement de protection individuel', unitInclTaxes: 2, volume: 5, total: 10 },
-        { name: 'Remises', total: 5 },
-        { name: 'Participation du/des tier(s) payeur(s)', total: -29.24 },
+        { name: 'Remises', total: -15 },
+        { name: 'Prise en charge du/des tiers(s) payeur(s)', total: -9.240000000000002 },
       ],
       totalExclTaxes: '20,30 €',
       totalVAT: '1,70 €',


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- ~~Tests intégrations~~:
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [ ] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### ~~FONCTIONNALITÉS APPS MOBILES~~
- Si mes changements impactent l'application formation :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- Si mes changements impactent l'application erp :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### ~~MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME~~
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### ~~MODIFICATIONS SUR LES MODÈLES~~
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### ~~CONSTANTES ET VARIABLE D'ENV~~
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : client

- Périmetre roles : admin / bénéficiaire

- Cas d'usage : 
Sur les factures où le tier payeur a payé une partie des frais, je vois une ligne décrivant le montant payé

Comment tester : 
- Tester sur un bénéficiaire sans tier payeur -> je ne vois pas la ligne
- Tester sur un bénéficiaire avec tier payeur -> je vois pas la ligne