### PR TITLE
COM-2424 populate subProgram's name and program in step

### DIFF
--- a/src/helpers/programs.js
+++ b/src/helpers/programs.js
@@ -47,7 +47,10 @@ exports.getProgram = async (programId) => {
       path: 'subPrograms',
       populate: {
         path: 'steps',
-        populate: [{ path: 'activities ', populate: 'cards' }, { path: 'subPrograms', select: '_id -steps' }],
+        populate: [
+          { path: 'activities ', populate: 'cards' },
+          { path: 'subPrograms', select: 'name -steps', populate: { path: 'program', select: 'name -subPrograms' } },
+        ],
       },
     })
     .populate({ path: 'testers', select: 'identity.firstname identity.lastname local.email contact.phone' })

--- a/tests/integration/programs.test.js
+++ b/tests/integration/programs.test.js
@@ -186,8 +186,16 @@ describe('PROGRAMS ROUTES - GET /programs/{_id}', () => {
           activities: [],
           areActivitiesValid: true,
           subPrograms: expect.arrayContaining([
-            expect.objectContaining({ _id: subProgramsList[0]._id }),
-            expect.objectContaining({ _id: subProgramsList[3]._id }),
+            expect.objectContaining({
+              _id: subProgramsList[0]._id,
+              name: 'sous-programme 1',
+              program: { _id: programsList[0]._id, name: 'program' },
+            }),
+            expect.objectContaining({
+              _id: subProgramsList[3]._id,
+              name: 'sous-programme 4',
+              program: { _id: programsList[4]._id, name: 'programme a vérifier' },
+            }),
           ]),
         }),
         expect.objectContaining({

--- a/tests/unit/helpers/programs.test.js
+++ b/tests/unit/helpers/programs.test.js
@@ -130,6 +130,7 @@ describe('getProgram', () => {
 
   it('should return the requested program', async () => {
     const programId = new ObjectID();
+    const otherProgramId = new ObjectID();
     const subProgramId = new ObjectID();
     const otherSubProgramId = new ObjectID();
     const stepId = new ObjectID();
@@ -146,7 +147,10 @@ describe('getProgram', () => {
             _id: activityId,
             cards: [{ _id: cardsIds[0], text: 'oui' }, { _id: cardsIds[1], text: 'non' }],
           }],
-          subPrograms: [subProgramId, otherSubProgramId],
+          subPrograms: [
+            { _id: subProgramId, name: 'sp 1', program: { _id: programId, name: 'prog 1' } },
+            { _id: otherSubProgramId, name: 'sp 2', program: { _id: otherProgramId, name: 'prog 2' } },
+          ],
         }],
       }],
     };
@@ -165,7 +169,10 @@ describe('getProgram', () => {
             _id: activityId,
             cards: cardsIds,
           }],
-          subPrograms: [subProgramId, otherSubProgramId],
+          subPrograms: [
+            { _id: subProgramId, name: 'sp 1', program: { _id: programId, name: 'prog 1' } },
+            { _id: otherSubProgramId, name: 'sp 2', program: { _id: otherProgramId, name: 'prog 2' } },
+          ],
         }],
       }],
     });
@@ -179,7 +186,14 @@ describe('getProgram', () => {
             path: 'subPrograms',
             populate: {
               path: 'steps',
-              populate: [{ path: 'activities ', populate: 'cards' }, { path: 'subPrograms', select: '_id -steps' }],
+              populate: [
+                { path: 'activities ', populate: 'cards' },
+                {
+                  path: 'subPrograms',
+                  select: 'name -steps',
+                  populate: { path: 'program', select: 'name -subPrograms' },
+                },
+              ],
             },
           }],
         },


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations :
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [x] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES
- Si mes changements impactent l'application formation :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- Si mes changements impactent l'application erp :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : formation vendeur

- Périmetre roles : rof

- Cas d'usage : Avec cette 1ere PR,  je peux deverouiller une étape en cliquant sur le cadenas. Une modale apparait me signalant les autres sous-programmes où l'etape est utilisée. Je peux alors confirmer ou annuler le deverouillage

dans une seconde PR, on rendra possible l'autre maniere de deverouiller en cliquant sur le crayon.
