### PR TITLE
Com 2366

### DIFF
--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -455,4 +455,8 @@ module.exports = {
   // NOTES
   NOTE_CREATION: 'note_creation',
   NOTE_UPDATE: 'note_update',
+  // STATUS
+  ACTIVATED: 'Actif',
+  STOPPED: 'Arrêté',
+  ARCHIVED: 'Archivé',
 };

--- a/src/helpers/dataExport.js
+++ b/src/helpers/dataExport.js
@@ -1,6 +1,7 @@
 const moment = require('moment');
 const get = require('lodash/get');
 const has = require('lodash/has');
+const isEmpty = require('lodash/isEmpty');
 const {
   CIVILITY_LIST,
   HELPER,
@@ -10,6 +11,9 @@ const {
   CUSTOMER_SITUATIONS,
   FUNDING_NATURES,
   SERVICE_NATURES,
+  STOPPED,
+  ARCHIVED,
+  ACTIVATED,
 } = require('./constants');
 const UtilsHelper = require('./utils');
 const Customer = require('../models/Customer');
@@ -57,9 +61,18 @@ const customerExportHeader = [
   'Souscriptions',
   'Nombre de financements',
   'Date de création',
+  'Statut',
 ];
 
 const formatIdentity = person => `${person.firstname} ${person.lastname}`;
+
+const getStatus = (customer) => {
+  if (isEmpty(customer)) return '';
+  if (customer.archivedAt) return ARCHIVED;
+  if (customer.stoppedAt) return STOPPED;
+
+  return ACTIVATED;
+};
 
 exports.exportCustomers = async (credentials) => {
   const companyId = get(credentials, 'company._id', null);
@@ -103,6 +116,7 @@ exports.exportCustomers = async (credentials) => {
       subscriptionsCount ? getServicesNameList(cus.subscriptions) : '',
       get(cus, 'fundings.length') || 0,
       cus.createdAt ? moment(cus.createdAt).format('DD/MM/YYYY') : '',
+      getStatus(cus),
     ];
 
     rows.push(cells);
@@ -132,6 +146,7 @@ const auxiliaryExportHeader = [
   'Date de fin de contrat prestataire',
   'Date d\'inactivité',
   'Date de création',
+  'Statut',
 ];
 
 const getDataForAuxiliariesExport = (aux, contractsLength, contract) => {

--- a/src/helpers/translate.js
+++ b/src/helpers/translate.js
@@ -117,7 +117,7 @@ module.exports = {
     customerFundingUpdated: 'Customer funding updated.',
     customerFundingRemoved: 'Customer funding removed.',
     qrCodeCreated: 'QR code created.',
-    archivingNotAllowed: 'Archivage impossible : interventions passées non facturées',
+    archivingNotAllowed: 'Archiving not allowed : customer has non-billed intervention(s)',
     /* Customer notes */
     customerNoteCreated: 'Customer note created.',
     customerNotesFound: 'Customer notes found.',
@@ -451,6 +451,7 @@ module.exports = {
     customerFundingUpdated: 'Financement du/de la bénéficiaire modifié.',
     customerFundingRemoved: 'Financement du/ de la bénéficiaire supprimé.',
     qrCodeCreated: 'QR code créé.',
+    archivingNotAllowed: 'Archivage impossible : interventions passées non facturées',
     /* Customer notes */
     customerNoteCreated: 'Note de suivi créée.',
     customerNotesFound: 'Notes de suivi trouvées.',

--- a/src/helpers/translate.js
+++ b/src/helpers/translate.js
@@ -117,6 +117,7 @@ module.exports = {
     customerFundingUpdated: 'Customer funding updated.',
     customerFundingRemoved: 'Customer funding removed.',
     qrCodeCreated: 'QR code created.',
+    archivingNotAllowed: 'Archivage impossible : interventions passées non facturées',
     /* Customer notes */
     customerNoteCreated: 'Customer note created.',
     customerNotesFound: 'Customer notes found.',

--- a/src/routes/customers.js
+++ b/src/routes/customers.js
@@ -102,9 +102,11 @@ exports.plugin = {
               bic: Joi.string(),
             }).min(1),
             stoppedAt: Joi.date(),
+            archivedAt: Joi.date(),
             stopReason: Joi.string().valid(...STOP_REASONS),
           })
-            .and('stoppedAt', 'stopReason'),
+            .and('stoppedAt', 'stopReason')
+            .oxor('stoppedAt', 'archivedAt'),
         },
         pre: [{ method: authorizeCustomerUpdate }],
       },

--- a/src/routes/preHandlers/customers.js
+++ b/src/routes/preHandlers/customers.js
@@ -71,6 +71,14 @@ exports.authorizeCustomerUpdate = async (req) => {
       );
       if (customer) return Boom.forbidden();
     }
