### PR TITLE
COM-2324: fix bug when create media card

### DIFF
--- a/src/models/Card.js
+++ b/src/models/Card.js
@@ -101,10 +101,10 @@ function save(next) {
         if (!this.isMandatory) this.isMandatory = false;
         break;
       case TEXT_MEDIA:
-        if (!this.media) this.media = { type: UPLOAD_IMAGE };
+        if (!this.media.type) this.media = { type: UPLOAD_IMAGE };
         break;
       case TITLE_TEXT_MEDIA:
-        if (!this.media) this.media = { type: UPLOAD_IMAGE };
+        if (!this.media.type) this.media = { type: UPLOAD_IMAGE };
         break;
       case OPEN_QUESTION:
         if (!this.isMandatory) this.isMandatory = false;


### PR DESCRIPTION
### TESTS
- [ ] Mon code est testé unitairement -np

- Tests intégrations : -np
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [ ] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES
- ~~Si mes changements impactent l'application formation :~~
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- ~~Si mes changements impactent l'application erp :~~
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME -np
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES
- ~~J'ai ajouté un modèle spécifique à une structure:~~
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - ~~J'ai ajouté un champ possible :~~
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - ~~J'ai rendu obligatoire un champs :~~
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - ~~J'ai retiré un champ possible :~~
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV
- ~~J'ai changé une constante :~~
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- ~~J'ai ajouté une variable d'environnement :~~
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : vendeur

- Périmetre roles : rof/admin

- Cas d'usage : je peux créer des cartes title text media et text media dans une activité


Le bug était dû au fait que media est défini comme nested path ( => https://mongoosejs.com/docs/subdocs.html#subdocuments-versus-nested-paths) et que par conséquent, media est défini sous forme de {} quoiqu'il arrive (à l'inverse de qcAnswers par exemple qui est en Subdoc et qui par défaut est à undefined). 
Pour résumer, un nested n'a jamais d'enfant undefined : on peut toujours setter les petits enfants même quand les enfants ne sont pas définis. Mais un Subdoc peut avoir un enfant undefined.
La question est donc de savoir Subdoc ou Nested ? je serais d'avis que, pour les propriété d'un modèle, si elle ne servent qu'une fois comme media/qcAnswers, on utilise plutôt Nested que Subdoc qui est un peu overkill (et qui rajoute un id par défaut). A voir du coup par la suite pour faire une PR pour passer les Subdoc pas utiles en Nested. 
Pour ce qui est de la structure enregistrée en base, les deux sont identiques, c'est purement de la forme.