### PR TITLE
COM-2440 populate subPrograms

### DIFF
--- a/src/helpers/activities.js
+++ b/src/helpers/activities.js
@@ -11,7 +11,7 @@ exports.getActivity = async activityId => Activity.findOne({ _id: activityId })
   .populate({
     path: 'steps',
     select: '_id -activities',
-    populate: { path: 'subProgram', select: '_id -steps', populate: { path: 'program', select: 'name -subPrograms' } },
+    populate: { path: 'subPrograms', select: '_id -steps', populate: { path: 'program', select: 'name -subPrograms' } },
   })
   .lean({ virtuals: true });
 

--- a/src/models/Step.js
+++ b/src/models/Step.js
@@ -13,11 +13,10 @@ const StepSchema = mongoose.Schema({
   status: { type: String, default: DRAFT, enum: STATUS_TYPES },
 }, { timestamps: true, id: false });
 
-StepSchema.virtual('subProgram', {
+StepSchema.virtual('subPrograms', {
   ref: 'SubProgram',
   localField: '_id',
   foreignField: 'steps',
-  justOne: true,
 });
 
 StepSchema.virtual('courseSlotsCount', {

--- a/src/routes/preHandlers/activityHistories.js
+++ b/src/routes/preHandlers/activityHistories.js
@@ -1,6 +1,5 @@
 const Boom = require('@hapi/boom');
 const get = require('lodash/get');
-const has = require('lodash/has');
 const Activity = require('../../models/Activity');
 const User = require('../../models/User');
 const Course = require('../../models/Course');
@@ -10,13 +9,18 @@ exports.authorizeAddActivityHistory = async (req) => {
   const { user: userId, activity: activityId, questionnaireAnswersList } = req.payload;
 
   const activity = await Activity.findOne({ _id: activityId })
-    .populate({ path: 'steps', select: '_id -activities', populate: { path: 'subProgram', select: '_id -steps' } })
+    .populate({ path: 'steps', select: '_id -activities', populate: { path: 'subPrograms', select: '_id -steps' } })
     .lean();
   const user = await User.countDocuments({ _id: userId });
 
   if (!activity || !user) throw Boom.notFound();
 
-  const activitySubPrograms = activity.steps.filter(s => has(s, 'subProgram._id')).map(s => s.subProgram._id);
+  const activitySubPrograms = activity.steps
+    .map(step => step.subPrograms)
+    .flat()
+    .map(s => s._id)
+    .filter(Boolean);
+
   const coursesWithActivityAndFollowedByUser = await Course
     .countDocuments({ subProgram: { $in: activitySubPrograms }, trainees: userId });
 

--- a/tests/unit/helpers/activities.test.js
+++ b/tests/unit/helpers/activities.test.js
@@ -34,7 +34,7 @@ describe('getActivity', () => {
           path: 'steps',
           select: '_id -activities',
           populate:
-          { path: 'subProgram', select: '_id -steps', populate: { path: 'program', select: 'name -subPrograms' } },
+          { path: 'subPrograms', select: '_id -steps', populate: { path: 'program', select: 'name -subPrograms' } },
         }],
       },
       { query: 'lean', args: [{ virtuals: true }] },

--- a/tests/unit/helpers/activityHistories.test.js
+++ b/tests/unit/helpers/activityHistories.test.js
@@ -54,14 +54,14 @@ describe('list', () => {
         activity: {
           steps: [
             {
-              subProgram: {
+              subPrograms: [{
                 program: { name: 'une incroyable découverte' },
                 courses: [{
                   misc: 'groupe 1',
                   format: 'strictly_e_learning',
                   trainees: [firstUserId],
                 }],
-              },
+              }],
             },
             { name: 'step without subprogram' },
           ],
@@ -72,14 +72,14 @@ describe('list', () => {
         user: secondUserId,
         activity: {
           steps: [{
-            subProgram: {
+            subPrograms: [{
               program: { name: 'une rencontre sensationnelle' },
               courses: [{
                 misc: 'groupe 2',
                 format: 'strictly_e_learning',
                 trainees: [new ObjectID()],
               }],
-            },
+            }],
           }],
         },
       }];
@@ -87,14 +87,14 @@ describe('list', () => {
       user: firstUserId,
       activity: {
         steps: [{
-          subProgram: {
+          subPrograms: [{
             program: { name: 'une incroyable découverte' },
             courses: [{
               misc: 'groupe 1',
               format: 'strictly_e_learning',
               trainees: [firstUserId],
             }],
-          },
+          }],
         }],
       },
     };
@@ -130,7 +130,7 @@ describe('list', () => {
               path: 'steps',
               select: '_id',
               populate: {
-                path: 'subProgram',
+                path: 'subPrograms',
                 select: '_id',
                 populate: [
                   { path: 'courses', select: 'misc format trainees', match: { format: 'strictly_e_learning' } },


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations :
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [x] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES
- Si mes changements impactent l'application formation :
  - [x] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [x] Affichage des pages explorer/mes formations/About/CourseProfile
    - [x] Inscription a une formation e-learning
    - [x] Possibilité de faire une activité

- Si mes changements impactent l'application erp :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : formation

- Périmetre roles : rof et coach

- Cas d'usage : refacto : le lien entre : `step (1) ---- (n) subProgram` devient `step (n) ---- (n) subProgram`. La ou on avait un sous-programme par etape, maintenant on a un tableau de sous-programme. Cette PR corrige les pb qui decoule de ce changement sans ajouter de fonctionnalité
