### PR TITLE
COM-2357 docxtemplater new syntaxe

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1168,11 +1168,11 @@
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
     },
     "axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.22.0.tgz",
+      "integrity": "sha512-Z0U3uhqQeg1oNcihswf4ZD57O3NrR1+ZXhxaROaWpDmsDTx7T2HNBV2ulBtie2hwJptu8UvgnJoK+BIqdzh/1w==",
       "requires": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.14.4"
       }
     },
     "babel-runtime": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1944,15 +1944,9 @@
       }
     },
     "es-abstract": {
-<<<<<<< HEAD
-      "version": "1.18.7",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.7.tgz",
-      "integrity": "sha512-uFG1gyVX91tZIiDWNmPsL8XNpiCk/6tkB7MZphoSJflS4w+KgWyQ2gjCVDnsPxFAo9WjRXG3eqONNYdfbJjAtw==",
-=======
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.0.tgz",
       "integrity": "sha512-oWPrF+7P1nGv/rw9oIInwdkmI1qediEJSvVfHFryBd8mWllCKB5tke3aKyf51J6chgyKmi6mODqdnin2yb88Nw==",
->>>>>>> cb6e1e6a (COM-2357 rm -rf)
       "requires": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1696,9 +1696,9 @@
       "integrity": "sha512-5uAPmiO5tlztgaJrAy8eQCbsVrvYap12JGQEULi7HtLFRML65Jrop74ylHsA6OrqzcEyd6b9WQRIG/kvNzqC8g=="
     },
     "date-holidays": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/date-holidays/-/date-holidays-3.9.0.tgz",
-      "integrity": "sha512-JTNHHlJLnc+IxY0HyZEnoAJEZLq6IT6nA4DtyxZcrXAhe9OQs4VVRvTPVwyf8BvL1tzSB1Pq5Dxl0GNWSr0HGw==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/date-holidays/-/date-holidays-3.9.1.tgz",
+      "integrity": "sha512-A5h8wWNfDNG8l4oiAxKOpz0jokLI/gyfg8BRw/hNBAVffxj1EYHSLWk5UB8bv/WEDgGhMwcY5fWcwqu27cmWQQ==",
       "requires": {
         "date-holidays-parser": "^3.2.2",
         "js-yaml": "^4.1.0",
@@ -1944,9 +1944,15 @@
       }
     },
     "es-abstract": {
+<<<<<<< HEAD
       "version": "1.18.7",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.7.tgz",
       "integrity": "sha512-uFG1gyVX91tZIiDWNmPsL8XNpiCk/6tkB7MZphoSJflS4w+KgWyQ2gjCVDnsPxFAo9WjRXG3eqONNYdfbJjAtw==",
+=======
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.0.tgz",
+      "integrity": "sha512-oWPrF+7P1nGv/rw9oIInwdkmI1qediEJSvVfHFryBd8mWllCKB5tke3aKyf51J6chgyKmi6mODqdnin2yb88Nw==",
+>>>>>>> cb6e1e6a (COM-2357 rm -rf)
       "requires": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
@@ -1959,7 +1965,9 @@
         "is-callable": "^1.2.4",
         "is-negative-zero": "^2.0.1",
         "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.1",
         "is-string": "^1.0.7",
+        "is-weakref": "^1.0.1",
         "object-inspect": "^1.11.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.2",
@@ -3277,6 +3285,11 @@
         "has-tostringtag": "^1.0.0"
       }
     },
+    "is-shared-array-buffer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
+      "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA=="
+    },
     "is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -3320,6 +3333,14 @@
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
       "dev": true
+    },
+    "is-weakref": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.1.tgz",
+      "integrity": "sha512-b2jKc2pQZjaeFYWEf7ScFj+Be1I+PXmlu572Q8coTXZ+LD/QQZ7ShPMst8h16riVgyXTQwUsFEl74mDvc/3MHQ==",
+      "requires": {
+        "call-bind": "^1.0.0"
+      }
     },
     "isarray": {
       "version": "1.0.0",
@@ -5503,17 +5524,17 @@
       }
     },
     "table": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/table/-/table-6.7.1.tgz",
-      "integrity": "sha512-ZGum47Yi6KOOFDE8m223td53ath2enHcYLgOCjGr5ngu8bdIARQk6mN/wRMv4yMRcHnCSnHbCEha4sobQx5yWg==",
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.7.2.tgz",
+      "integrity": "sha512-UFZK67uvyNivLeQbVtkiUs8Uuuxv24aSL4/Vil2PJVtMgU8Lx0CYkP12uCGa3kjyQzOSgV1+z9Wkb82fCGsO0g==",
       "dev": true,
       "requires": {
         "ajv": "^8.0.1",
         "lodash.clonedeep": "^4.5.0",
         "lodash.truncate": "^4.4.2",
         "slice-ansi": "^4.0.0",
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0"
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
       },
       "dependencies": {
         "ajv": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@hapi/good-squeeze": "^6.0.0",
     "@hapi/hapi": "^20.1.3",
     "@hapi/inert": "^6.0.4",
-    "axios": "^0.21.4",
+    "axios": "^0.22.0",
     "bcrypt": "^5.0.1",
     "bignumber.js": "^9.0.1",
     "cron": "^1.7.2",

--- a/src/helpers/docx.js
+++ b/src/helpers/docx.js
@@ -15,7 +15,8 @@ const docxParser = tag => ({
   },
 });
 