+
+    if (payload.archivedAt) {
+      const customer = await Customer.countDocuments({
+        _id: req.params._id,
+        $or: [{ stoppedAt: { $exists: false } }, { archivedAt: { $exists: true } }],
+      });
+      if (customer) throw Boom.forbidden();
+    }
   }
 
   return null;

--- a/src/routes/preHandlers/customers.js
+++ b/src/routes/preHandlers/customers.js
@@ -79,7 +79,7 @@ exports.authorizeCustomerUpdate = async (req) => {
       });
       if (customer) throw Boom.forbidden();
 
-      const eventsToBill = await Event.countDocuments({ _id: req.params._id, isBilled: false });
+      const eventsToBill = await Event.countDocuments({ customer: req.params._id, isBilled: false });
       if (eventsToBill) throw Boom.forbidden(translate[language].archivingNotAllowed);
     }
   }

--- a/src/routes/preHandlers/customers.js
+++ b/src/routes/preHandlers/customers.js
@@ -78,6 +78,9 @@ exports.authorizeCustomerUpdate = async (req) => {
         $or: [{ stoppedAt: { $exists: false } }, { archivedAt: { $exists: true } }],
       });
       if (customer) throw Boom.forbidden();
+
+      const eventsToBill = await Event.countDocuments({ _id: req.params._id, isBilled: false });
+      if (eventsToBill) throw Boom.forbidden(translate[language].archivingNotAllowed);
     }
   }
 

