### PR TITLE
Com 2414

### DIFF
--- a/src/helpers/bills.js
+++ b/src/helpers/bills.js
@@ -72,6 +72,9 @@ exports.formatCustomerBills = (customerBills, customer, number, company) => {
     } else {
       bill.billingItemList.push(exports.formatBillingItemData(draftBill));
       for (const ev of draftBill.eventsList) {
+        if (!billedEvents[ev.event]) {
+          billedEvents[ev.event] = { event: ev.event, exclTaxesCustomer: 0, inclTaxesCustomer: 0 };
+        }
         if (!billedEvents[ev.event].billingItems) billedEvents[ev.event].billingItems = [];
         if (!billedEvents[ev.event].exclTaxesCustomer) billedEvents[ev.event].exclTaxesCustomer = 0;
         if (!billedEvents[ev.event].inclTaxesCustomer) billedEvents[ev.event].inclTaxesCustomer = 0;

--- a/tests/unit/helpers/bills.test.js
+++ b/tests/unit/helpers/bills.test.js
@@ -436,7 +436,7 @@ describe('formatCustomerBills', () => {
     formatBillingItemData.restore();
   });
 
-  it('Case 1 : 1 bill', () => {
+  it('Case 1 : 1 bill with subscription', () => {
     const company = { prefixNumber: 1234, _id: new ObjectID() };
     const customer = { _id: 'lilalo' };
     const number = { prefix: 'Picsou', seq: 77 };
@@ -496,6 +496,67 @@ describe('formatCustomerBills', () => {
     sinon.assert.calledWithExactly(formatBillNumber, 1234, 'Picsou', 77);
     sinon.assert.calledWithExactly(getFixedNumber, 14.4, 2);
     sinon.assert.calledWithExactly(formatSubscriptionData, customerBills.bills[0]);
+    sinon.assert.notCalled(formatBillingItemData);
+  });
+
+  it('Case 1bis : 1 bill with billing items #tag', () => {
+    const company = { prefixNumber: 1234, _id: new ObjectID() };
+    const customer = { _id: 'lilalo' };
+    const number = { prefix: 'Picsou', seq: 77 };
+    const customerBills = {
+      shouldBeSent: true,
+      bills: [{
+        billingItem: { _id: 'biid', name: 'depl' },
+        endDate: '2019-09-19T00:00:00',
+        exclTaxes: 13,
+        eventsList: [
+          { event: '123', startDate: '2019-05-28T10:00:55', endDate: '2019-05-28T13:00:55', auxiliary: '34567890' },
+          { event: '456', startDate: '2019-05-29T08:00:55', endDate: '2019-05-29T10:00:55', auxiliary: '34567890' },
+        ],
+        inclTaxes: 14.4,
+        startDate: '2019-05-31T10:00:55',
+        unitExclTaxes: 24,
+        unitInclTaxes: 30,
+      }],
+      total: 14.4,
+    };
+    formatBillNumber.returns('FACT-1234Picsou00077');
+    getFixedNumber.returns(14.40);
+    formatBillingItemData.returns({ billingItem: 'billingItem' });
+
+    const result = BillHelper.formatCustomerBills(customerBills, customer, number, company);
+
+    expect(result).toBeDefined();
+    expect(result.bill).toBeDefined();
+    expect(result.bill).toEqual({
+      company: company._id,
+      customer: 'lilalo',
+      number: 'FACT-1234Picsou00077',
+      shouldBeSent: true,
+      subscriptions: [],
+      type: 'automatic',
+      netInclTaxes: 14.40,
+      date: '2019-09-19T00:00:00',
+      billingItemList: [{ billingItem: 'billingItem' }],
+    });
+    expect(result.billedEvents).toEqual({
+      123: {
+        event: '123',
+        billingItems: [{ billingItem: 'biid', inclTaxes: 30, exclTaxes: 24 }],
+        exclTaxesCustomer: 24,
+        inclTaxesCustomer: 30,
+      },
+      456: {
+        event: '456',
+        billingItems: [{ billingItem: 'biid', inclTaxes: 30, exclTaxes: 24 }],
+        exclTaxesCustomer: 24,
+        inclTaxesCustomer: 30,
+      },
+    });
+    sinon.assert.calledWithExactly(formatBillNumber, 1234, 'Picsou', 77);
+    sinon.assert.calledWithExactly(getFixedNumber, 14.4, 2);
+    sinon.assert.notCalled(formatSubscriptionData);
+    sinon.assert.calledWithExactly(formatBillingItemData, customerBills.bills[0]);
   });
 
   it('Case 2 : multiple bills', () => {

--- a/tests/unit/helpers/bills.test.js
+++ b/tests/unit/helpers/bills.test.js
@@ -448,20 +448,20 @@ describe('formatCustomerBills', () => {
         unitExclTaxes: 24.644549763033176,
         exclTaxes: 13.649289099526067,
         inclTaxes: 14.4,
-        startDate: '2019-05-31T10:00:55.374Z',
+        startDate: '2019-05-31T10:00:55',
         hours: 1.5,
         eventsList: [
           {
             event: '123',
-            startDate: '2019-05-28T10:00:55.374Z',
-            endDate: '2019-05-28T13:00:55.374Z',
+            startDate: '2019-05-28T10:00:55',
+            endDate: '2019-05-28T13:00:55',
             auxiliary: '34567890',
             inclTaxesTpp: 14.4,
           },
           {
             event: '456',
-            startDate: '2019-05-29T08:00:55.374Z',
-            endDate: '2019-05-29T10:00:55.374Z',
+            startDate: '2019-05-29T08:00:55',
+            endDate: '2019-05-29T10:00:55',
             auxiliary: '34567890',
             inclTaxesTpp: 12,
           },
@@ -476,7 +476,6 @@ describe('formatCustomerBills', () => {
     const result = BillHelper.formatCustomerBills(customerBills, customer, number, company);
 
     expect(result).toBeDefined();
-    expect(result.bill).toBeDefined();
     expect(result.bill).toEqual({
       company: company._id,
       customer: 'lilalo',
@@ -489,17 +488,29 @@ describe('formatCustomerBills', () => {
       billingItemList: [],
     });
     expect(result.billedEvents).toBeDefined();
-    expect(result.billedEvents).toMatchObject({
-      123: { event: '123', inclTaxesTpp: 14.4 },
-      456: { event: '456', inclTaxesTpp: 12 },
+    expect(result.billedEvents).toEqual({
+      123: {
+        event: '123',
+        startDate: '2019-05-28T10:00:55',
+        endDate: '2019-05-28T13:00:55',
+        auxiliary: '34567890',
+        inclTaxesTpp: 14.4,
+      },
+      456: {
+        event: '456',
+        startDate: '2019-05-29T08:00:55',
+        endDate: '2019-05-29T10:00:55',
+        auxiliary: '34567890',
+        inclTaxesTpp: 12,
+      },
     });
-    sinon.assert.calledWithExactly(formatBillNumber, 1234, 'Picsou', 77);
-    sinon.assert.calledWithExactly(getFixedNumber, 14.4, 2);
-    sinon.assert.calledWithExactly(formatSubscriptionData, customerBills.bills[0]);
+    sinon.assert.calledOnceWithExactly(formatBillNumber, 1234, 'Picsou', 77);
+    sinon.assert.calledOnceWithExactly(getFixedNumber, 14.4, 2);
+    sinon.assert.calledOnceWithExactly(formatSubscriptionData, customerBills.bills[0]);
     sinon.assert.notCalled(formatBillingItemData);
   });
 
-  it('Case 1bis : 1 bill with billing items #tag', () => {
+  it('Case 1bis : 1 bill with billing items', () => {
     const company = { prefixNumber: 1234, _id: new ObjectID() };
     const customer = { _id: 'lilalo' };
     const number = { prefix: 'Picsou', seq: 77 };
@@ -527,7 +538,6 @@ describe('formatCustomerBills', () => {
     const result = BillHelper.formatCustomerBills(customerBills, customer, number, company);
 
     expect(result).toBeDefined();
-    expect(result.bill).toBeDefined();
     expect(result.bill).toEqual({
       company: company._id,
       customer: 'lilalo',
@@ -553,10 +563,10 @@ describe('formatCustomerBills', () => {
         inclTaxesCustomer: 30,
       },
     });
-    sinon.assert.calledWithExactly(formatBillNumber, 1234, 'Picsou', 77);
-    sinon.assert.calledWithExactly(getFixedNumber, 14.4, 2);
+    sinon.assert.calledOnceWithExactly(formatBillNumber, 1234, 'Picsou', 77);
+    sinon.assert.calledOnceWithExactly(getFixedNumber, 14.4, 2);
     sinon.assert.notCalled(formatSubscriptionData);
-    sinon.assert.calledWithExactly(formatBillingItemData, customerBills.bills[0]);
+    sinon.assert.calledOnceWithExactly(formatBillingItemData, customerBills.bills[0]);
   });
 
   it('Case 2 : multiple bills', () => {


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations :
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [ ] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES
- Si mes changements impactent l'application formation :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- Si mes changements impactent l'application erp :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : Client

- Périmetre roles : Admin

- Cas d'usage : Je peux facturer uniquement des articles de facturation a mon bénéficiaire sur la page a facturer
