### PR TITLE
COM-2474 - Prevent event creation and update if customer is absent

### DIFF
--- a/src/helpers/customerAbsences.js
+++ b/src/helpers/customerAbsences.js
@@ -1,3 +1,9 @@
 const CustomerAbsence = require('../models/CustomerAbsence');
 
 exports.create = async (payload, companyId) => CustomerAbsence.create({ ...payload, company: companyId });
+
+exports.isAbsent = (customer, date) => CustomerAbsence.countDocuments({
+  customer,
+  startDate: { $lte: date },
+  endDate: { $gte: date },
+});

--- a/src/helpers/customerAbsences.js
+++ b/src/helpers/customerAbsences.js
@@ -2,7 +2,7 @@ const CustomerAbsence = require('../models/CustomerAbsence');
 
 exports.create = async (payload, companyId) => CustomerAbsence.create({ ...payload, company: companyId });
 
-exports.isAbsent = (customer, date) => CustomerAbsence.countDocuments({
+exports.isAbsent = async (customer, date) => !!await CustomerAbsence.countDocuments({
   customer,
   startDate: { $lte: date },
   endDate: { $gte: date },

--- a/src/helpers/eventsValidation.js
+++ b/src/helpers/eventsValidation.js
@@ -67,10 +67,8 @@ exports.isEditionAllowed = async (event) => {
   }
 
   if (event.type === INTERVENTION) {
-    if (event.customer) {
-      const customerIsAbsent = await CustomerAbsencesHelper.isAbsent(event.customer, event.startDate);
-      if (customerIsAbsent) throw Boom.conflict(translate[language].customerIsAbsent);
-    }
+    const customerIsAbsent = await CustomerAbsencesHelper.isAbsent(event.customer, event.startDate);
+    if (customerIsAbsent) throw Boom.conflict(translate[language].customerIsAbsent);
 
     return exports.isCustomerSubscriptionValid(event);
   }

--- a/src/helpers/eventsValidation.js
+++ b/src/helpers/eventsValidation.js
@@ -8,6 +8,7 @@ const User = require('../models/User');
 const Customer = require('../models/Customer');
 const EventHistory = require('../models/EventHistory');
 const ContractsHelper = require('./contracts');
+const CustomerAbsencesHelper = require('./customerAbsences');
 const EventRepository = require('../repositories/EventRepository');
 const UtilsHelper = require('./utils');
 const translate = require('./translate');
@@ -65,7 +66,14 @@ exports.isEditionAllowed = async (event) => {
     if (!isUserContractValidOnEventDates) return false;
   }
 
-  if (event.type === INTERVENTION) return exports.isCustomerSubscriptionValid(event);
+  if (event.type === INTERVENTION) {
+    if (event.customer) {
+      const customerIsAbsent = await CustomerAbsencesHelper.isAbsent(event.customer, event.startDate);
+      if (customerIsAbsent) throw Boom.conflict(translate[language].customerIsAbsent);
+    }
+
+    return exports.isCustomerSubscriptionValid(event);
+  }
 
   return true;
 };

--- a/src/helpers/translate.js
+++ b/src/helpers/translate.js
@@ -119,6 +119,7 @@ module.exports = {
     qrCodeCreated: 'QR code created.',
     archivingNotAllowed: 'Archiving not allowed : customer has non-billed interventions.',
     archivingNotAllowedBeforeStoppingDate: 'Archiving not allowed before stopping date.',
+    customerIsAbsent: 'Customer is absent at this date.',
     /* Customer absence */
     stoppedCustomer: 'Can\'t create an absence on a period where customer is stopped.',
     customerAlreadyAbsent: 'Customer absence already exists on this period.',
@@ -469,6 +470,7 @@ module.exports = {
     qrCodeCreated: 'QR code créé.',
     archivingNotAllowed: 'Archivage impossible : interventions non facturées.',
     archivingNotAllowedBeforeStoppingDate: 'Vous ne pouvez pas archiver une personne avant sa date d\'arrêt.',
+    customerIsAbsent: 'Le bénéficiaire est absent à cette date',
     /* Customer absence */
     stoppedCustomer: 'Impossible: le bénéficiaire est arrêté sur cette période.',
     customerAlreadyAbsent: 'Impossible: une absence existe déjà sur cette période.',
@@ -496,7 +498,7 @@ module.exports = {
     eventDeleted: 'Evènement supprimé.',
     eventsDeleted: 'Evènements supprimé.',
     eventDatesNotOnSameDay: 'Les dates de début et de fin devraient être le même jour.',
-    eventsConflict: 'Evènement en conflit avec les évènements de l\'auxiliaire.',
+    eventsConflict: 'L\'évènement est en conflit avec les évènements de l\'auxiliaire.',
     eventTimeStamped: 'Evènement horodaté.',
     alreadyTimeStamped: 'L\'évènement est déja horodaté.',
     timeStampConflict: 'L\'horodatage est en conflit avec un évènement.',

--- a/src/helpers/translate.js
+++ b/src/helpers/translate.js
@@ -470,7 +470,7 @@ module.exports = {
     qrCodeCreated: 'QR code créé.',
     archivingNotAllowed: 'Archivage impossible : interventions non facturées.',
     archivingNotAllowedBeforeStoppingDate: 'Vous ne pouvez pas archiver une personne avant sa date d\'arrêt.',
-    customerIsAbsent: 'Le bénéficiaire est absent à cette date',
+    customerIsAbsent: 'Le bénéficiaire est absent à cette date.',
     /* Customer absence */
     stoppedCustomer: 'Impossible: le bénéficiaire est arrêté sur cette période.',
     customerAlreadyAbsent: 'Impossible: une absence existe déjà sur cette période.',

--- a/tests/unit/customerAbsences.test.js
+++ b/tests/unit/customerAbsences.test.js
@@ -1,5 +1,6 @@
 const { ObjectID } = require('bson');
 const sinon = require('sinon');
+const expect = require('expect');
 const CustomerAbsence = require('../../src/models/CustomerAbsence');
 const CustomerAbsenceHelper = require('../../src/helpers/customerAbsences');
 
@@ -20,6 +21,7 @@ describe('createAbsence', () => {
       customer: new ObjectID(),
       absenceType: 'leave',
     };
+
     await CustomerAbsenceHelper.create(payload, companyId);
 
     sinon.assert.calledOnceWithExactly(create, { ...payload, company: companyId });
@@ -39,11 +41,25 @@ describe('isAbsent', () => {
     const customer = new ObjectID();
     const date = new Date('2019-11-01');
 
-    await CustomerAbsenceHelper.isAbsent(customer, date);
+    countDocuments.returns(1);
 
+    const result = await CustomerAbsenceHelper.isAbsent(customer, date);
+
+    expect(result).toEqual(true);
     sinon.assert.calledOnceWithExactly(
       countDocuments,
       { customer, startDate: { $lte: new Date('2019-11-01') }, endDate: { $gte: new Date('2019-11-01') } }
     );
+  });
+
+  it('should return false if customer is not absent', async () => {
+    const customer = new ObjectID();
+    const date = new Date('2019-11-01');
+
+    countDocuments.returns(0);
+
+    const result = await CustomerAbsenceHelper.isAbsent(customer, date);
+
+    expect(result).toEqual(false);
   });
 });

--- a/tests/unit/customerAbsences.test.js
+++ b/tests/unit/customerAbsences.test.js
@@ -25,3 +25,25 @@ describe('createAbsence', () => {
     sinon.assert.calledOnceWithExactly(create, { ...payload, company: companyId });
   });
 });
+
+describe('isAbsent', () => {
+  let countDocuments;
+  beforeEach(() => {
+    countDocuments = sinon.stub(CustomerAbsence, 'countDocuments');
+  });
+  afterEach(() => {
+    countDocuments.restore();
+  });
+
+  it('should return true if customer is absent', async () => {
+    const customer = new ObjectID();
+    const date = new Date('2019-11-01');
+
+    await CustomerAbsenceHelper.isAbsent(customer, date);
+
+    sinon.assert.calledOnceWithExactly(
+      countDocuments,
+      { customer, startDate: { $lte: new Date('2019-11-01') }, endDate: { $gte: new Date('2019-11-01') } }
+    );
+  });
+});

--- a/tests/unit/helpers/eventsValidation.test.js
+++ b/tests/unit/helpers/eventsValidation.test.js
@@ -484,7 +484,7 @@ describe('isCreationAllowed', () => {
       await EventsValidationHelper.isCreationAllowed(event, credentials);
     } catch (e) {
       expect(e.output.statusCode).toEqual(409);
-      expect(e.output.payload.message).toEqual('Evènement en conflit avec les évènements de l\'auxiliaire.');
+      expect(e.output.payload.message).toEqual('L\'évènement est en conflit avec les évènements de l\'auxiliaire.');
     } finally {
       sinon.assert.notCalled(isEditionAllowed);
       sinon.assert.calledWithExactly(hasConflicts, event);

--- a/tests/unit/helpers/eventsValidation.test.js
+++ b/tests/unit/helpers/eventsValidation.test.js
@@ -387,7 +387,7 @@ describe('isEditionAllowed', () => {
       await EventsValidationHelper.isEditionAllowed(event, credentials);
     } catch (e) {
       expect(e.output.statusCode).toBe(409);
-      expect(e.output.payload.message).toBe('Le bénéficiaire est absent à cette date');
+      expect(e.output.payload.message).toBe('Le bénéficiaire est absent à cette date.');
     } finally {
       sinon.assert.calledOnceWithExactly(isAbsent, event.customer, event.startDate);
       sinon.assert.notCalled(isUserContractValidOnEventDates);

--- a/tests/unit/helpers/eventsValidation.test.js
+++ b/tests/unit/helpers/eventsValidation.test.js
@@ -6,6 +6,7 @@ const User = require('../../../src/models/User');
 const Customer = require('../../../src/models/Customer');
 const EventHistory = require('../../../src/models/EventHistory');
 const EventsValidationHelper = require('../../../src/helpers/eventsValidation');
+const CustomerAbsencesHelper = require('../../../src/helpers/customerAbsences');
 const EventRepository = require('../../../src/repositories/EventRepository');
 const { INTERVENTION, ABSENCE, INTERNAL_HOUR, UNAVAILABILITY } = require('../../../src/helpers/constants');
 const SinonMongoose = require('../sinonMongoose');
@@ -303,13 +304,16 @@ describe('hasConflicts', () => {
 describe('isEditionAllowed', () => {
   let isUserContractValidOnEventDates;
   let isCustomerSubscriptionValid;
+  let isAbsent;
   beforeEach(() => {
     isUserContractValidOnEventDates = sinon.stub(EventsValidationHelper, 'isUserContractValidOnEventDates');
     isCustomerSubscriptionValid = sinon.stub(EventsValidationHelper, 'isCustomerSubscriptionValid');
+    isAbsent = sinon.stub(CustomerAbsencesHelper, 'isAbsent');
   });
   afterEach(() => {
     isUserContractValidOnEventDates.restore();
     isCustomerSubscriptionValid.restore();
+    isAbsent.restore();
   });
 
   it('should return false as event is not absence and not on one day', async () => {
@@ -364,6 +368,31 @@ describe('isEditionAllowed', () => {
     expect(result).toBeFalsy();
     sinon.assert.calledWithExactly(isUserContractValidOnEventDates, event);
     sinon.assert.notCalled(isCustomerSubscriptionValid);
+  });
+
+  it('should return false if event is intervention and customer is absent', async () => {
+    const companyId = new ObjectID();
+    const credentials = { company: { _id: companyId } };
+    const customerId = new ObjectID();
+    const event = {
+      customer: customerId.toHexString(),
+      type: INTERVENTION,
+      startDate: '2019-04-13T09:00:00',
+      endDate: '2019-04-13T11:00:00',
+    };
+
+    isAbsent.returns(true);
+
+    try {
+      await EventsValidationHelper.isEditionAllowed(event, credentials);
+    } catch (e) {
+      expect(e.output.statusCode).toBe(409);
+      expect(e.output.payload.message).toBe('Le bénéficiaire est absent à cette date');
+    } finally {
+      sinon.assert.calledOnceWithExactly(isAbsent, event.customer, event.startDate);
+      sinon.assert.notCalled(isUserContractValidOnEventDates);
+      sinon.assert.notCalled(isCustomerSubscriptionValid);
+    }
   });
 
   it('should return false if event is intervention and customer subscription is not valid', async () => {


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- ~~Tests intégrations :~~
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [ ] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### ~~FONCTIONNALITÉS APPS MOBILES~~
- Si mes changements impactent l'application formation :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- Si mes changements impactent l'application erp :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### ~~MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME~~
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### ~~MODIFICATIONS SUR LES MODÈLES~~
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### ~~CONSTANTES ET VARIABLE D'ENV~~
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : client

- Périmetre roles : admin / auxi

- Cas d'usage : 
Ne pas autoriser la création / l'édition d'évènement si le bénéficiaire est absent à cette date