-exports.createDocxTemplater = (zip, data) => {
+exports.createDocxTemplater = (file, data) => {
+  const zip = new PizZip(file);
   const docxTemplater = new DocxTemplater(zip, { parser: docxParser, linebreaks: true });
   docxTemplater.render(data);
 
@@ -24,8 +25,7 @@ exports.createDocxTemplater = (zip, data) => {
 
 exports.createDocx = async (filePath, data) => {
   const file = await fsPromises.readFile(filePath, 'binary');
-  const zip = new PizZip(file);
-  const doc = exports.createDocxTemplater(zip, data);
+  const doc = exports.createDocxTemplater(file, data);
   const filledZip = doc.getZip().generate({ type: 'nodebuffer' });
   const date = new Date();
   const tmpOutputPath = path.join(os.tmpdir(), `template-filled-${date.getTime()}.docx`);

--- a/src/helpers/docx.js
+++ b/src/helpers/docx.js
@@ -15,14 +15,17 @@ const docxParser = tag => ({
   },
 });
 
+exports.createDocxTemplater = (zip, data) => {
+  const docxTemplater = new DocxTemplater(zip, { parser: docxParser, linebreaks: true });
+  docxTemplater.render(data);
+
+  return docxTemplater;
+};
+
 exports.createDocx = async (filePath, data) => {
   const file = await fsPromises.readFile(filePath, 'binary');
   const zip = new PizZip(file);
-  const doc = new DocxTemplater();
-  doc.loadZip(zip);
-  doc.setOptions({ parser: docxParser, linebreaks: true });
-  doc.setData(data);
-  doc.render();
+  const doc = exports.createDocxTemplater(zip, data);
   const filledZip = doc.getZip().generate({ type: 'nodebuffer' });
   const date = new Date();
   const tmpOutputPath = path.join(os.tmpdir(), `template-filled-${date.getTime()}.docx`);

--- a/tests/unit/helpers/docx.test.js
+++ b/tests/unit/helpers/docx.test.js
@@ -30,10 +30,7 @@ describe('generateDocx', () => {
 describe('createDocx', () => {
   it('should return filled docx template path', async () => {
     sinon.createStubInstance(PizZip);
-    const loadZipStub = sinon.stub(DocxTemplater.prototype, 'loadZip');
-    const setOptionsStub = sinon.stub(DocxTemplater.prototype, 'setOptions');
-    const setDataStub = sinon.stub(DocxTemplater.prototype, 'setData');
-    const renderStub = sinon.stub(DocxTemplater.prototype, 'render');
+    const createDocxStub = sinon.stub(DocxHelper, 'createDocxTemplater').returns(new DocxTemplater());
     const generateStub = sinon.stub().returns('This is a filled zip file');
     const getZipStub = sinon.stub(DocxTemplater.prototype, 'getZip').returns({ generate: generateStub });
     const readFileStub = sinon.stub(fs.promises, 'readFile');
@@ -48,17 +45,10 @@ describe('createDocx', () => {
 
     expect(result).toBe(outputPath);
     sinon.assert.calledWithExactly(readFileStub, filePath, 'binary');
-    sinon.assert.calledOnce(loadZipStub);
-    sinon.assert.calledWithExactly(setOptionsStub, { parser: sinon.match.func, linebreaks: true });
-    sinon.assert.calledWithExactly(setDataStub, data);
-    sinon.assert.calledOnce(renderStub);
+    sinon.assert.calledOnce(createDocxStub);
     sinon.assert.calledOnce(getZipStub);
     sinon.assert.calledWithExactly(generateStub, { type: 'nodebuffer' });
     sinon.assert.calledWithExactly(writeFileStub, outputPath, 'This is a filled zip file');
-    loadZipStub.restore();
-    setOptionsStub.restore();
-    setDataStub.restore();
-    renderStub.restore();
     getZipStub.restore();
     readFileStub.restore();
     writeFileStub.restore();

--- a/tests/unit/helpers/docx.test.js
+++ b/tests/unit/helpers/docx.test.js
@@ -3,7 +3,6 @@ const expect = require('expect');
 const path = require('path');
 const os = require('os');
 const fs = require('fs');
-const PizZip = require('pizzip');
 const DocxTemplater = require('docxtemplater');
 const Drive = require('../../../src/models/Google/Drive');
 const DocxHelper = require('../../../src/helpers/docx');
@@ -29,7 +28,6 @@ describe('generateDocx', () => {
 
 describe('createDocx', () => {
   it('should return filled docx template path', async () => {
-    sinon.createStubInstance(PizZip);
     const createDocxStub = sinon.stub(DocxHelper, 'createDocxTemplater').returns(new DocxTemplater());
     const generateStub = sinon.stub().returns('This is a filled zip file');
     const getZipStub = sinon.stub(DocxTemplater.prototype, 'getZip').returns({ generate: generateStub });


### PR DESCRIPTION
nmp outdated :
<img width="439" alt="Capture d’écran 2021-10-01 à 10 33 46" src="https://user-images.githubusercontent.com/47056365/135591335-e4817d8f-d1b3-4585-8169-3203f11a4587.png">
 
Axios s'est rajouté ce matin : 0.21.4  -> 0.22.0 : pas de changement importants. (pas de correction du bug des appels infinis) https://github.com/axios/axios/blob/master/CHANGELOG.md

On  attend d'être sûr.e de nous pour mettre a jour le driver mongo.
La maj de mongoose depend du driver.
La maj de mongoose-autopopulate depend de mongoose.


---
Docxtemplater : 
en ajoutant des arguments au constructeur Docxtemplater, l'exectution du test bloque. Je n'ai pas reussi, a "stuber" l'instance de Docxtemplater (comme pour zippiz). J'ai l'impression que le constructeur de Docxtemplater n'est pas construit comme l'attend sinon.stub. jsp 😕 
J'ai donc séparé l'instanciation et le rendu de docxtemplater a part, pour pouvoir facilement mettre un stub. Qu'en pensez vous ?
