### PR TITLE
COM-2433 forbid update if repetition is invalid

### DIFF
--- a/src/helpers/events.js
+++ b/src/helpers/events.js
@@ -250,6 +250,9 @@ exports.updateEvent = async (event, eventPayload, credentials) => {
     throw Boom.badRequest(translate[language].eventDatesNotOnSameDay);
   }
   if (!(await EventsValidationHelper.isUpdateAllowed(event, eventPayload, credentials))) throw Boom.badData();
+  if (eventPayload.shouldUpdateRepetition && !EventsRepetitionHelper.isRepetitionValid(event.repetition)) {
+    throw Boom.badData(translate[language].invalidRepetition);
+  }
 
   const companyId = get(credentials, 'company._id', null);
   await EventHistoriesHelper.createEventHistoryOnUpdate(eventPayload, event, credentials);

--- a/src/helpers/eventsRepetition.js
+++ b/src/helpers/eventsRepetition.js
@@ -187,12 +187,12 @@ exports.updateRepetition = async (eventFromDb, eventPayload, credentials) => {
   return eventFromDb;
 };
 
-const isRepetitionValid = repetition => repetition.frequency !== NEVER && !!repetition.parentId;
+exports.isRepetitionValid = repetition => repetition.frequency !== NEVER && !!repetition.parentId;
 
 exports.deleteRepetition = async (event, credentials) => {
   const { type, repetition } = event;
   if (type === ABSENCE || !repetition) return;
-  if (!isRepetitionValid(repetition)) throw Boom.badData(translate[language].invalidRepetition);
+  if (!exports.isRepetitionValid(repetition)) throw Boom.badData(translate[language].invalidRepetition);
 
   const query = {
     'repetition.parentId': event.repetition.parentId,

--- a/src/helpers/translate.js
+++ b/src/helpers/translate.js
@@ -152,7 +152,7 @@ module.exports = {
     isTimeStamped: 'You can not delete a timestamped event.',
     timeStampCancelledEvent: 'Can\'t timestamp a cancelled event.',
     /* Repetitions */
-    invalidRepetition: 'Forbidden deletion : Invalid repetition.',
+    invalidRepetition: 'Forbidden action : Invalid repetition.',
     /* Sectors */
     sectorCreated: 'Sector created.',
     sectorUpdated: 'Sector updated.',
@@ -490,7 +490,7 @@ module.exports = {
     isTimeStamped: 'Vous ne pouvez pas supprimer un évènement horodaté.',
     timeStampCancelledEvent: 'Vous ne pouvez pas horodater un évènement annulé.',
     /* Repetitions */
-    invalidRepetition: 'Suppression impossible : La répétition est invalide.',
+    invalidRepetition: 'Action impossible : La répétition est invalide.',
     /* Sectors */
     sectorCreated: 'Équipe créée.',
     sectorUpdated: 'Équipe modifiée.',

--- a/tests/integration/events.test.js
+++ b/tests/integration/events.test.js
@@ -1614,6 +1614,24 @@ describe('PUT /events/{_id}', () => {
 
       expect(response.statusCode).toEqual(422);
     });
+
+    it('should return a 422 if repetition is invalid', async () => {
+      const payload = {
+        startDate: '2019-10-23T15:30:19.543Z',
+        endDate: '2019-10-23T17:30:19.543Z',
+        auxiliary: auxiliaries[0]._id,
+        shouldUpdateRepetition: true,
+      };
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/events/${eventsList[27]._id}`,
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(422);
+    });
   });
 
   describe('Other roles', () => {


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations :
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [x] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles -np
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES -np
- Si mes changements impactent l'application formation :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- Si mes changements impactent l'application erp :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME -np
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES -np
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV -np
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : client

- Périmetre roles : coach

- Cas d'usage : Si je mets a jour un des evenements de la repetition sans parentId, j'ai un message d'erreur. 
Choses que je n'ai pas faite dans cette pr pour que la mep puisse se faire rapidement : 
- je n'ai pas gere l'affichage du message d'erreur en front (on envoie plusieurs 422 du back sur la maj d'un evenement)
- Autre petit soucis mais beaucoup moins genant que je n'ai pas resolu : si on supprime en masse les evenements d'un beneficiaire a partir d'une date --> le soucis va aussi se produire mais que pour se beneficiaire donc ca ne change rien. 
