### PR TITLE
COM-2372 add remote step type

### DIFF
--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -308,6 +308,10 @@ module.exports = {
   // STEP
   E_LEARNING: 'e_learning',
   ON_SITE: 'on_site',
+  REMOTE: 'remote',
+  get LIVE_STEPS() {
+    return [this.ON_SITE, this.REMOTE];
+  },
   // ACTIVITY
   LESSON: 'lesson',
   QUIZ: 'quiz',

--- a/src/models/Step.js
+++ b/src/models/Step.js
@@ -1,10 +1,10 @@
 const mongoose = require('mongoose');
 const has = require('lodash/has');
 const mongooseLeanVirtuals = require('mongoose-lean-virtuals');
-const { E_LEARNING, ON_SITE, DRAFT } = require('../helpers/constants');
+const { E_LEARNING, ON_SITE, REMOTE, DRAFT, LIVE_STEPS } = require('../helpers/constants');
 const { STATUS_TYPES } = require('./SubProgram');
 
-const STEP_TYPES = [E_LEARNING, ON_SITE];
+const STEP_TYPES = [E_LEARNING, ON_SITE, REMOTE];
 
 const StepSchema = mongoose.Schema({
   name: { type: String, required: true },
@@ -30,7 +30,7 @@ StepSchema.virtual('courseSlotsCount', {
 // eslint-disable-next-line consistent-return
 function setAreActivitiesValid() {
   const hasActivities = this.activities && this.activities.length !== 0;
-  if (this.type === ON_SITE && !hasActivities) return true;
+  if (LIVE_STEPS.includes(this.type) && !hasActivities) return true;
   if (this.type === E_LEARNING && !hasActivities) return false;
 
   if (this.activities && this.activities.length && has(this.activities[0], 'areCardsValid')) {

--- a/tests/integration/activities.test.js
+++ b/tests/integration/activities.test.js
@@ -33,7 +33,6 @@ describe('ACTIVITIES ROUTES - GET /activity/{_id}', () => {
 
       expect(response.statusCode).toBe(200);
       expect(response.result.data.activity._id).toEqual(activityId);
-      expect(response.result.data.activity.name).toEqual('fumer');
       expect(response.result.data.activity.quizCount).toEqual(2);
     });
   });

--- a/tests/integration/activities.test.js
+++ b/tests/integration/activities.test.js
@@ -17,7 +17,7 @@ describe('NODE ENV', () => {
 describe('ACTIVITIES ROUTES - GET /activity/{_id}', () => {
   let authToken;
   beforeEach(populateDB);
-  const activityId = activitiesList[0]._id;
+  const activityId = activitiesList[2]._id;
 
   describe('Logged user', () => {
     beforeEach(async () => {
@@ -33,6 +33,8 @@ describe('ACTIVITIES ROUTES - GET /activity/{_id}', () => {
 
       expect(response.statusCode).toBe(200);
       expect(response.result.data.activity._id).toEqual(activityId);
+      expect(response.result.data.activity.name).toEqual('fumer');
+      expect(response.result.data.activity.quizCount).toEqual(2);
     });
   });
 });

--- a/tests/integration/programs.test.js
+++ b/tests/integration/programs.test.js
@@ -262,7 +262,7 @@ describe('PROGRAMS ROUTES - GET /programs/{_id}', () => {
       });
 
       expect(response.statusCode).toBe(200);
-      expect(response.result.data.program.subPrograms[0].areStepsValid).toBeTruthy();
+      expect(response.result.data.program.subPrograms[0].isStrictlyELearning).toBeTruthy();
     });
 
     it('should return 404 if program does not exist', async () => {

--- a/tests/integration/programs.test.js
+++ b/tests/integration/programs.test.js
@@ -167,7 +167,7 @@ describe('PROGRAMS ROUTES - GET /programs/{_id}', () => {
       authToken = await getToken('training_organisation_manager');
     });
 
-    it('should get program #tag', async () => {
+    it('should get program not strictly e-learning', async () => {
       const response = await app.inject({
         method: 'GET',
         url: `/programs/${programsList[4]._id}`,
@@ -252,6 +252,17 @@ describe('PROGRAMS ROUTES - GET /programs/{_id}', () => {
           areActivitiesValid: false,
         }),
       ]));
+    });
+
+    it('should return a program strictly e-learning', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/programs/${programsList[2]._id}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.result.data.program.subPrograms[0].areStepsValid).toBeTruthy();
     });
 
     it('should return 404 if program does not exist', async () => {

--- a/tests/integration/programs.test.js
+++ b/tests/integration/programs.test.js
@@ -167,15 +167,91 @@ describe('PROGRAMS ROUTES - GET /programs/{_id}', () => {
       authToken = await getToken('training_organisation_manager');
     });
 
-    it('should get program', async () => {
+    it('should get program #tag', async () => {
       const response = await app.inject({
         method: 'GET',
-        url: `/programs/${programsList[0]._id}`,
+        url: `/programs/${programsList[4]._id}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
       expect(response.statusCode).toBe(200);
-      expect(response.result.data.program._id).toEqual(programsList[0]._id);
+      expect(response.result.data.program._id).toEqual(programsList[4]._id);
+      expect(response.result.data.program.subPrograms[0].areStepsValid).toBeFalsy();
+      expect(response.result.data.program.subPrograms[0].isStrictlyELearning).toBeFalsy();
+      expect(response.result.data.program.subPrograms[0].steps).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          name: 'étape 3 - sans act',
+          type: 'on_site',
+          activities: [],
+          areActivitiesValid: true,
+        }),
+        expect.objectContaining({
+          name: 'étape 4 - tout valide',
+          type: 'on_site',
+          activities: expect.arrayContaining([expect.objectContaining({ name: 'activité 1', areCardsValid: true })]),
+          areActivitiesValid: true,
+        }),
+        expect.objectContaining({
+          name: 'étape 5 - carte non valide',
+          type: 'on_site',
+          activities: expect.arrayContaining([expect.objectContaining({ name: 'activité 2', areCardsValid: false })]),
+          areActivitiesValid: false,
+        }),
+        expect.objectContaining({
+          name: 'étape 6 - sans carte',
+          type: 'on_site',
+          activities: expect.arrayContaining([expect.objectContaining({ name: 'activité 3', areCardsValid: false })]),
+          areActivitiesValid: false,
+        }),
+        expect.objectContaining({
+          name: 'étape 7 - sans act',
+          type: 'e_learning',
+          activities: [],
+          areActivitiesValid: false,
+        }),
+        expect.objectContaining({
+          name: 'étape 8 - tout valide',
+          type: 'e_learning',
+          activities: expect.arrayContaining([expect.objectContaining({ name: 'activité 1', areCardsValid: true })]),
+          areActivitiesValid: true,
+        }),
+        expect.objectContaining({
+          name: 'étape 9 - carte non valide',
+          type: 'e_learning',
+          activities: expect.arrayContaining([expect.objectContaining({ name: 'activité 2', areCardsValid: false })]),
+          areActivitiesValid: false,
+        }),
+        expect.objectContaining({
+          name: 'étape 10 - sans carte',
+          type: 'e_learning',
+          activities: expect.arrayContaining([expect.objectContaining({ name: 'activité 3', areCardsValid: false })]),
+          areActivitiesValid: false,
+        }),
+        expect.objectContaining({
+          name: 'étape 11 - sans act',
+          type: 'remote',
+          activities: [],
+          areActivitiesValid: true,
+        }),
+        expect.objectContaining({
+          name: 'étape 12 - tout valide',
+          type: 'remote',
+          activities: expect.arrayContaining([expect.objectContaining({ name: 'activité 1', areCardsValid: true })]),
+          areActivitiesValid: true,
+        }),
+        expect.objectContaining({
+          name: 'étape 13 - carte non valide',
+          type: 'remote',
+          activities: expect.arrayContaining([expect.objectContaining({ name: 'activité 2', areCardsValid: false })]),
+          areActivitiesValid: false,
+        }),
+        expect.objectContaining({
+          name: 'étape 14 - sans carte',
+          type: 'remote',
+          activities: expect.arrayContaining([expect.objectContaining({ name: 'activité 3', areCardsValid: false })]),
+          areActivitiesValid: false,
+        }),
+      ]));
     });
 
     it('should return 404 if program does not exist', async () => {

--- a/tests/integration/seed/activitiesSeed.js
+++ b/tests/integration/seed/activitiesSeed.js
@@ -4,7 +4,14 @@ const SubProgram = require('../../../src/models/SubProgram');
 const Step = require('../../../src/models/Step');
 const Activity = require('../../../src/models/Activity');
 const Card = require('../../../src/models/Card');
-const { TRANSITION, FLASHCARD, TITLE_TEXT, TITLE_TEXT_MEDIA } = require('../../../src/helpers/constants');
+const {
+  TRANSITION,
+  FLASHCARD,
+  TITLE_TEXT,
+  TITLE_TEXT_MEDIA,
+  FILL_THE_GAPS,
+  ORDER_THE_SEQUENCE,
+} = require('../../../src/helpers/constants');
 const { deleteNonAuthenticationSeeds } = require('../helpers/authentication');
 
 const cardsList = [
@@ -20,6 +27,8 @@ const cardsList = [
   { _id: new ObjectID(), template: FLASHCARD, backText: 'ceci est un backText', text: 'ceci est un text' },
   { _id: new ObjectID(), template: TITLE_TEXT },
   { _id: new ObjectID(), template: TRANSITION },
+  { _id: new ObjectID(), template: FILL_THE_GAPS },
+  { _id: new ObjectID(), template: ORDER_THE_SEQUENCE },
 ];
 
 const activitiesList = [
@@ -31,7 +40,7 @@ const activitiesList = [
     cards: [cardsList[0]._id, cardsList[1]._id, cardsList[2]._id, cardsList[3]._id],
   },
   { _id: new ObjectID(), name: 'bouger', type: 'lesson' },
-  { _id: new ObjectID(), name: 'fumer', type: 'video' },
+  { _id: new ObjectID(), name: 'fumer', type: 'video', cards: [cardsList[0]._id, cardsList[6]._id, cardsList[7]._id] },
   {
     _id: new ObjectID(),
     name: 'publiée',

--- a/tests/integration/seed/programsSeed.js
+++ b/tests/integration/seed/programsSeed.js
@@ -16,8 +16,9 @@ const cards = [
 ];
 
 const activitiesList = [
-  { _id: new ObjectID(), name: 'c\'est une activité', type: 'sharing_experience', cards: [cards[0]._id] },
-  { _id: new ObjectID(), name: 'toujours une activité', type: 'quiz', cards: [cards[1]._id] },
+  { _id: new ObjectID(), name: 'activité 1', type: 'sharing_experience', cards: [cards[0]._id] },
+  { _id: new ObjectID(), name: 'activité 2', type: 'quiz', cards: [cards[1]._id] },
+  { _id: new ObjectID(), name: 'activité 3', type: 'quiz', cards: [] },
 ];
 
 const categoriesList = [
@@ -33,18 +34,46 @@ const stepsList = [
   {
     _id: new ObjectID(),
     type: 'e_learning',
-    name: 'c\'est une étape',
+    name: 'étape 1',
     activities: [activitiesList[0]._id, activitiesList[1]._id],
   },
-  { _id: new ObjectID(), type: 'e_learning', name: 'toujours une étape', activities: [activitiesList[0]._id] },
-  { _id: new ObjectID(), type: 'on_site', name: 'encore une étape', activities: [activitiesList[0]._id] },
-  { _id: new ObjectID(), type: 'on_site', name: 'encore une étape', activities: [activitiesList[1]._id] },
+  { _id: new ObjectID(), type: 'e_learning', name: 'étape 2', activities: [activitiesList[0]._id] },
+  { _id: new ObjectID(), type: 'on_site', name: 'étape 3 - sans act', activities: [] },
+  { _id: new ObjectID(), type: 'on_site', name: 'étape 4 - tout valide', activities: [activitiesList[0]._id] },
+  { _id: new ObjectID(), type: 'on_site', name: 'étape 5 - carte non valide', activities: [activitiesList[1]._id] },
+  { _id: new ObjectID(), type: 'on_site', name: 'étape 6 - sans carte', activities: [activitiesList[2]._id] },
+  { _id: new ObjectID(), type: 'e_learning', name: 'étape 7 - sans act', activities: [] },
+  { _id: new ObjectID(), type: 'e_learning', name: 'étape 8 - tout valide', activities: [activitiesList[0]._id] },
+  { _id: new ObjectID(), type: 'e_learning', name: 'étape 9 - carte non valide', activities: [activitiesList[1]._id] },
+  { _id: new ObjectID(), type: 'e_learning', name: 'étape 10 - sans carte', activities: [activitiesList[2]._id] },
+  { _id: new ObjectID(), type: 'remote', name: 'étape 11 - sans act', activities: [] },
+  { _id: new ObjectID(), type: 'remote', name: 'étape 12 - tout valide', activities: [activitiesList[0]._id] },
+  { _id: new ObjectID(), type: 'remote', name: 'étape 13 - carte non valide', activities: [activitiesList[1]._id] },
+  { _id: new ObjectID(), type: 'remote', name: 'étape 14 - sans carte', activities: [activitiesList[2]._id] },
 ];
 
 const subProgramsList = [
-  { _id: new ObjectID(), name: 'c\'est un sous-programme', steps: [stepsList[2]._id] },
-  { _id: new ObjectID(), name: 'c\'est un sous-programme', steps: [stepsList[3]._id] },
-  { _id: new ObjectID(), name: 'c\'est un sous-programme elearning', steps: [stepsList[1]._id] },
+  { _id: new ObjectID(), name: 'sous-programme 1', steps: [stepsList[2]._id] },
+  { _id: new ObjectID(), name: 'sous-programme 2', steps: [stepsList[3]._id] },
+  { _id: new ObjectID(), name: 'sous-programme 3', steps: [stepsList[1]._id] },
+  {
+    _id: new ObjectID(),
+    name: 'sous-programme 4',
+    steps: [
+      stepsList[2]._id,
+      stepsList[3]._id,
+      stepsList[4]._id,
+      stepsList[5]._id,
+      stepsList[6]._id,
+      stepsList[7]._id,
+      stepsList[8]._id,
+      stepsList[9]._id,
+      stepsList[10]._id,
+      stepsList[11]._id,
+      stepsList[12]._id,
+      stepsList[13]._id,
+    ],
+  },
 ];
 
 const programsList = [
@@ -70,6 +99,7 @@ const programsList = [
     subPrograms: [subProgramsList[2]._id],
   },
   { _id: new ObjectID(), name: 'non valid program', subPrograms: [subProgramsList[1]._id] },
+  { _id: new ObjectID(), name: 'programme a vérifier', subPrograms: [subProgramsList[3]._id] },
 ];
 
 const course = {


### PR DESCRIPTION
### TESTS
- [ ] Mon code est testé unitairement : NON
🟠  A ce propos je me rend compte qu'on ne test pas les virtuals. Est-ce qu'il faudrait le faire ? 
(j'ai testé depuis le navigateur que la pastille orange apparait ou non selon différentes conditions)

- ~Tests intégrations~ :
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [ ] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### ~FONCTIONNALITÉS APPS MOBILES~
- Si mes changements impactent l'application formation :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- Si mes changements impactent l'application erp :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : formation

- Périmetre roles : admin

- Cas d'usage : je peux créer une étape distancielle
