### PR TITLE
COM-2431

### DIFF
--- a/src/helpers/users.js
+++ b/src/helpers/users.js
@@ -134,6 +134,7 @@ exports.getUser = async (userId, credentials) => {
       },
     })
     .populate({ path: 'companyLinkRequest', populate: { path: 'company', select: '_id name' } })
+    .populate({ path: 'establishment', select: 'siret' })
     .lean({ autopopulate: true, virtuals: true });
 
   if (!user) throw Boom.notFound(translate[language].userNotFound);

--- a/tests/unit/helpers/users.test.js
+++ b/tests/unit/helpers/users.test.js
@@ -475,6 +475,7 @@ describe('getUser', () => {
           query: 'populate',
           args: [{ path: 'companyLinkRequest', populate: { path: 'company', select: '_id name' } }],
         },
+        { query: 'populate', args: [{ path: 'establishment', select: 'siret' }] },
         { query: 'lean', args: [{ autopopulate: true, virtuals: true }] },
       ]
     );
@@ -520,6 +521,7 @@ describe('getUser', () => {
           query: 'populate',
           args: [{ path: 'companyLinkRequest', populate: { path: 'company', select: '_id name' } }],
         },
+        { query: 'populate', args: [{ path: 'establishment', select: 'siret' }] },
         { query: 'lean', args: [{ autopopulate: true, virtuals: true }] },
       ]
     );
@@ -565,6 +567,7 @@ describe('getUser', () => {
           query: 'populate',
           args: [{ path: 'companyLinkRequest', populate: { path: 'company', select: '_id name' } }],
         },
+        { query: 'populate', args: [{ path: 'establishment', select: 'siret' }] },
         { query: 'lean', args: [{ autopopulate: true, virtuals: true }] },
       ]
     );
@@ -610,6 +613,7 @@ describe('getUser', () => {
           query: 'populate',
           args: [{ path: 'companyLinkRequest', populate: { path: 'company', select: '_id name' } }],
         },
+        { query: 'populate', args: [{ path: 'establishment', select: 'siret' }] },
         { query: 'lean', args: [{ autopopulate: true, virtuals: true }] },
       ]
     );
@@ -661,6 +665,7 @@ describe('getUser', () => {
             query: 'populate',
             args: [{ path: 'companyLinkRequest', populate: { path: 'company', select: '_id name' } }],
           },
+          { query: 'populate', args: [{ path: 'establishment', select: 'siret' }] },
           { query: 'lean', args: [{ autopopulate: true, virtuals: true }] },
         ]
       );


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations : -np
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [ ] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES -np
- Si mes changements impactent l'application formation :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- Si mes changements impactent l'application erp :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME -np
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES -np
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV -np
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : client

- Périmetre roles : Admin

- Cas d'usage :  je peux utiliser le SIRET de l'établissement & ville de naissance dans les tags auxiliaire
- Pour tester la PR: 
    - modifier le template d'un contrat ou d'un avenant en ajoutant les tags {companySIRET} et {auxiliaryBirthCity}
    - generer un contrat ou un avenant --> les infos correspondant aux tags sont bien présentes
