### PR TITLE
COM-2368 prevent billing archived customer

### DIFF
--- a/src/routes/preHandlers/bills.js
+++ b/src/routes/preHandlers/bills.js
@@ -108,7 +108,11 @@ exports.authorizeBillCreation = async (req) => {
   const { credentials } = req.auth;
   const companyId = credentials.company._id;
 
-  const customer = await Customer.countDocuments({ _id: req.payload.customer, company: companyId });
+  const customer = await Customer.countDocuments({
+    _id: req.payload.customer,
+    company: companyId,
+    archivedAt: { $eq: null },
+  });
   if (!customer) throw Boom.forbidden();
 
   const billingItemIds = [...new Set(req.payload.billingItemList.map(bi => bi.billingItem))];

--- a/tests/integration/bills.test.js
+++ b/tests/integration/bills.test.js
@@ -935,6 +935,23 @@ describe('BILL ROUTES - POST /bills', () => {
       expect(response.statusCode).toBe(403);
     });
 
+    it('should return a 403 if the customer is archived', async () => {
+      const payload = {
+        customer: billCustomerList[3]._id,
+        date: new Date('2021-09-02T20:00:00'),
+        billingItemList: [{ billingItem: billingItemList[0]._id, unitInclTaxes: 15, count: 2 }],
+        netInclTaxes: 30,
+      };
+      const response = await app.inject({
+        method: 'POST',
+        url: '/bills',
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(403);
+    });
+
     it('should return 409 billNumber is already taken', async () => {
       const formatBillNumber = sinon.stub(BillHelper, 'formatBillNumber');
       formatBillNumber.returns(billList[0].number);

--- a/tests/integration/seed/billsSeed.js
+++ b/tests/integration/seed/billsSeed.js
@@ -197,6 +197,39 @@ const billCustomerList = [
       mandates: [{ rum: 'R014345658903456780', _id: new ObjectID() }],
     },
   },
+  {
+    _id: new ObjectID(),
+    company: authCompany._id,
+    identity: { title: 'mr', firstname: 'Jean', lastname: 'Paul' },
+    contact: {
+      primaryAddress: {
+        fullAddress: '37 rue de ponthieu 75008 Paris',
+        zipCode: '75008',
+        city: 'Paris',
+        street: '37 rue de Ponthieu',
+        location: { type: 'Point', coordinates: [2.377133, 48.801389] },
+      },
+      phone: '0612345678',
+    },
+    subscriptions: [{
+      _id: new ObjectID(),
+      service: billServices[1]._id,
+      versions: [{
+        unitTTCRate: 12,
+        estimatedWeeklyVolume: 12,
+        evenings: 2,
+        sundays: 1,
+        startDate: '2018-01-01T10:00:00.000+01:00',
+      }],
+    }],
+    payment: {
+      bankAccountOwner: 'Roberto Alagna',
+      mandates: [{ rum: 'R014345658903456780', _id: new ObjectID() }],
+    },
+    stoppedAt: '2021-09-01T10:00:00.000+01:00',
+    stopReason: 'death',
+    archivedAt: '2021-10-07T10:00:00.000+01:00',
+  },
 ];
 
 const billUserList = [


### PR DESCRIPTION
### TESTS
- [ ] Mon code est testé unitairement -np

- Tests intégrations :
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [ ] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES
- Si mes changements impactent l'application formation :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- Si mes changements impactent l'application erp :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : client

- Périmetre roles : coach/admin

- Cas d'usage : Je ne peux pas creer de facture manuelle pour un benéficiaire archivé.
- Pour tester la PR:
         - Creer un beneficiaire
         - L'archiver
         - Creer une facture manuelle pour ce beneficiaire --> erreur 
