### PR TITLE
COM-2467 - do not call methods if no event

### DIFF
--- a/src/helpers/delivery.js
+++ b/src/helpers/delivery.js
@@ -270,9 +270,12 @@ exports.getEvents = async (query, credentials) => {
     })
     .lean();
 
+  const billedEvents = events.filter(ev => !!ev.isBilled &&
+    UtilsHelper.doesArrayIncludeId(tpps, ev.bills.thirdPartyPayer));
+
   return [
     ...await exports.formatNonBilledEvents(events.filter(ev => !ev.isBilled), startDate, endDate, credentials),
-    ...await exports.formatBilledEvents(events.filter(ev => !!ev.isBilled), credentials),
+    ...await exports.formatBilledEvents(billedEvents, credentials),
   ];
 };
 

--- a/src/helpers/delivery.js
+++ b/src/helpers/delivery.js
@@ -226,6 +226,8 @@ exports.formatEvents = async (events, companyId) => {
 };
 
 exports.formatNonBilledEvents = async (events, startDate, endDate, credentials) => {
+  if (!events.length) return [];
+
   const companyId = get(credentials, 'company._id');
   const billsQuery = { startDate, endDate, eventIds: events.map(ev => ev._id) };
   const bills = await DraftBillsHelper.getDraftBillsList(billsQuery, credentials);
@@ -238,8 +240,11 @@ exports.formatNonBilledEvents = async (events, startDate, endDate, credentials) 
   return exports.formatEvents(eventsWithBillingInfo, companyId);
 };
 
-exports.formatBilledEvents = async (events, credentials) =>
-  exports.formatEvents(events, get(credentials, 'company._id'));
+exports.formatBilledEvents = async (events, credentials) => {
+  if (!events.length) return [];
+
+  return exports.formatEvents(events, get(credentials, 'company._id'));
+};
 
 exports.getEvents = async (query, credentials) => {
   const companyId = get(credentials, 'company._id');

--- a/src/repositories/EventRepository.js
+++ b/src/repositories/EventRepository.js
@@ -2,6 +2,7 @@ const { ObjectID } = require('mongodb');
 const moment = require('moment');
 const omit = require('lodash/omit');
 const get = require('lodash/get');
+const has = require('lodash/has');
 const groupBy = require('lodash/groupBy');
 const { cloneDeep } = require('lodash');
 const Event = require('../models/Event');
@@ -267,7 +268,7 @@ exports.getEventsToPay = async (start, end, auxiliaries, companyId) => {
 
 exports.getEventsToBill = async (query, companyId) => {
   const rules = [];
-  if (query.eventIds && query.eventIds.length) rules.push({ _id: { $in: query.eventIds.map(id => new ObjectID(id)) } });
+  if (has(query, 'eventIds')) rules.push({ _id: { $in: query.eventIds.map(id => new ObjectID(id)) } });
   else {
     rules.push(
       { endDate: { $lt: query.endDate } },

--- a/tests/unit/helpers/delivery.test.js
+++ b/tests/unit/helpers/delivery.test.js
@@ -251,7 +251,11 @@ describe('getEvents', () => {
         ],
       },
     ];
-    const events = [{ isBilled: true, _id: 'billed' }, { isBilled: false, _id: 'not_billed' }];
+    const events = [
+      { isBilled: true, _id: 'billed', bills: { thirdPartyPayer: tpp1 } },
+      { isBilled: false, _id: 'not_billed' },
+      { isBilled: true, _id: 'billedbutwrongtpp', bills: { thirdPartyPayer: new ObjectID() } },
+    ];
     findCustomers.returns(SinonMongoose.stubChainedQueries([customers], ['lean']));
     findEvents.returns(SinonMongoose.stubChainedQueries([events], ['lean']));
     formatNonBilledEvents.returns([{ isBilled: false, _id: 'not_billed', auxiliary: 'auxiliary' }]);
@@ -299,7 +303,7 @@ describe('getEvents', () => {
     );
     sinon.assert.calledOnceWithExactly(
       formatBilledEvents,
-      [{ isBilled: true, _id: 'billed' }],
+      [{ isBilled: true, _id: 'billed', bills: { thirdPartyPayer: tpp1 } }],
       { company: { _id: companyId } }
     );
   });

--- a/tests/unit/helpers/delivery.test.js
+++ b/tests/unit/helpers/delivery.test.js
@@ -127,6 +127,20 @@ describe('formatNonBilledEvents', () => {
     getDraftBillsList.restore();
   });
 
+  it('should return [] if no events', async () => {
+    const companyId = new ObjectID();
+    const startDate = '2021-10-12T09:00:00';
+    const endDate = '2021-10-15T19:00:00';
+    const events = [];
+
+    const result = await DeliveryHelper
+      .formatNonBilledEvents(events, startDate, endDate, { company: { _id: companyId } });
+
+    expect(result).toEqual([]);
+    sinon.assert.notCalled(getDraftBillsList);
+    sinon.assert.notCalled(formatEvents);
+  });
+
   it('should format non billed events', async () => {
     const companyId = new ObjectID();
     const startDate = '2021-10-12T09:00:00';
@@ -177,6 +191,16 @@ describe('formatBilledEvents', () => {
   });
   afterEach(() => {
     formatEvents.restore();
+  });
+
+  it('should return [] if no events', async () => {
+    const companyId = new ObjectID();
+    const events = [];
+
+    const result = await DeliveryHelper.formatBilledEvents(events, { company: { _id: companyId } });
+
+    expect(result).toEqual([]);
+    sinon.assert.notCalled(formatEvents);
   });
 
   it('should format events', async () => {


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations :
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [x] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES
- Si mes changements impactent l'application formation :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- Si mes changements impactent l'application erp :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : Client

- Périmetre roles : Coach

- Cas d'usage : 

La facturation de septembre est faite -> pour la génération du fichier, tous les évènements qu'on récupere sont en `isBilled: true`.
La methode `formatNonBilledEvents` prend en argument [] pour `events` qui est passé a `getDraftBillsList` puis `getEventsToBIll`. 
La `query.events.length` est nul donc la requête sur les évènements passent dans le else et renvoie les évènements non facturés de septembre -> ce qu'on ne veut pas 

pour reproduire, tu peux :

    Ajouter un id de teletransmission a un un tiers payeur pour pouvoir telecharger un fichier (prends un tiers payeurs peut utiliser ce sera plus simple je pense)  
    Verifies que tu as bien **aucune intervention a facturer** sur septembre par exemple pour ce tiers payeurs -> si oui **les facturer**
    Ajoute dans le planning de septembre un évènement a un bénéficiaire qui a un tpp mais pas celui  modifié dessus
    Sur la branche de dev, quand tu telecharges le fichier tu vois l'intervention créée plus haut (il faut que tu changes le option du selecteur pour ajouter septembre aussi)

===> Or tu ne devrais pas la voir car elle ne concerne pas le tiers payeur que tu as selectionné au dessus

Autre bug corrigé : 
Si certaines interventions (mais pas toutes) d'un bénéficiaire sont facturées au tiers payeurs (les autres uniquement au bénéficiaire) elles apparaissent toutes dans le fichier
