### PR TITLE
COM-2483 add integration test

### DIFF
--- a/src/routes/courses.js
+++ b/src/routes/courses.js
@@ -44,6 +44,7 @@ const {
   checkSalesRepresentativeExists,
   authorizeGetQuestionnaires,
   authorizeAttendanceSheetsGetAndAssignCourse,
+  authorizeSmsSending,
 } = require('./preHandlers/courses');
 const { INTRA } = require('../helpers/constants');
 
@@ -218,7 +219,11 @@ exports.plugin = {
             type: Joi.string().required().valid(...MESSAGE_TYPE),
           }).required(),
         },
-        pre: [{ method: getCourse, assign: 'course' }, { method: authorizeCourseEdit }],
+        pre: [
+          { method: getCourse, assign: 'course' },
+          { method: authorizeCourseEdit },
+          { method: authorizeSmsSending },
+        ],
       },
       handler: sendSMS,
     });

--- a/src/routes/preHandlers/courses.js
+++ b/src/routes/preHandlers/courses.js
@@ -321,3 +321,12 @@ exports.authorizeAttendanceSheetsGetAndAssignCourse = async (req) => {
 
   return course;
 };
+
+exports.authorizeSmsSending = async (req) => {
+  const { course } = req.pre;
+
+  const slotsToCome = course.slots.filter(slot => moment().isBefore(slot.startDate));
+  if (!slotsToCome.length && !course.slotsToPlan.length) throw Boom.forbidden();
+
+  return null;
+};

--- a/src/routes/preHandlers/courses.js
+++ b/src/routes/preHandlers/courses.js
@@ -328,11 +328,11 @@ exports.authorizeSmsSending = async (req) => {
 
   const noSlotToCome = !course.slots || !course.slots.some(slot => moment().isBefore(slot.startDate));
   const noReceiver = !course.trainees || !course.trainees.some(trainee => get(trainee, 'contact.phone'));
-  if (noSlotToCome) throw Boom.forbidden('no slot to come');
-  if (noReceiver) throw Boom.forbidden('no receiver');
-  if (!get(course, 'contact.name')) throw Boom.forbidden('no contact name');
-  if (!get(course, 'contact.phone')) throw Boom.forbidden('no contact phone');
-  if (!course.trainer) throw Boom.forbidden('no trainer');
+  if (noSlotToCome) throw Boom.forbidden();
+  if (noReceiver) throw Boom.forbidden();
+  if (!get(course, 'contact.name')) throw Boom.forbidden();
+  if (!get(course, 'contact.phone')) throw Boom.forbidden();
+  if (!course.trainer) throw Boom.forbidden();
 
   return null;
 };

