### PR TITLE
Com 2478

### DIFF
--- a/src/models/Course.js
+++ b/src/models/Course.js
@@ -25,6 +25,7 @@ const CourseSchema = mongoose.Schema({
     ref: 'User',
     required() { return this.format === BLENDED; },
   },
+  archivedAt: { type: Date },
 }, { timestamps: true });
 
 // eslint-disable-next-line consistent-return

--- a/src/routes/courses.js
+++ b/src/routes/courses.js
@@ -183,6 +183,7 @@ exports.plugin = {
               email: Joi.string().allow('', null),
             }).min(1),
             salesRepresentative: Joi.objectId(),
+            archivedAt: Joi.date(),
           }),
         },
         pre: [{ method: getCourse, assign: 'course' }, { method: authorizeCourseEdit }],

--- a/src/routes/preHandlers/courses.js
+++ b/src/routes/preHandlers/courses.js
@@ -64,12 +64,12 @@ exports.authorizeCourseEdit = async (req) => {
     if (archivedAt) {
       const userVendorRole = get(req, 'auth.credentials.role.vendor.name');
       const hasVendorRole = [TRAINING_ORGANISATION_MANAGER, VENDOR_ADMIN].includes(userVendorRole);
+      if (!hasVendorRole) return Boom.forbidden();
 
-      const isCompleted = course.slots.every(slot => moment(slot.endDate).isBefore(archivedAt));
-      const isBlended = course.format === BLENDED;
-      const isArchivable = course.trainees.length && course.slots.length && !course.slotsToPlan.length &&
-        isCompleted && isBlended;
-      if (!isArchivable || !hasVendorRole) return Boom.forbidden();
+      if (!course.trainees.length || !course.slots.length) return Boom.forbidden();
+      if (course.slotsToPlan.length) return Boom.forbidden();
+      if (course.format !== BLENDED) return Boom.forbidden();
+      if (course.slots.some(slot => moment(slot.endDate).isAfter(archivedAt))) return Boom.forbidden();
     }
 
     return null;

--- a/src/routes/preHandlers/courses.js
+++ b/src/routes/preHandlers/courses.js
@@ -1,5 +1,6 @@
 const Boom = require('@hapi/boom');
 const get = require('lodash/get');
+const moment = require('moment');
 const Course = require('../../models/Course');
 const User = require('../../models/User');
 const UserCompany = require('../../models/UserCompany');
@@ -58,6 +59,18 @@ exports.authorizeCourseEdit = async (req) => {
     this.checkAuthorization(credentials, courseTrainerId, courseCompanyId);
 
     if (get(req, 'payload.salesRepresentative')) await this.checkSalesRepresentativeExists(req);
+
+    const archivedAt = get(req, 'payload.archivedAt');
+    if (archivedAt) {
+      const userVendorRole = get(req, 'auth.credentials.role.vendor.name');
+      const hasVendorRole = [TRAINING_ORGANISATION_MANAGER, VENDOR_ADMIN].includes(userVendorRole);
+
+      const isCompleted = course.slots.every(slot => moment(slot.endDate).isBefore(archivedAt));
+      const isBlended = course.format === BLENDED;
+      const isArchivable = course.trainees.length && course.slots.length && !course.slotsToPlan.length &&
+        isCompleted && isBlended;
+      if (!isArchivable || !hasVendorRole) return Boom.forbidden();
+    }
 
     return null;
   } catch (e) {
@@ -203,7 +216,10 @@ exports.authorizeGetCourse = async (req) => {
 };
 
 exports.getCourse = async (req) => {
-  const course = await Course.findById(req.params._id).lean();
+  const course = await Course.findById(req.params._id)
+    .populate({ path: 'slots', select: 'startDate endDate' })
+    .populate({ path: 'slotsToPlan' })
+    .lean();
   if (!course) throw Boom.notFound();
 
   return course;

--- a/tests/integration/courses.test.js
+++ b/tests/integration/courses.test.js
@@ -235,7 +235,7 @@ describe('COURSES ROUTES - GET /courses', () => {
       });
 
       expect(response.statusCode).toBe(200);
-      expect(response.result.data.courses.length).toEqual(6);
+      expect(response.result.data.courses.length).toEqual(10);
     });
 
     it('should get strictly e-learning courses', async () => {
@@ -246,7 +246,7 @@ describe('COURSES ROUTES - GET /courses', () => {
       });
 
       expect(response.statusCode).toBe(200);
-      expect(response.result.data.courses.length).toEqual(7);
+      expect(response.result.data.courses.length).toEqual(4);
     });
 
     it('should return 400 if bad format', async () => {
@@ -270,7 +270,7 @@ describe('COURSES ROUTES - GET /courses', () => {
       });
 
       expect(response.statusCode).toBe(200);
-      expect(response.result.data.courses.length).toEqual(3);
+      expect(response.result.data.courses.length).toEqual(4);
     });
 
     it('should get courses for a specific company', async () => {
@@ -635,7 +635,7 @@ describe('COURSES ROUTES - GET /courses/{_id}/questionnaires', () => {
     it('should return 404 if course is strictly e-learning', async () => {
       const response = await app.inject({
         method: 'GET',
-        url: `/courses/${coursesList[4]._id.toHexString()}/questionnaires`,
+        url: `/courses/${coursesList[8]._id.toHexString()}/questionnaires`,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
@@ -870,6 +870,66 @@ describe('COURSES ROUTES - PUT /courses/{_id}', () => {
       const response = await app.inject({
         method: 'PUT',
         url: `/courses/${courseIdFromAuthCompany}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+        payload,
+      });
+
+      expect(response.statusCode).toBe(403);
+    });
+
+    it('should return 403 if trying to archive course without trainee', async () => {
+      const payload = { archivedAt: new Date('2020-03-25T09:00:00') };
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/courses/${coursesList[13]._id}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+        payload,
+      });
+
+      expect(response.statusCode).toBe(403);
+    });
+
+    it('should return 403 if trying to archive course without slot', async () => {
+      const payload = { archivedAt: new Date('2020-03-25T09:00:00') };
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/courses/${coursesList[4]._id}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+        payload,
+      });
+
+      expect(response.statusCode).toBe(403);
+    });
+
+    it('should return 403 if trying to archive course with slot to plan', async () => {
+      const payload = { archivedAt: new Date('2020-03-25T09:00:00') };
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/courses/${coursesList[7]._id}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+        payload,
+      });
+
+      expect(response.statusCode).toBe(403);
+    });
+
+    it('should return 403 if trying to archive a not blended course', async () => {
+      const payload = { archivedAt: new Date('2020-03-25T09:00:00') };
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/courses/${coursesList[8]._id}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+        payload,
+      });
+
+      expect(response.statusCode).toBe(403);
+    });
+
+    it('should return 403 if trying to archive a course in progress', async () => {
+      const payload = { archivedAt: new Date('2020-03-10T00:00:00') };
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/courses/${coursesList[5]._id}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
         payload,
       });
@@ -1434,7 +1494,6 @@ describe('COURSES ROUTES - PUT /courses/{_id}/trainee', () => {
 
 describe('COURSES ROUTES - POST /courses/{_id}/register-e-learning', () => {
   let authToken;
-  const course = coursesList[4];
 
   beforeEach(populateDB);
 
@@ -1444,6 +1503,7 @@ describe('COURSES ROUTES - POST /courses/{_id}/register-e-learning', () => {
     });
 
     it('should add trainee to e-learning course', async () => {
+      const course = coursesList[6];
       const response = await app.inject({
         method: 'POST',
         url: `/courses/${course._id}/register-e-learning`,
@@ -1480,7 +1540,7 @@ describe('COURSES ROUTES - POST /courses/{_id}/register-e-learning', () => {
 
       const response = await app.inject({
         method: 'POST',
-        url: `/courses/${course._id}/register-e-learning`,
+        url: `/courses/${coursesList[4]._id}/register-e-learning`,
         headers: { 'x-access-token': authToken },
       });
 

--- a/tests/integration/courses.test.js
+++ b/tests/integration/courses.test.js
@@ -887,6 +887,17 @@ describe('COURSES ROUTES - PUT /courses/{_id}', () => {
       });
 
       expect(response.statusCode).toBe(403);
+
+      const course = await Course.findById(coursesList[13]._id)
+        .populate({ path: 'slots', select: 'startDate endDate' })
+        .populate({ path: 'slotsToPlan' })
+        .lean();
+
+      expect(course.trainees.length).toBeFalsy();
+      expect(course.slots.length).toBeTruthy();
+      expect(course.slotsToPlan.length).toBe(0);
+      expect(course.format).toBe('blended');
+      expect(course.slots.every(slot => moment(slot.endDate).isBefore(payload.archivedAt))).toBeTruthy();
     });
 
     it('should return 403 if trying to archive course without slot', async () => {
@@ -899,6 +910,17 @@ describe('COURSES ROUTES - PUT /courses/{_id}', () => {
       });
 
       expect(response.statusCode).toBe(403);
+
+      const course = await Course.findById(coursesList[4]._id)
+        .populate({ path: 'slots', select: 'startDate endDate' })
+        .populate({ path: 'slotsToPlan' })
+        .lean();
+
+      expect(course.trainees.length).toBeTruthy();
+      expect(course.slots.length).toBeFalsy();
+      expect(course.slotsToPlan.length).toBe(0);
+      expect(course.format).toBe('blended');
+      expect(course.slots.every(slot => moment(slot.endDate).isBefore(payload.archivedAt))).toBeTruthy();
     });
 
     it('should return 403 if trying to archive course with slot to plan', async () => {
@@ -911,6 +933,17 @@ describe('COURSES ROUTES - PUT /courses/{_id}', () => {
       });
 
       expect(response.statusCode).toBe(403);
+
+      const course = await Course.findById(coursesList[7]._id)
+        .populate({ path: 'slots', select: 'startDate endDate' })
+        .populate({ path: 'slotsToPlan' })
+        .lean();
+
+      expect(course.trainees.length).toBeTruthy();
+      expect(course.slots.length).toBeTruthy();
+      expect(course.slotsToPlan.length).toBeTruthy();
+      expect(course.format).toBe('blended');
+      expect(course.slots.every(slot => moment(slot.endDate).isBefore(payload.archivedAt))).toBeTruthy();
     });
 
     it('should return 403 if trying to archive a not blended course', async () => {
@@ -923,6 +956,17 @@ describe('COURSES ROUTES - PUT /courses/{_id}', () => {
       });
 
       expect(response.statusCode).toBe(403);
+
+      const course = await Course.findById(coursesList[8]._id)
+        .populate({ path: 'slots', select: 'startDate endDate' })
+        .populate({ path: 'slotsToPlan' })
+        .lean();
+
+      expect(course.trainees.length).toBeTruthy();
+      expect(course.slots.length).toBeTruthy();
+      expect(course.slotsToPlan.length).toBe(0);
+      expect(course.format).toBe('strictly_e_learning');
+      expect(course.slots.every(slot => moment(slot.endDate).isBefore(payload.archivedAt))).toBeTruthy();
     });
 
     it('should return 403 if trying to archive a course in progress', async () => {
@@ -935,6 +979,17 @@ describe('COURSES ROUTES - PUT /courses/{_id}', () => {
       });
 
       expect(response.statusCode).toBe(403);
+
+      const course = await Course.findById(coursesList[5]._id)
+        .populate({ path: 'slots', select: 'startDate endDate' })
+        .populate({ path: 'slotsToPlan' })
+        .lean();
+
+      expect(course.trainees.length).toBeTruthy();
+      expect(course.slots.length).toBeTruthy();
+      expect(course.slotsToPlan.length).toBe(0);
+      expect(course.format).toBe('blended');
+      expect(course.slots.every(slot => moment(slot.endDate).isBefore(payload.archivedAt))).toBeFalsy();
     });
   });
 

--- a/tests/integration/seed/coursesSeed.js
+++ b/tests/integration/seed/coursesSeed.js
@@ -117,7 +117,7 @@ const programsList = [
 ];
 
 const coursesList = [
-  {
+  { // 1
     _id: new ObjectID(),
     subProgram: subProgramsList[0]._id,
     company: authCompany._id,
@@ -126,8 +126,9 @@ const coursesList = [
     trainees: [coach._id, helper._id, clientAdmin._id, trainer._id],
     type: 'intra',
     salesRepresentative: vendorAdmin._id,
+    // format: 'strictly_e_learning',
   },
-  {
+  { // 2
     _id: new ObjectID(),
     subProgram: subProgramsList[0]._id,
     company: otherCompany._id,
@@ -137,7 +138,7 @@ const coursesList = [
     type: 'intra',
     salesRepresentative: vendorAdmin._id,
   },
-  {
+  { // 3
     _id: new ObjectID(),
     subProgram: subProgramsList[0]._id,
     company: authCompany._id,
@@ -154,7 +155,7 @@ const coursesList = [
     ],
     salesRepresentative: vendorAdmin._id,
   },
-  {
+  { // 4
     _id: new ObjectID(),
     subProgram: subProgramsList[0]._id,
     company: otherCompany._id,
@@ -164,26 +165,26 @@ const coursesList = [
     salesRepresentative: vendorAdmin._id,
     trainer: trainerAndCoach._id,
   },
-  { // course without slots
+  { // 5 course without slots
     _id: new ObjectID(),
     subProgram: subProgramsList[0]._id,
     misc: 'inter b2b session concerning auth company',
     type: 'inter_b2b',
     trainees: [traineeFromOtherCompany._id, coach._id],
-    format: 'strictly_e_learning',
+    format: 'blended',
     trainer: trainer._id,
     salesRepresentative: vendorAdmin._id,
   },
-  { // course with slots
+  { // 6 course with slots
     _id: new ObjectID(),
     subProgram: subProgramsList[0]._id,
     misc: 'inter b2b session NOT concerning auth company',
     type: 'inter_b2b',
-    format: 'strictly_e_learning',
+    format: 'blended',
     trainees: [noRoleNoCompany._id],
     salesRepresentative: vendorAdmin._id,
   },
-  { // course without trainees and slots
+  { // 7 course without trainees and slots
     _id: new ObjectID(),
     subProgram: subProgramsList[0]._id,
     misc: 'inter b2b session NOT concerning auth company',
@@ -191,15 +192,16 @@ const coursesList = [
     format: 'strictly_e_learning',
     salesRepresentative: vendorAdmin._id,
   },
-  { // course with slots to plan
+  { // 8 course with slots to plan
     _id: new ObjectID(),
     subProgram: subProgramsList[0]._id,
     misc: 'inter b2b session NOT concerning auth company',
     type: 'inter_b2b',
-    format: 'strictly_e_learning',
+    format: 'blended',
+    trainees: [trainer._id],
     salesRepresentative: vendorAdmin._id,
   },
-  { // course with access rules
+  { // 9 course with access rules
     _id: new ObjectID(),
     subProgram: subProgramsList[0]._id,
     misc: 'inter_b2b with accessRules',
@@ -209,7 +211,7 @@ const coursesList = [
     accessRules: [authCompany._id, new ObjectID()],
     salesRepresentative: vendorAdmin._id,
   },
-  { // course with access rules and trainee that can't have access to the course but has already suscribed
+  { // 10 course with access rules and trainee that can't have access to the course but has already suscribed
     _id: new ObjectID(),
     subProgram: subProgramsList[0]._id,
     misc: 'inter_b2b with accessRules',
@@ -219,7 +221,7 @@ const coursesList = [
     accessRules: [authCompany._id, new ObjectID()],
     salesRepresentative: vendorAdmin._id,
   },
-  { // course with contact
+  { // 11 course with contact
     _id: new ObjectID(),
     subProgram: subProgramsList[0]._id,
     trainer: coach._id,
@@ -229,7 +231,7 @@ const coursesList = [
     contact: { name: 'Romain Delendarroze', email: 'romainlebg77@gmail.com', phone: '0123456789' },
     salesRepresentative: vendorAdmin._id,
   },
-  { // course without authCompany in access rules (11ème position)
+  { // 12 course without authCompany in access rules (11ème position)
     _id: new ObjectID(),
     subProgram: subProgramsList[0]._id,
     misc: 'inter_b2b',
@@ -239,12 +241,21 @@ const coursesList = [
     accessRules: [otherCompany._id],
     salesRepresentative: vendorAdmin._id,
   },
-  { // course with no on-site slot
+  { // 13 course with no on-site slot
     _id: new ObjectID(),
     subProgram: subProgramsList[1]._id,
     misc: 'inter_b2b',
     type: 'inter_b2b',
     trainees: [coach._id],
+    salesRepresentative: vendorAdmin._id,
+  },
+  { // 13 course without trainee
+    _id: new ObjectID(),
+    subProgram: subProgramsList[0]._id,
+    misc: '',
+    type: 'inter_b2b',
+    format: 'blended',
+    trainer: trainer._id,
     salesRepresentative: vendorAdmin._id,
   },
 ];
@@ -310,6 +321,24 @@ const slots = [
     step: stepList[0]._id,
   },
   { course: coursesList[7] },
+  {
+    startDate: moment('2020-03-20T09:00:00').toDate(),
+    endDate: moment('2020-03-20T11:00:00').toDate(),
+    course: coursesList[7],
+    step: stepList[0]._id,
+  },
+  {
+    startDate: moment('2020-03-20T09:00:00').toDate(),
+    endDate: moment('2020-03-20T11:00:00').toDate(),
+    course: coursesList[8],
+    step: stepList[0]._id,
+  },
+  {
+    startDate: moment('2020-03-20T09:00:00').toDate(),
+    endDate: moment('2020-03-20T11:00:00').toDate(),
+    course: coursesList[13],
+    step: stepList[0]._id,
+  },
 ];
 
 const populateDB = async () => {

--- a/tests/integration/seed/coursesSeed.js
+++ b/tests/integration/seed/coursesSeed.js
@@ -117,7 +117,7 @@ const programsList = [
 ];
 
 const coursesList = [
-  { // 1
+  { // 0
     _id: new ObjectID(),
     subProgram: subProgramsList[0]._id,
     company: authCompany._id,
@@ -127,7 +127,7 @@ const coursesList = [
     type: 'intra',
     salesRepresentative: vendorAdmin._id,
   },
-  { // 2
+  { // 1
     _id: new ObjectID(),
     subProgram: subProgramsList[0]._id,
     company: otherCompany._id,
@@ -137,7 +137,7 @@ const coursesList = [
     type: 'intra',
     salesRepresentative: vendorAdmin._id,
   },
-  { // 3
+  { // 2
     _id: new ObjectID(),
     subProgram: subProgramsList[0]._id,
     company: authCompany._id,
@@ -154,7 +154,7 @@ const coursesList = [
     ],
     salesRepresentative: vendorAdmin._id,
   },
-  { // 4
+  { // 3
     _id: new ObjectID(),
     subProgram: subProgramsList[0]._id,
     company: otherCompany._id,
@@ -164,7 +164,7 @@ const coursesList = [
     salesRepresentative: vendorAdmin._id,
     trainer: trainerAndCoach._id,
   },
-  { // 5 course without slots
+  { // 4 course without slots
     _id: new ObjectID(),
     subProgram: subProgramsList[0]._id,
     misc: 'inter b2b session concerning auth company',
@@ -174,7 +174,7 @@ const coursesList = [
     trainer: trainer._id,
     salesRepresentative: vendorAdmin._id,
   },
-  { // 6 course with slots
+  { // 5 course with slots
     _id: new ObjectID(),
     subProgram: subProgramsList[0]._id,
     misc: 'inter b2b session NOT concerning auth company',
@@ -183,7 +183,7 @@ const coursesList = [
     trainees: [noRoleNoCompany._id],
     salesRepresentative: vendorAdmin._id,
   },
-  { // 7 course without trainees and slots
+  { // 6 course without trainees and slots
     _id: new ObjectID(),
     subProgram: subProgramsList[0]._id,
     misc: 'inter b2b session NOT concerning auth company',
@@ -191,7 +191,7 @@ const coursesList = [
     format: 'strictly_e_learning',
     salesRepresentative: vendorAdmin._id,
   },
-  { // 8 course with slots to plan
+  { // 7 course with slots to plan
     _id: new ObjectID(),
     subProgram: subProgramsList[0]._id,
     misc: 'inter b2b session NOT concerning auth company',
@@ -200,7 +200,7 @@ const coursesList = [
     trainees: [trainer._id],
     salesRepresentative: vendorAdmin._id,
   },
-  { // 9 course with access rules
+  { // 8 course with access rules
     _id: new ObjectID(),
     subProgram: subProgramsList[0]._id,
     misc: 'inter_b2b with accessRules',
@@ -210,7 +210,7 @@ const coursesList = [
     accessRules: [authCompany._id, new ObjectID()],
     salesRepresentative: vendorAdmin._id,
   },
-  { // 10 course with access rules and trainee that can't have access to the course but has already suscribed
+  { // 9 course with access rules and trainee that can't have access to the course but has already suscribed
     _id: new ObjectID(),
     subProgram: subProgramsList[0]._id,
     misc: 'inter_b2b with accessRules',
@@ -220,7 +220,7 @@ const coursesList = [
     accessRules: [authCompany._id, new ObjectID()],
     salesRepresentative: vendorAdmin._id,
   },
-  { // 11 course with contact
+  { // 10 course with contact
     _id: new ObjectID(),
     subProgram: subProgramsList[0]._id,
     trainer: coach._id,
@@ -230,7 +230,7 @@ const coursesList = [
     contact: { name: 'Romain Delendarroze', email: 'romainlebg77@gmail.com', phone: '0123456789' },
     salesRepresentative: vendorAdmin._id,
   },
-  { // 12 course without authCompany in access rules (11ème position)
+  { // 11 course without authCompany in access rules (11ème position)
     _id: new ObjectID(),
     subProgram: subProgramsList[0]._id,
     misc: 'inter_b2b',
@@ -240,7 +240,7 @@ const coursesList = [
     accessRules: [otherCompany._id],
     salesRepresentative: vendorAdmin._id,
   },
-  { // 13 course with no on-site slot
+  { // 12 course with no on-site slot
     _id: new ObjectID(),
     subProgram: subProgramsList[1]._id,
     misc: 'inter_b2b',

--- a/tests/integration/seed/coursesSeed.js
+++ b/tests/integration/seed/coursesSeed.js
@@ -126,7 +126,6 @@ const coursesList = [
     trainees: [coach._id, helper._id, clientAdmin._id, trainer._id],
     type: 'intra',
     salesRepresentative: vendorAdmin._id,
-    // format: 'strictly_e_learning',
   },
   { // 2
     _id: new ObjectID(),


### PR DESCRIPTION
### TESTS
- [ ] ~Mon code est testé unitairement~ je n'ai pas touché aux helpers

- Tests intégrations :
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [x] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### ~FONCTIONNALITÉS APPS MOBILES~
- Si mes changements impactent l'application formation :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- Si mes changements impactent l'application erp :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : formation vendeur et client

- Périmetre roles : rof et coach

- Cas d'usage : ETQ rof, coté vendeur Sur la page d'une foramtion, je peux archiver une formation avec un bouton en haut a gauche. Une fois la formation archivée, une pastille grise apparait dans le header. Coté client, etq rof, le bouton n'apparait pas.

ETQ coach, coté client. Le bouton n'apparait pas. La pastille apparait si la formation est archivée.