--- a/tests/integration/customers.test.js
+++ b/tests/integration/customers.test.js
@@ -682,7 +682,7 @@ describe('CUSTOMERS ROUTES', () => {
       });
 
       it('should archive customer', async () => {
-        const customer = customersList[8];
+        const customer = customersList[9];
 
         const res = await app.inject({
           method: 'PUT',
@@ -791,6 +791,32 @@ describe('CUSTOMERS ROUTES', () => {
           method: 'PUT',
           url: `/customers/${customer._id}`,
           payload: { stoppedAt: new Date('2021-05-23'), stopReason: DEATH },
+          headers: { Cookie: `alenvi_token=${authToken}` },
+        });
+
+        expect(res.statusCode).toBe(403);
+      });
+
+      it('should return 403 if user tries to archive a customer before stopping it', async () => {
+        const customer = customersList[10];
+
+        const res = await app.inject({
+          method: 'PUT',
+          url: `/customers/${customer._id}`,
+          payload: { archivedAt: new Date() },
+          headers: { Cookie: `alenvi_token=${authToken}` },
+        });
+
+        expect(res.statusCode).toBe(403);
+      });
+
+      it('should return 403 if user tries to archive a customer who is already archived', async () => {
+        const customer = customersList[11];
+
+        const res = await app.inject({
+          method: 'PUT',
+          url: `/customers/${customer._id}`,
+          payload: { archivedAt: new Date() },
           headers: { Cookie: `alenvi_token=${authToken}` },
         });
 

--- a/tests/integration/customers.test.js
+++ b/tests/integration/customers.test.js
@@ -759,7 +759,6 @@ describe('CUSTOMERS ROUTES', () => {
         expect(res.statusCode).toBe(400);
       });
 
-
       it('should return a 404 error if no customer found', async () => {
         const res = await app.inject({
           method: 'PUT',
@@ -771,7 +770,7 @@ describe('CUSTOMERS ROUTES', () => {
         expect(res.statusCode).toBe(404);
       });
 
-      it('should return 403 if already stop', async () => {
+      it('should return 403 if already stopped', async () => {
         const customer = customersList[9];
 
         const res = await app.inject({
@@ -828,6 +827,17 @@ describe('CUSTOMERS ROUTES', () => {
           method: 'PUT',
           url: `/customers/${otherCompanyCustomer._id}`,
           payload: updatePayload,
+          headers: { Cookie: `alenvi_token=${authToken}` },
+        });
+
+        expect(res.statusCode).toBe(403);
+      });
+
+      it('should return 403 if customer has not billed interventions', async () => {
+        const res = await app.inject({
+          method: 'PUT',
+          url: `/customers/${customersList[9]._id}`,
+          payload: { archivedAt: '2021-01-16T14:30:19' },
           headers: { Cookie: `alenvi_token=${authToken}` },
         });
 

--- a/tests/integration/customers.test.js
+++ b/tests/integration/customers.test.js
@@ -681,15 +681,30 @@ describe('CUSTOMERS ROUTES', () => {
         expect(res.statusCode).toBe(200);
       });
 
-      it('should return a 404 error if no customer found', async () => {
+      it('should archive customer', async () => {
+        const customer = customersList[8];
+
         const res = await app.inject({
           method: 'PUT',
-          url: `/customers/${new ObjectID()}`,
-          payload: updatePayload,
+          url: `/customers/${customer._id}`,
+          payload: { archivedAt: new Date() },
           headers: { Cookie: `alenvi_token=${authToken}` },
         });
 
-        expect(res.statusCode).toBe(404);
+        expect(res.statusCode).toBe(200);
+      });
+
+      it('should return a 400 if there are both archivedAt and stoppedAt in payload', async () => {
+        const customer = customersList[0];
+
+        const res = await app.inject({
+          method: 'PUT',
+          url: `/customers/${customer._id}`,
+          payload: { stoppedAt: new Date(), stopReason: DEATH, archivedAt: new Date() },
+          headers: { Cookie: `alenvi_token=${authToken}` },
+        });
+
+        expect(res.statusCode).toBe(400);
       });
 
       it('should return a 400 error if phone number is invalid', async () => {
@@ -705,7 +720,20 @@ describe('CUSTOMERS ROUTES', () => {
         expect(res.statusCode).toBe(400);
       });
 
-      it('should return a 400 error if missing stopReason or stoppedAt in status update', async () => {
+      it('should return a 400 error if missing stopReason when stoppedAt is in payload', async () => {
+        const customer = customersList[0];
+
+        const res = await app.inject({
+          method: 'PUT',
+          url: `/customers/${customer._id}`,
+          payload: { stoppedAt: new Date() },
+          headers: { Cookie: `alenvi_token=${authToken}` },
+        });
+
+        expect(res.statusCode).toBe(400);
+      });
+
+      it('should return a 400 error if missing stoppedAt when stopReason is in payload', async () => {
         const customer = customersList[0];
 
         const res = await app.inject({
@@ -729,6 +757,18 @@ describe('CUSTOMERS ROUTES', () => {
         });
 
         expect(res.statusCode).toBe(400);
+      });
+
+
+      it('should return a 404 error if no customer found', async () => {
+        const res = await app.inject({
+          method: 'PUT',
+          url: `/customers/${new ObjectID()}`,
+          payload: updatePayload,
+          headers: { Cookie: `alenvi_token=${authToken}` },
+        });
+
+        expect(res.statusCode).toBe(404);
       });
 
       it('should return 403 if already stop', async () => {

--- a/tests/integration/seed/customersSeed.js
+++ b/tests/integration/seed/customersSeed.js
@@ -848,6 +848,23 @@ const eventList = [
       location: { type: 'Point', coordinates: [2.377133, 48.801389] },
     },
   },
+  {
+    _id: new ObjectID(),
+    company: authCompany._id,
+    customer: customersList[9]._id,
+    auxiliary: userList[6]._id,
+    type: 'intervention',
+    subscription: new ObjectID(),
+    startDate: '2019-01-16T14:30:19',
+    endDate: '2019-01-16T15:30:21',
+    address: {
+      fullAddress: '37 rue de ponthieu 75008 Paris',
+      zipCode: '75008',
+      city: 'Paris',
+      street: '37 rue de Ponthieu',
+      location: { type: 'Point', coordinates: [2.377133, 48.801389] },
+    },
+  },
 ];
 
 const helpersList = [

--- a/tests/integration/seed/customersSeed.js
+++ b/tests/integration/seed/customersSeed.js
@@ -414,7 +414,7 @@ const customersList = [
       },
     ],
   },
-  { // 8
+  { // 9
     _id: new ObjectID(),
     company: authCompany._id,
     identity: { title: 'mr', firstname: 'Julian', lastname: 'Alaphilippe' },
@@ -444,6 +444,23 @@ const customersList = [
       },
     },
     createdAt: new Date('2021-05-24'),
+  },
+  { // 11
+    _id: new ObjectID(),
+    company: authCompany._id,
+    identity: { title: 'mr', firstname: 'alex', lastname: 'terieur' },
+    contact: {
+      primaryAddress: {
+        fullAddress: '37 rue de ponthieu 75008 Paris',
+        zipCode: '75008',
+        city: 'Paris',
+        street: '37 rue de Ponthieu',
+        location: { type: 'Point', coordinates: [2.377133, 48.801389] },
+      },
+    },
+    stoppedAt: new Date(),
+    stopReason: DEATH,
+    archivedAt: new Date(),
   },
 ];
 

--- a/tests/integration/seed/customersSeed.js
+++ b/tests/integration/seed/customersSeed.js
@@ -414,7 +414,7 @@ const customersList = [
       },
     ],
   },
-  {
+  { // 8
     _id: new ObjectID(),
     company: authCompany._id,
     identity: { title: 'mr', firstname: 'Julian', lastname: 'Alaphilippe' },

--- a/tests/unit/helpers/dataExport.test.js
+++ b/tests/unit/helpers/dataExport.test.js
@@ -61,6 +61,7 @@ describe('exportCustomers', () => {
       'Souscriptions',
       'Nombre de financements',
       'Date de création',
+      'Statut',
     ]);
     SinonMongoose.calledWithExactly(
       findCustomer,
@@ -139,6 +140,7 @@ describe('exportCustomers', () => {
       'Au service de sa majesté\r\n Service public\r\n Service civique',
       2,
       '12/12/2012',
+      'Actif',
     ]);
     SinonMongoose.calledWithExactly(
       findCustomer,
@@ -167,7 +169,7 @@ describe('exportCustomers', () => {
     expect(result).toBeDefined();
     expect(result[1]).toBeDefined();
     expect(result[1]).toMatchObject([
-      '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', 0, '', 0, '',
+      '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', 0, '', 0, '', '',
     ]);
     SinonMongoose.calledWithExactly(
       findCustomer,


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations : -np
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [ ] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES
- Si mes changements impactent l'application formation :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- Si mes changements impactent l'application erp :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME -np
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES -np
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV -np
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : client

- Périmetre roles : coach/ admin client

- Cas d'usage : Depuis la page profil bénéficiaire, je peux archiver un bénéficiaire arrêté