--- a/src/routes/preHandlers/courses.js
+++ b/src/routes/preHandlers/courses.js
@@ -64,7 +64,7 @@ exports.authorizeCourseEdit = async (req) => {
   try {
     const { credentials } = req.auth;
     const { course } = req.pre;
-    if (course.archivedAt) throw Boom.forbidden('archived');
+    if (course.archivedAt) throw Boom.forbidden();
 
     const courseTrainerId = course.trainer ? course.trainer.toHexString() : null;
     const courseCompanyId = course.company ? course.company.toHexString() : null;

--- a/tests/integration/courses.test.js
+++ b/tests/integration/courses.test.js
@@ -1195,6 +1195,10 @@ describe('COURSES ROUTES - POST /courses/{_id}/sms', () => {
   const courseIdFromAuthCompany = coursesList[2]._id;
   const courseIdFromOtherCompany = coursesList[3]._id;
   const archivedCourseId = coursesList[14]._id;
+  const courseIdWithNoReceiver = coursesList[7]._id;
+  const courseIdWithoutContactName = coursesList[9]._id;
+  const courseIdWithoutContactPhone = coursesList[1]._id;
+  const courseIdWithoutTrainer = coursesList[8]._id;
   let SmsHelperStub;
   let momentIsBefore;
   const payload = { content: 'Ceci est un test', type: CONVOCATION };
@@ -1209,7 +1213,7 @@ describe('COURSES ROUTES - POST /courses/{_id}/sms', () => {
     momentIsBefore.restore();
   });
 
-  describe('TRAINING_ORGANISATION_MANAGER #tag', () => {
+  describe('TRAINING_ORGANISATION_MANAGER', () => {
     beforeEach(async () => {
       authToken = await getToken('training_organisation_manager');
     });
@@ -1251,7 +1255,7 @@ describe('COURSES ROUTES - POST /courses/{_id}/sms', () => {
       sinon.assert.notCalled(SmsHelperStub);
     });
 
-    it('should return a 403 if course is finished or has no slot', async () => {
+    it('should return a 403 if course has no slot to come', async () => {
       momentIsBefore.returns(false);
       const response = await app.inject({
         method: 'POST',
@@ -1261,6 +1265,59 @@ describe('COURSES ROUTES - POST /courses/{_id}/sms', () => {
       });
 
       expect(response.statusCode).toBe(403);
+      expect(response.result.message).toBe('no slot to come');
+      sinon.assert.notCalled(SmsHelperStub);
+    });
+
+    it('should return a 403 if sms have no receiver', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: `/courses/${courseIdWithNoReceiver}/sms`,
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(403);
+      expect(response.result.message).toBe('no receiver');
+      sinon.assert.notCalled(SmsHelperStub);
+    });
+
+    it('should return a 403 if course has no contact name', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: `/courses/${courseIdWithoutContactName}/sms`,
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(403);
+      expect(response.result.message).toBe('no contact name');
+      sinon.assert.notCalled(SmsHelperStub);
+    });
+
+    it('should return a 403 if course has no contact phone', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: `/courses/${courseIdWithoutContactPhone}/sms`,
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(403);
+      expect(response.result.message).toBe('no contact phone');
+      sinon.assert.notCalled(SmsHelperStub);
+    });
+
+    it('should return a 403 if course has no trainer', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: `/courses/${courseIdWithoutTrainer}/sms`,
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(403);
+      expect(response.result.message).toBe('no trainer');
       sinon.assert.notCalled(SmsHelperStub);
     });
 
@@ -1273,6 +1330,7 @@ describe('COURSES ROUTES - POST /courses/{_id}/sms', () => {
       });
 
       expect(response.statusCode).toBe(403);
+      expect(response.result.message).toBe('archived');
       sinon.assert.notCalled(SmsHelperStub);
     });
 

--- a/tests/integration/courses.test.js
+++ b/tests/integration/courses.test.js
@@ -1193,6 +1193,7 @@ describe('COURSES ROUTES - POST /courses/{_id}/sms', () => {
   let authToken;
   const courseIdFromAuthCompany = coursesList[2]._id;
   const courseIdFromOtherCompany = coursesList[3]._id;
+  const courseIdArchived = coursesList[14]._id;
   let SmsHelperStub;
   const payload = { content: 'Ceci est un test', type: CONVOCATION };
 
@@ -1235,7 +1236,6 @@ describe('COURSES ROUTES - POST /courses/{_id}/sms', () => {
     });
 
     it('should return a 400 error if type is invalid', async () => {
-      SmsHelperStub.returns('SMS SENT !');
       const response = await app.inject({
         method: 'POST',
         url: `/courses/${courseIdFromAuthCompany}/sms`,
@@ -1247,9 +1247,20 @@ describe('COURSES ROUTES - POST /courses/{_id}/sms', () => {
       sinon.assert.notCalled(SmsHelperStub);
     });
 
+    it('should return a 403 if course is archived', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: `/courses/${courseIdArchived}/sms`,
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(403);
+      sinon.assert.notCalled(SmsHelperStub);
+    });
+
     ['content', 'type'].forEach((param) => {
       it(`should return a 400 error if missing ${param} parameter`, async () => {
-        SmsHelperStub.returns('SMS SENT !');
         const response = await app.inject({
           method: 'POST',
           url: `/courses/${courseIdFromAuthCompany}/sms`,

--- a/tests/integration/courses.test.js
+++ b/tests/integration/courses.test.js
@@ -1193,7 +1193,7 @@ describe('COURSES ROUTES - POST /courses/{_id}/sms', () => {
   let authToken;
   const courseIdFromAuthCompany = coursesList[2]._id;
   const courseIdFromOtherCompany = coursesList[3]._id;
-  const courseIdArchived = coursesList[14]._id;
+  const archivedCourseId = coursesList[14]._id;
   let SmsHelperStub;
   const payload = { content: 'Ceci est un test', type: CONVOCATION };
 
@@ -1250,7 +1250,7 @@ describe('COURSES ROUTES - POST /courses/{_id}/sms', () => {
     it('should return a 403 if course is archived', async () => {
       const response = await app.inject({
         method: 'POST',
-        url: `/courses/${courseIdArchived}/sms`,
+        url: `/courses/${archivedCourseId}/sms`,
         payload,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });

--- a/tests/integration/seed/coursesSeed.js
+++ b/tests/integration/seed/coursesSeed.js
@@ -196,10 +196,12 @@ const coursesList = [
   { // 7 course with slots to plan
     _id: new ObjectID(),
     subProgram: subProgramsList[0]._id,
+    contact: { name: 'Alain Bashung', phone: '0191166745' },
     misc: 'inter b2b session NOT concerning auth company',
     type: 'inter_b2b',
     format: 'blended',
     trainees: [trainer._id],
+    trainer: coach._id,
     salesRepresentative: vendorAdmin._id,
   },
   { // 8 course with access rules
@@ -216,6 +218,8 @@ const coursesList = [
   { // 9 course with access rules and trainee that can't have access to the course but has already suscribed
     _id: new ObjectID(),
     subProgram: subProgramsList[0]._id,
+    contact: { phone: '0127274124' },
+    trainer: trainer._id,
     misc: 'inter_b2b with accessRules',
     type: 'inter_b2b',
     format: 'strictly_e_learning',

--- a/tests/integration/seed/coursesSeed.js
+++ b/tests/integration/seed/coursesSeed.js
@@ -130,6 +130,7 @@ const coursesList = [
   { // 1
     _id: new ObjectID(),
     subProgram: subProgramsList[0]._id,
+    contact: { name: 'Johnny' },
     company: otherCompany._id,
     misc: 'team formation',
     trainer: new ObjectID(),
@@ -140,6 +141,7 @@ const coursesList = [
   { // 2
     _id: new ObjectID(),
     subProgram: subProgramsList[0]._id,
+    contact: { name: 'Slim Shady', phone: '0987654433' },
     company: authCompany._id,
     misc: 'second session',
     trainer: trainer._id,
@@ -203,6 +205,7 @@ const coursesList = [
   { // 8 course with access rules
     _id: new ObjectID(),
     subProgram: subProgramsList[0]._id,
+    contact: { name: 'Edith Piaf', phone: '0987654321' },
     misc: 'inter_b2b with accessRules',
     type: 'inter_b2b',
     format: 'strictly_e_learning',
@@ -341,6 +344,12 @@ const slots = [
     startDate: moment('2020-03-20T09:00:00').toDate(),
     endDate: moment('2020-03-20T11:00:00').toDate(),
     course: coursesList[8],
+    step: stepList[0]._id,
+  },
+  {
+    startDate: moment('2020-03-20T09:00:00').toDate(),
+    endDate: moment('2020-03-20T11:00:00').toDate(),
+    course: coursesList[9],
     step: stepList[0]._id,
   },
   {


### PR DESCRIPTION
### TESTS
- [ ] Mon code est testé unitairement

- Tests intégrations :
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [x] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES
- Si mes changements impactent l'application formation :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- Si mes changements impactent l'application erp :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : vendeur

- Périmetre roles : rof

- Cas d'usage : ajout d'un test d'inté pour bloquer l'envoie de sms si la formation est archivée
