### PR TITLE
 Com 2492

### DIFF
--- a/src/helpers/eventsRepetition.js
+++ b/src/helpers/eventsRepetition.js
@@ -182,7 +182,7 @@ exports.updateRepetition = async (eventFromDb, eventPayload, credentials) => {
       endDate,
       _id: events[i]._id,
       type: events[i].type,
-      customer: events[i].customer,
+      ...(events[i].customer && { customer: events[i].customer }),
     };
 
     if (eventToSet.type === INTERVENTION) {

--- a/src/helpers/eventsRepetition.js
+++ b/src/helpers/eventsRepetition.js
@@ -51,6 +51,7 @@ exports.formatRepeatedPayload = async (event, sector, momentDay) => {
     const customerIsAbsent = await CustomerAbsencesHelper.isAbsent(event.customer, payload.startDate);
     if (customerIsAbsent) return null;
   }
+
   if (([INTERNAL_HOUR, UNAVAILABILITY].includes(event.type)) && hasConflicts) return null;
 
   return new Event(payload);

--- a/src/helpers/eventsRepetition.js
+++ b/src/helpers/eventsRepetition.js
@@ -172,6 +172,9 @@ exports.updateRepetition = async (eventFromDb, eventPayload, credentials) => {
   }
 
   for (let i = 0, l = events.length; i < l; i++) {
+    const customerIsAbsent = await CustomerAbsencesHelper.isAbsent(events[i].customer, events[i].startDate);
+    if (customerIsAbsent) continue;
+  
     const startDate = moment(events[i].startDate).hours(parentStartDate.hours())
       .minutes(parentStartDate.minutes()).toISOString();
     const endDate = moment(events[i].endDate).hours(parentEndDate.hours())

--- a/src/jobs/eventRepetitions.js
+++ b/src/jobs/eventRepetitions.js
@@ -82,7 +82,7 @@ const eventRepetitions = {
         const isCustomerStopped = isIntervention && DatesHelper.isAfter(newEventStartDate, stoppedAt);
 
         if (isIntervention) {
-          const isCustomerAbsent = await CustomerAbsencesHelper.isAbsent(repetition.customer, newEventStartDate);
+          const isCustomerAbsent = await CustomerAbsencesHelper.isAbsent(repetition.customer._id, newEventStartDate);
           if (isCustomerAbsent) continue;
         }
 

--- a/tests/unit/helpers/eventsRepetition.test.js
+++ b/tests/unit/helpers/eventsRepetition.test.js
@@ -1081,7 +1081,7 @@ describe('updateRepetition', () => {
     sinon.assert.notCalled(formatEditionPayload);
     sinon.assert.notCalled(isAbsent);
   });
-  
+
   it('should not update an event of a repetition if customer is absent during this period', async () => {
     const companyId = new ObjectID();
     const credentials = { company: { _id: companyId } };
@@ -1135,7 +1135,7 @@ describe('updateRepetition', () => {
     isAbsent.onCall(2).returns(true);
 
     await EventsRepetitionHelper.updateRepetition(event, payload, credentials);
-    
+
     sinon.assert.notCalled(findOneUser);
     SinonMongoose.calledWithExactly(
       find,

--- a/tests/unit/helpers/eventsRepetition.test.js
+++ b/tests/unit/helpers/eventsRepetition.test.js
@@ -762,6 +762,7 @@ describe('updateRepetition', () => {
         startDate: '2019-03-23T09:00:00.000Z',
         endDate: '2019-03-23T11:00:00.000Z',
         _id: 'asdfghjk',
+        type: ABSENCE,
       },
       {
         repetition: { parentId: 'qwertyuiop', frequency: 'every_day' },
@@ -813,11 +814,12 @@ describe('updateRepetition', () => {
         endDate: '2019-03-23T11:00:00.000Z',
         auxiliary: '1234567890',
         _id: 'asdfghjk',
+        type: ABSENCE,
       },
       false
     );
     sinon.assert.calledWithExactly(updateRepetitions, payload, 'qwertyuiop');
-    sinon.assert.calledOnceWithExactly(isAbsent, events[1].customer, events[1].startDate);
+    sinon.assert.calledOnceWithExactly(isAbsent, events[1].customer, '2019-03-24T10:00:00.000Z');
   });
 
   it('should unassign intervention in conflict', async () => {
@@ -842,6 +844,7 @@ describe('updateRepetition', () => {
         startDate: '2019-03-24T09:00:00.000Z',
         endDate: '2019-03-24T11:00:00.000Z',
         _id: '123456',
+        type: ABSENCE,
       },
     ];
 
@@ -895,6 +898,7 @@ describe('updateRepetition', () => {
         startDate: '2019-03-24T10:00:00.000Z',
         endDate: '2019-03-24T11:00:00.000Z',
         company: companyId,
+        type: ABSENCE,
       }
     );
     sinon.assert.calledWithExactly(
@@ -920,6 +924,7 @@ describe('updateRepetition', () => {
         endDate: '2019-03-24T11:00:00.000Z',
         sector: sectorId,
         _id: '123456',
+        type: ABSENCE,
       },
       true
     );
@@ -945,6 +950,7 @@ describe('updateRepetition', () => {
         startDate: '2019-03-24T09:00:00.000Z',
         endDate: '2019-03-24T11:00:00.000Z',
         _id: '123456',
+        type: ABSENCE,
       },
     ];
 
@@ -992,7 +998,13 @@ describe('updateRepetition', () => {
     );
     sinon.assert.calledWithExactly(
       hasConflicts,
-      { _id: '123456', startDate: '2019-03-24T10:00:00.000Z', endDate: '2019-03-24T11:00:00.000Z', company: companyId }
+      {
+        _id: '123456',
+        startDate: '2019-03-24T10:00:00.000Z',
+        endDate: '2019-03-24T11:00:00.000Z',
+        company: companyId,
+        type: ABSENCE,
+      }
     );
     sinon.assert.calledWithExactly(
       updateOne,
@@ -1012,7 +1024,13 @@ describe('updateRepetition', () => {
     sinon.assert.calledOnceWithExactly(
       formatEditionPayload,
       events[0],
-      { startDate: '2019-03-24T10:00:00.000Z', endDate: '2019-03-24T11:00:00.000Z', sector: sectorId, _id: '123456' },
+      {
+        startDate: '2019-03-24T10:00:00.000Z',
+        endDate: '2019-03-24T11:00:00.000Z',
+        sector: sectorId,
+        _id: '123456',
+        type: ABSENCE,
+      },
       false
     );
     sinon.assert.notCalled(deleteOne);
@@ -1037,6 +1055,7 @@ describe('updateRepetition', () => {
         startDate: '2019-03-24T09:00:00.000Z',
         endDate: '2019-03-24T11:00:00.000Z',
         _id: '123456',
+        type: ABSENCE,
       },
     ];
 
@@ -1074,7 +1093,13 @@ describe('updateRepetition', () => {
     );
     sinon.assert.calledWithExactly(
       hasConflicts,
-      { _id: '123456', startDate: '2019-03-24T10:00:00.000Z', endDate: '2019-03-24T11:00:00.000Z', company: companyId }
+      {
+        _id: '123456',
+        startDate: '2019-03-24T10:00:00.000Z',
+        endDate: '2019-03-24T11:00:00.000Z',
+        company: companyId,
+        type: ABSENCE,
+      }
     );
     sinon.assert.notCalled(updateOne);
     sinon.assert.calledWithExactly(deleteOne, { _id: '123456' });
@@ -1158,9 +1183,9 @@ describe('updateRepetition', () => {
     sinon.assert.calledTwice(updateOne);
     sinon.assert.calledTwice(formatEditionPayload);
     sinon.assert.calledWithExactly(updateRepetitions, payload, 'qwertyuiop');
-    sinon.assert.calledWithExactly(isAbsent, events[0].customer, events[0].startDate);
-    sinon.assert.calledWithExactly(isAbsent, events[1].customer, events[1].startDate);
-    sinon.assert.calledWithExactly(isAbsent, events[2].customer, events[2].startDate);
+    sinon.assert.calledWithExactly(isAbsent.getCall(0), events[0].customer, '2019-03-23T10:00:00.000Z');
+    sinon.assert.calledWithExactly(isAbsent.getCall(1), events[1].customer, '2019-03-24T10:00:00.000Z');
+    sinon.assert.calledWithExactly(isAbsent.getCall(2), events[2].customer, '2019-03-25T10:00:00.000Z');
   });
 });
 

--- a/tests/unit/helpers/eventsRepetition.test.js
+++ b/tests/unit/helpers/eventsRepetition.test.js
@@ -237,10 +237,11 @@ describe('formatRepeatedPayload', () => {
 
     hasConflicts.returns(false);
     isAbsent.returns(true);
+
     const result = await EventsRepetitionHelper.formatRepeatedPayload(event, sector, day);
 
     expect(result).toBeNull();
-    sinon.assert.calledWithExactly(isAbsent, event.customer, payload.startDate);
+    sinon.assert.calledOnceWithExactly(isAbsent, event.customer, payload.startDate);
   });
 });
 
@@ -816,7 +817,7 @@ describe('updateRepetition', () => {
       false
     );
     sinon.assert.calledWithExactly(updateRepetitions, payload, 'qwertyuiop');
-    sinon.assert.calledWithExactly(isAbsent, events[1].customer, events[1].startDate);
+    sinon.assert.calledOnceWithExactly(isAbsent, events[1].customer, events[1].startDate);
   });
 
   it('should unassign intervention in conflict', async () => {

--- a/tests/unit/jobs/eventRepetitions.test.js
+++ b/tests/unit/jobs/eventRepetitions.test.js
@@ -66,6 +66,8 @@ describe('method', () => {
 
     it(`should create a J+90 event for ${freq.type} repetition object`, async () => {
       const companyId = new ObjectID();
+      const newEventStartDate = moment(new Date()).add(90, 'd')
+        .set({ hours: 8, minutes: 0, seconds: 0, milliseconds: 0 });
 
       const futureEvent = {
         type: 'intervention',
@@ -74,7 +76,7 @@ describe('method', () => {
         subscription: '5d4422b306ab3d00147caf13',
         auxiliary: '5d121abe9ff937001403b6c6',
         sector: '5d1a40b7ecb0da251cfa4ff2',
-        startDate: moment(new Date()).add(90, 'd').set({ hours: 8, minutes: 0, seconds: 0, milliseconds: 0 }),
+        startDate: newEventStartDate,
         endDate: moment(new Date()).add(90, 'd').set({ hours: 9, minutes: 0, seconds: 0, milliseconds: 0 }),
         repetition: {
           frequency: freq,
@@ -105,7 +107,7 @@ describe('method', () => {
         findCompany,
         [{ query: 'find', args: [{ 'subscriptions.erp': true }] }, { query: 'lean' }]
       );
-      sinon.assert.calledOnceWithExactly(isAbsent, repetition[0].customer._id, futureEvent.startDate);
+      sinon.assert.calledOnceWithExactly(isAbsent, repetition[0].customer._id, newEventStartDate);
       sinon.assert.calledOnceWithExactly(create, futureEvent);
       sinon.assert.notCalled(deleteOneRepetition);
     });
@@ -265,6 +267,8 @@ describe('method', () => {
       frequency: 'every_day',
       parentId: '5d84f869b7e67963c65236a9',
     }];
+    const newEventStartDate = moment(new Date()).add(90, 'd')
+      .set({ hours: 8, minutes: 0, seconds: 0, milliseconds: 0 });
     const futureEvent = {
       type: 'intervention',
       company: new ObjectID(),
@@ -272,7 +276,7 @@ describe('method', () => {
       subscription: '5d4422b306ab3d00147caf13',
       auxiliary: '5d121abe9ff937001403b6c6',
       sector: '5d1a40b7ecb0da251cfa4ff2',
-      startDate: moment(new Date()).add(90, 'd').set({ hours: 8, minutes: 0, seconds: 0, milliseconds: 0 }),
+      startDate: newEventStartDate,
       endDate: moment(new Date()).add(90, 'd').set({ hours: 9, minutes: 0, seconds: 0, milliseconds: 0 }),
       repetition: {
         frequency: 'every_day',
@@ -303,6 +307,6 @@ describe('method', () => {
     sinon.assert.notCalled(formatEventBasedOnRepetitionStub);
     sinon.assert.notCalled(create);
     sinon.assert.notCalled(deleteOneRepetition);
-    sinon.assert.calledOnceWithExactly(isAbsent, repetition[0].customer._id, futureEvent.startDate);
+    sinon.assert.calledOnceWithExactly(isAbsent, repetition[0].customer._id, newEventStartDate);
   });
 });

--- a/tests/unit/jobs/eventRepetitions.test.js
+++ b/tests/unit/jobs/eventRepetitions.test.js
@@ -255,17 +255,21 @@ describe('method', () => {
 
   it('should not create an event of a repetition if customer is absent', async () => {
     const companyId = new ObjectID();
+    const auxiliaryId = new ObjectID();
+    const subscriptionId = new ObjectID();
+    const sectorId = new ObjectID();
+    const parentId = new ObjectID();
     const repetition = [{
       _id: '5d84f869b7e67963c6523704',
       type: 'intervention',
       customer: { _id: new ObjectID() },
-      subscription: '5d4422b306ab3d00147caf13',
-      auxiliary: '5d121abe9ff937001403b6c6',
-      sector: '5d1a40b7ecb0da251cfa4ff2',
+      subscription: subscriptionId,
+      auxiliary: auxiliaryId,
+      sector: sectorId,
       startDate: '2019-09-16T06:00:00.000Z',
       endDate: '2019-09-16T06:00:00.000Z',
       frequency: 'every_day',
-      parentId: '5d84f869b7e67963c65236a9',
+      parentId,
     }];
     const newEventStartDate = moment(new Date()).add(90, 'd')
       .set({ hours: 8, minutes: 0, seconds: 0, milliseconds: 0 });
@@ -273,15 +277,12 @@ describe('method', () => {
       type: 'intervention',
       company: new ObjectID(),
       customer: { _id: new ObjectID() },
-      subscription: '5d4422b306ab3d00147caf13',
-      auxiliary: '5d121abe9ff937001403b6c6',
-      sector: '5d1a40b7ecb0da251cfa4ff2',
+      subscription: subscriptionId,
+      auxiliary: auxiliaryId,
+      sector: sectorId,
       startDate: newEventStartDate,
       endDate: moment(new Date()).add(90, 'd').set({ hours: 9, minutes: 0, seconds: 0, milliseconds: 0 }),
-      repetition: {
-        frequency: 'every_day',
-        parentId: '5d84f869b7e67963c65236a9',
-      },
+      repetition: { frequency: 'every_day', parentId },
     };
 
     findRepetition.returns(SinonMongoose.stubChainedQueries([repetition]));

--- a/tests/unit/jobs/eventRepetitions.test.js
+++ b/tests/unit/jobs/eventRepetitions.test.js
@@ -7,6 +7,7 @@ const Repetition = require('../../../src/models/Repetition');
 const Company = require('../../../src/models/Company');
 const Event = require('../../../src/models/Event');
 const EventsRepetitionHelper = require('../../../src/helpers/eventsRepetition');
+const CustomerAbsencesHelper = require('../../../src/helpers/customerAbsences');
 const eventRepetitions = require('../../../src/jobs/eventRepetitions');
 
 describe('method', () => {
@@ -19,6 +20,7 @@ describe('method', () => {
   const server = { log: (tags, text) => `${tags}, ${text}` };
   let serverLogStub;
   let deleteOneRepetition;
+  let isAbsent;
   beforeEach(() => {
     create = sinon.stub(Event, 'create');
     findRepetition = sinon.stub(Repetition, 'find');
@@ -27,6 +29,7 @@ describe('method', () => {
     date = sinon.useFakeTimers(fakeDate);
     serverLogStub = sinon.stub(server, 'log');
     deleteOneRepetition = sinon.stub(Repetition, 'deleteOne');
+    isAbsent = sinon.stub(CustomerAbsencesHelper, 'isAbsent');
   });
   afterEach(() => {
     create.restore();
@@ -36,6 +39,7 @@ describe('method', () => {
     date.restore();
     serverLogStub.restore();
     deleteOneRepetition.restore();
+    isAbsent.restore();
   });
 
   const frequencies = [
@@ -44,11 +48,13 @@ describe('method', () => {
     { type: 'every_week_day', dates: { startDate: '2019-09-19T06:00:00.000Z', endDate: '2019-09-19T07:00:00.000Z' } },
     { type: 'every_two_weeks', dates: { startDate: '2019-08-29T06:00:00.000Z', endDate: '2019-08-29T07:00:00.000Z' } },
   ];
+  const customerId = new ObjectID();
+
   frequencies.forEach((freq) => {
     const repetition = [{
       _id: '5d84f869b7e67963c6523704',
       type: 'intervention',
-      customer: { _id: new ObjectID() },
+      customer: { _id: customerId },
       subscription: '5d4422b306ab3d00147caf13',
       auxiliary: '5d121abe9ff937001403b6c6',
       sector: '5d1a40b7ecb0da251cfa4ff2',
@@ -61,25 +67,27 @@ describe('method', () => {
     it(`should create a J+90 event for ${freq.type} repetition object`, async () => {
       const companyId = new ObjectID();
 
-      findRepetition.returns(SinonMongoose.stubChainedQueries([repetition]));
-      findCompany.returns(SinonMongoose.stubChainedQueries([[{ _id: companyId }]], ['lean']));
-
-      const futureEvent = new Event({
+      const futureEvent = {
         type: 'intervention',
         company: new ObjectID(),
         customer: { _id: new ObjectID() },
         subscription: '5d4422b306ab3d00147caf13',
         auxiliary: '5d121abe9ff937001403b6c6',
         sector: '5d1a40b7ecb0da251cfa4ff2',
-        startDate: moment().add(90, 'd').set({ hours: 8, minutes: 0, seconds: 0, milliseconds: 0 }).toDate(),
-        endDate: moment().add(90, 'd').set({ hours: 9, minutes: 0, seconds: 0, milliseconds: 0 }).toDate(),
+        startDate: moment(new Date()).add(90, 'd').set({ hours: 8, minutes: 0, seconds: 0, milliseconds: 0 }),
+        endDate: moment(new Date()).add(90, 'd').set({ hours: 9, minutes: 0, seconds: 0, milliseconds: 0 }),
         repetition: {
           frequency: freq,
           parentId: '5d84f869b7e67963c65236a9',
         },
-      });
+      };
+
+      findRepetition.returns(SinonMongoose.stubChainedQueries([repetition]));
+      findCompany.returns(SinonMongoose.stubChainedQueries([[{ _id: companyId }]], ['lean']));
+
       formatEventBasedOnRepetitionStub.returns(futureEvent);
       create.returns(futureEvent);
+      isAbsent.returns(false);
 
       const result = await eventRepetitions.method(server);
 
@@ -97,6 +105,7 @@ describe('method', () => {
         findCompany,
         [{ query: 'find', args: [{ 'subscriptions.erp': true }] }, { query: 'lean' }]
       );
+      sinon.assert.calledOnceWithExactly(isAbsent, repetition[0].customer._id, futureEvent.startDate);
       sinon.assert.calledOnceWithExactly(create, futureEvent);
       sinon.assert.notCalled(deleteOneRepetition);
     });
@@ -240,5 +249,60 @@ describe('method', () => {
       [{ query: 'find', args: [{ 'subscriptions.erp': true }] }, { query: 'lean' }]
     );
     sinon.assert.calledWith(serverLogStub, ['error', 'cron', 'jobs'], error);
+  });
+
+  it('should not create an event of a repetition if customer is absent', async () => {
+    const companyId = new ObjectID();
+    const repetition = [{
+      _id: '5d84f869b7e67963c6523704',
+      type: 'intervention',
+      customer: { _id: new ObjectID() },
+      subscription: '5d4422b306ab3d00147caf13',
+      auxiliary: '5d121abe9ff937001403b6c6',
+      sector: '5d1a40b7ecb0da251cfa4ff2',
+      startDate: '2019-09-16T06:00:00.000Z',
+      endDate: '2019-09-16T06:00:00.000Z',
+      frequency: 'every_day',
+      parentId: '5d84f869b7e67963c65236a9',
+    }];
+    const futureEvent = {
+      type: 'intervention',
+      company: new ObjectID(),
+      customer: { _id: new ObjectID() },
+      subscription: '5d4422b306ab3d00147caf13',
+      auxiliary: '5d121abe9ff937001403b6c6',
+      sector: '5d1a40b7ecb0da251cfa4ff2',
+      startDate: moment(new Date()).add(90, 'd').set({ hours: 8, minutes: 0, seconds: 0, milliseconds: 0 }),
+      endDate: moment(new Date()).add(90, 'd').set({ hours: 9, minutes: 0, seconds: 0, milliseconds: 0 }),
+      repetition: {
+        frequency: 'every_day',
+        parentId: '5d84f869b7e67963c65236a9',
+      },
+    };
+
+    findRepetition.returns(SinonMongoose.stubChainedQueries([repetition]));
+    findCompany.returns(SinonMongoose.stubChainedQueries([[{ _id: companyId }]], ['lean']));
+    formatEventBasedOnRepetitionStub.returns(futureEvent);
+    isAbsent.returns(true);
+
+    const result = await eventRepetitions.method(server);
+
+    expect(result).toMatchObject({ results: [], errors: [], deletedRepetitions: [] });
+    SinonMongoose.calledWithExactly(
+      findRepetition,
+      [
+        { query: 'find', args: [{ startDate: { $lt: fakeDate }, company: companyId }] },
+        { query: 'populate', args: [{ path: 'customer', select: 'stoppedAt' }] },
+        { query: 'lean' },
+      ]
+    );
+    SinonMongoose.calledWithExactly(
+      findCompany,
+      [{ query: 'find', args: [{ 'subscriptions.erp': true }] }, { query: 'lean' }]
+    );
+    sinon.assert.notCalled(formatEventBasedOnRepetitionStub);
+    sinon.assert.notCalled(create);
+    sinon.assert.notCalled(deleteOneRepetition);
+    sinon.assert.calledOnceWithExactly(isAbsent, repetition[0].customer._id, futureEvent.startDate);
   });
 });


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations :
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [ ] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES
- Si mes changements impactent l'application formation :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- Si mes changements impactent l'application erp :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : client 

- Périmetre roles : coach/auxiliaire/admin

- Cas d'usage : Les interventions d'une répétition ne sont pas créés si le bénéficiaire a une absence.
Pour tester la PR:
 - creer une absence beneficiaire 
 - creer une répétition qui commence avant et finit apres l'absence : les evenements avant et apres l'absence sont créés
 - tester l'edition de cette répétition
 
Sur postman: 
- supprimer les absences en bdd
- creer une absence pour un beneficiaire dans 90 jours ( 17/11 + 90j --> 15/02)
- lancer la requête GET /scripts/events-repetitions
- les evenemments sont créés sauf pour le beneficiaire absent 
