### PR TITLE
COM-2368 

### DIFF
--- a/src/controllers/customerController.js
+++ b/src/controllers/customerController.js
@@ -10,7 +10,7 @@ const { language } = translate;
 
 const list = async (req) => {
   try {
-    const customers = await CustomerHelper.getCustomers(req.auth.credentials);
+    const customers = await CustomerHelper.getCustomers(req.query, req.auth.credentials);
 
     return {
       message: customers.length === 0 ? translate[language].customersNotFound : translate[language].customersFound,

--- a/src/controllers/customerController.js
+++ b/src/controllers/customerController.js
@@ -10,7 +10,7 @@ const { language } = translate;
 
 const list = async (req) => {
   try {
-    const customers = await CustomerHelper.getCustomers(req.query, req.auth.credentials);
+    const customers = await CustomerHelper.getCustomers(req.auth.credentials, req.query);
 
     return {
       message: customers.length === 0 ? translate[language].customersNotFound : translate[language].customersFound,

--- a/src/helpers/customers.js
+++ b/src/helpers/customers.js
@@ -78,11 +78,11 @@ exports.getCustomersWithBilledEvents = async (credentials) => {
   return EventRepository.getCustomersWithBilledEvents(query, companyId);
 };
 
-exports.getCustomers = async (query = null, credentials) => {
+exports.getCustomers = async (credentials, query = null) => {
   const findQuery = {
     company: get(credentials, 'company._id', null),
-    ...(query.archived && { archivedAt: { $ne: null } }),
-    ...(query.archived === false && { archivedAt: { $eq: null } }),
+    ...(query && query.archived && { archivedAt: { $ne: null } }),
+    ...(query && query.archived === false && { archivedAt: { $eq: null } }),
   };
 
   const customers = await Customer.find(findQuery).populate({ path: 'subscriptions.service' }).lean();

--- a/src/helpers/customers.js
+++ b/src/helpers/customers.js
@@ -79,10 +79,11 @@ exports.getCustomersWithBilledEvents = async (credentials) => {
 };
 
 exports.getCustomers = async (query = null, credentials) => {
-  let findQuery = { company: get(credentials, 'company._id', null) };
-
-  if (query.archived) findQuery = { ...findQuery, archivedAt: { $ne: null } };
-  else if (query.archived === false) findQuery = { ...findQuery, archivedAt: { $eq: null } };
+  const findQuery = {
+    company: get(credentials, 'company._id', null),
+    ...(query.archived && { archivedAt: { $ne: null } }),
+    ...(query.archived === false && { archivedAt: { $eq: null } }),
+  };
 
   const customers = await Customer.find(findQuery).populate({ path: 'subscriptions.service' }).lean();
 

--- a/src/routes/customers.js
+++ b/src/routes/customers.js
@@ -118,6 +118,7 @@ exports.plugin = {
       path: '/',
       options: {
         auth: { scope: ['customers:read'] },
+        validate: { query: Joi.object({ archived: Joi.boolean() }) },
       },
       handler: list,
     });

--- a/tests/integration/customers.test.js
+++ b/tests/integration/customers.test.js
@@ -181,8 +181,8 @@ describe('CUSTOMERS ROUTES', () => {
         const areAllCustomersFromCompany = res.result.data.customers
           .every(c => UtilsHelper.areObjectIdsEquals(c.company, authCompany._id));
         expect(areAllCustomersFromCompany).toBe(true);
-        const customers = await Customer.find({ company: authCompany._id, archivedAt: { $ne: null } }).lean();
-        expect(res.result.data.customers).toHaveLength(customers.length);
+        const archivedCustomers = await Customer.find({ company: authCompany._id, archivedAt: { $ne: null } }).lean();
+        expect(res.result.data.customers).toHaveLength(archivedCustomers.length);
       });
 
       it('should get non-archived customers', async () => {
@@ -196,8 +196,9 @@ describe('CUSTOMERS ROUTES', () => {
         const areAllCustomersFromCompany = res.result.data.customers
           .every(c => UtilsHelper.areObjectIdsEquals(c.company, authCompany._id));
         expect(areAllCustomersFromCompany).toBe(true);
-        const customers = await Customer.find({ company: authCompany._id, archivedAt: { $eq: null } }).lean();
-        expect(res.result.data.customers).toHaveLength(customers.length);
+        const notArchivedCustomers = await Customer.find({ company: authCompany._id, archivedAt: { $eq: null } })
+          .lean();
+        expect(res.result.data.customers).toHaveLength(notArchivedCustomers.length);
       });
     });
 

--- a/tests/integration/customers.test.js
+++ b/tests/integration/customers.test.js
@@ -169,6 +169,36 @@ describe('CUSTOMERS ROUTES', () => {
         const customers = await Customer.find({ company: authCompany._id }).lean();
         expect(res.result.data.customers).toHaveLength(customers.length);
       });
+
+      it('should get archived customers', async () => {
+        const res = await app.inject({
+          method: 'GET',
+          url: `/customers?archived=${true}`,
+          headers: { Cookie: `alenvi_token=${authToken}` },
+        });
+
+        expect(res.statusCode).toBe(200);
+        const areAllCustomersFromCompany = res.result.data.customers
+          .every(c => UtilsHelper.areObjectIdsEquals(c.company, authCompany._id));
+        expect(areAllCustomersFromCompany).toBe(true);
+        const customers = await Customer.find({ company: authCompany._id, archivedAt: { $ne: null } }).lean();
+        expect(res.result.data.customers).toHaveLength(customers.length);
+      });
+
+      it('should get non-archived customers', async () => {
+        const res = await app.inject({
+          method: 'GET',
+          url: `/customers?archived=${false}`,
+          headers: { Cookie: `alenvi_token=${authToken}` },
+        });
+
+        expect(res.statusCode).toBe(200);
+        const areAllCustomersFromCompany = res.result.data.customers
+          .every(c => UtilsHelper.areObjectIdsEquals(c.company, authCompany._id));
+        expect(areAllCustomersFromCompany).toBe(true);
+        const customers = await Customer.find({ company: authCompany._id, archivedAt: { $eq: null } }).lean();
+        expect(res.result.data.customers).toHaveLength(customers.length);
+      });
     });
 
     describe('Other roles', () => {

--- a/tests/unit/helpers/customers.test.js
+++ b/tests/unit/helpers/customers.test.js
@@ -246,21 +246,40 @@ describe('getCustomers', () => {
     ];
 
     findCustomer.returns(SinonMongoose.stubChainedQueries([[customers[0]]]));
-    populateSubscriptionsServices.returnsArg(0);
-    subscriptionsAccepted.callsFake(cus => ({ ...cus, subscriptionsAccepted: true }));
+    populateSubscriptionsServices.returns({
+      identity: { firstname: 'Emmanuel' },
+      company: companyId,
+      archivedAt: '2021-09-10T00:00:00',
+      subscriptions: [{ unitTTCRate: 75 }],
+    });
+    subscriptionsAccepted.returns({
+      identity: { firstname: 'Emmanuel' },
+      company: companyId,
+      archivedAt: '2021-09-10T00:00:00',
+      subscriptionsAccepted: true,
+    });
 
     const result = await CustomerHelper.getCustomers(query, credentials);
 
-    expect(result).toEqual([
+    expect(result).toEqual([{
+      identity: { firstname: 'Emmanuel' },
+      archivedAt: '2021-09-10T00:00:00',
+      subscriptionsAccepted: true,
+      company: companyId,
+    }]);
+    sinon.assert.calledOnceWithExactly(
+      subscriptionsAccepted,
       {
         identity: { firstname: 'Emmanuel' },
-        archivedAt: '2021-09-10T00:00:00',
-        subscriptionsAccepted: true,
         company: companyId,
-      },
-    ]);
-    sinon.assert.calledOnce(subscriptionsAccepted);
-    sinon.assert.calledOnce(populateSubscriptionsServices);
+        archivedAt: '2021-09-10T00:00:00',
+        subscriptions: [{ unitTTCRate: 75 }],
+      }
+    );
+    sinon.assert.calledOnceWithExactly(
+      populateSubscriptionsServices,
+      { identity: { firstname: 'Emmanuel' }, company: companyId, archivedAt: '2021-09-10T00:00:00' }
+    );
     SinonMongoose.calledWithExactly(
       findCustomer,
       [
@@ -282,8 +301,16 @@ describe('getCustomers', () => {
     ];
 
     findCustomer.returns(SinonMongoose.stubChainedQueries([[customers[1]]]));
-    populateSubscriptionsServices.returnsArg(0);
-    subscriptionsAccepted.callsFake(cus => ({ ...cus, subscriptionsAccepted: true }));
+    populateSubscriptionsServices.returns({
+      identity: { firstname: 'Jean-Paul', lastname: 'Belmondot' },
+      company: companyId,
+      subscriptions: [{ unitTTCRate: 75 }],
+    });
+    subscriptionsAccepted.returns({
+      identity: { firstname: 'Jean-Paul', lastname: 'Belmondot' },
+      company: companyId,
+      subscriptionsAccepted: true,
+    });
 
     const result = await CustomerHelper.getCustomers(query, credentials);
 
@@ -294,8 +321,20 @@ describe('getCustomers', () => {
         company: companyId,
       },
     ]);
-    sinon.assert.calledOnce(subscriptionsAccepted);
-    sinon.assert.calledOnce(populateSubscriptionsServices);
+
+    sinon.assert.calledOnceWithExactly(
+      subscriptionsAccepted,
+      {
+        identity: { firstname: 'Jean-Paul', lastname: 'Belmondot' },
+        company: companyId,
+        subscriptions: [{ unitTTCRate: 75 }],
+      }
+    );
+    sinon.assert.calledOnceWithExactly(
+      populateSubscriptionsServices,
+      { identity: { firstname: 'Jean-Paul', lastname: 'Belmondot' }, company: companyId }
+    );
+
     SinonMongoose.calledWithExactly(
       findCustomer,
       [


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations :
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [ ] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES
- Si mes changements impactent l'application formation :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- Si mes changements impactent l'application erp :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : client

- Périmetre roles : admin client/ coach

- Cas d'usage : Dans "Factures manuelles" je ne peux pas facturer un bénéficiaire archivé

Pour tester la PR: 
- creer un beneficiaire
- dans Configuration bénéficiaires, creer un article de facturation manuel 
- creer une facture manuelle pour le beneficiaire --> fonctionne bien
- archiver le beneficiaire 
- creer  a nouveau une facture manuelle pour ce beneficiaire --> impossible, le nom du beneficiaire n'apparait plus dans le sélecteur
