### PR TITLE
COM-2514: replace moment with luxon in coursehistories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -814,9 +814,9 @@
       }
     },
     "@types/node": {
-      "version": "16.11.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.7.tgz",
-      "integrity": "sha512-QB5D2sqfSjCmTuWcBWyJ+/44bcjO7VbjSbOE0ucoVbAsSNQc4Lt6QkgkVXkTDwkL4z/beecZNDvVX15D4P8Jbw=="
+      "version": "16.11.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.10.tgz",
+      "integrity": "sha512-3aRnHa1KlOEEhJ6+CvyHKK5vE9BcLGjtUpwvqYLRvYNQKMfabu3BwfJaA/SLW8dxe28LsNDjtHwePTuzn3gmOA=="
     },
     "@types/request": {
       "version": "2.48.1",
@@ -1727,9 +1727,9 @@
       }
     },
     "docxtemplater": {
-      "version": "3.26.4",
-      "resolved": "https://registry.npmjs.org/docxtemplater/-/docxtemplater-3.26.4.tgz",
-      "integrity": "sha512-ZyRn2n15t3l6sTc/YVLDWNpc5QMXDXRF9y4rof91R5V6y7zhQI+CyzHC/08iMmBQQ6zIr5L7wh/ZuOuoPIV4lQ==",
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/docxtemplater/-/docxtemplater-3.27.1.tgz",
+      "integrity": "sha512-3YyYcDEcuv2Mvsxn6bunYO0cI0K2nQu4Ma6TpR0JQ99cWGZ5EM+AebqpL7ov/sIvAwpq+gPGfmknXyyP0LunaQ==",
       "requires": {
         "@xmldom/xmldom": "^0.7.5"
       }
@@ -1971,9 +1971,9 @@
       }
     },
     "eslint": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.2.0.tgz",
-      "integrity": "sha512-erw7XmM+CLxTOickrimJ1SiF55jiNlVSp2qqm0NuBWPtHYQCegD5ZMaW0c3i5ytPqL+SSLaCxdvQXFPLJn+ABw==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.3.0.tgz",
+      "integrity": "sha512-aIay56Ph6RxOTC7xyr59Kt3ewX185SaGnAr8eWukoPLeriCrvGjvAubxuvaXOfsxhtwV5g0uBOsyhAom4qJdww==",
       "dev": true,
       "requires": {
         "@eslint/eslintrc": "^1.0.4",
@@ -1985,10 +1985,10 @@
         "doctrine": "^3.0.0",
         "enquirer": "^2.3.5",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^6.0.0",
+        "eslint-scope": "^7.1.0",
         "eslint-utils": "^3.0.0",
-        "eslint-visitor-keys": "^3.0.0",
-        "espree": "^9.0.0",
+        "eslint-visitor-keys": "^3.1.0",
+        "espree": "^9.1.0",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -2249,9 +2249,9 @@
       }
     },
     "eslint-scope": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-6.0.0.tgz",
-      "integrity": "sha512-uRDL9MWmQCkaFus8RF5K9/L/2fn+80yoW3jkD53l4shjCh26fCtvJGasxjUqP5OT87SYTxCVA3BwTUzuELx9kA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.0.tgz",
+      "integrity": "sha512-aWwkhnS0qAXqNOgKOK0dJ2nvzEbhEvpy8OlJ9kZ0FeZnA6zpjv1/Vei+puGFFX7zkPCkHHXb7IDX3A+7yPrRWg==",
       "dev": true,
       "requires": {
         "esrecurse": "^4.3.0",
@@ -2289,14 +2289,14 @@
       "integrity": "sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA=="
     },
     "espree": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.0.0.tgz",
-      "integrity": "sha512-r5EQJcYZ2oaGbeR0jR0fFVijGOcwai07/690YRXLINuhmVeRY4UKSAsQPe/0BNuDgwP7Ophoc1PRsr2E3tkbdQ==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.1.0.tgz",
+      "integrity": "sha512-ZgYLvCS1wxOczBYGcQT9DDWgicXwJ4dbocr9uYN+/eresBAUuBu+O4WzB21ufQ/JqQT8gyp7hJ3z8SHii32mTQ==",
       "dev": true,
       "requires": {
-        "acorn": "^8.5.0",
+        "acorn": "^8.6.0",
         "acorn-jsx": "^5.3.1",
-        "eslint-visitor-keys": "^3.0.0"
+        "eslint-visitor-keys": "^3.1.0"
       },
       "dependencies": {
         "acorn": {
@@ -3556,6 +3556,11 @@
       "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
       "integrity": "sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0="
     },
+    "luxon": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.1.1.tgz",
+      "integrity": "sha512-6VQVNw7+kQu3hL1ZH5GyOhnk8uZm21xS7XJ/6vDZaFNcb62dpFDKcH8TI5NkoZOdMRxr7af7aYGrJlE/Wv0i1w=="
+    },
     "magic-string": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.1.tgz",
@@ -4677,9 +4682,9 @@
       "integrity": "sha512-+gxdEOMA2J+AI+fVsCqeNn7Tgx3M9ZN9jdi95939l1IJ8cZsqS8sqpJyOkic2SJk+1+98Uwryt/gL6XDaV+UZA=="
     },
     "signal-exit": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.5.tgz",
-      "integrity": "sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ=="
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.6.tgz",
+      "integrity": "sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ=="
     },
     "sinon": {
       "version": "11.1.2",
@@ -5022,9 +5027,9 @@
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
     },
     "tsconfig-paths": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.11.0.tgz",
-      "integrity": "sha512-7ecdYDnIdmv639mmDwslG6KQg1Z9STTz1j7Gcz0xa+nshh/gKDAHcPxRbWOsA3SPp0tXP2leTcY9Kw+NAkfZzA==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.12.0.tgz",
+      "integrity": "sha512-e5adrnOYT6zqVnWqZu7i/BQ3BnhzvGbjEjejFXO20lKIKpwTaupkCPgEfv4GZK1IBciJUEhYs3J3p75FdaTFVg==",
       "dev": true,
       "requires": {
         "@types/json5": "^0.0.29",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "jsonwebtoken": "^8.5.1",
     "jszip": "^3.7.1",
     "lodash": "^4.17.21",
+    "luxon": "^2.1.1",
     "moment": "^2.29.1",
     "moment-business-days": "^1.2.0",
     "moment-range": "^4.0.2",

--- a/src/helpers/companiDates.js
+++ b/src/helpers/companiDates.js
@@ -1,18 +1,18 @@
 const luxon = require('luxon');
 
-exports.CompaniDate = (...args) => companiDateFactory(exports._instantiateDateTimeFromMisc(...args));
+exports.CompaniDate = (...args) => companiDateFactory(exports._formatMiscToCompanyDate(...args));
 
 const companiDateFactory = _date => ({
   _date,
 
   isSame(miscTypeOtherDate, unit) {
-    const otherDate = exports._instantiateDateTimeFromMisc(miscTypeOtherDate);
+    const otherDate = exports._formatMiscToCompanyDate(miscTypeOtherDate);
 
     return this._date.hasSame(otherDate, unit);
   },
 });
 
-exports._instantiateDateTimeFromMisc = (...args) => {
+exports._formatMiscToCompanyDate = (...args) => {
   if (!args.length) return luxon.DateTime.now();
 
   if (args.length === 1) {
@@ -23,7 +23,7 @@ exports._instantiateDateTimeFromMisc = (...args) => {
   }
 
   if (args.length === 2 && typeof args[0] === 'string' && typeof args[1] === 'string') {
-    return luxon.DateTime.fromFormat(args[0], args[1]);
+    return luxon.DateTime.fromFormat(args[0], args[1], { zone: 'utc' });
   }
 
   return luxon.DateTime.invalid('wrong arguments');

--- a/src/helpers/companiDates.js
+++ b/src/helpers/companiDates.js
@@ -1,0 +1,30 @@
+const luxon = require('luxon');
+
+exports.CompaniDate = (...args) => companiDateFactory(exports._instantiateDateTimeFromMisc(...args));
+
+const companiDateFactory = _date => ({
+  _date,
+
+  isSame(miscTypeOtherDate, unit) {
+    const otherDate = exports._instantiateDateTimeFromMisc(miscTypeOtherDate);
+
+    return this._date.hasSame(otherDate, unit);
+  },
+});
+
+exports._instantiateDateTimeFromMisc = (...args) => {
+  if (!args.length) return luxon.DateTime.now();
+
+  if (args.length === 1) {
+    if (args[0] instanceof Object && args[0]._date && args[0]._date instanceof luxon.DateTime) return args[0]._date;
+    if (args[0] instanceof luxon.DateTime) return args[0];
+    if (args[0] instanceof Date) return luxon.DateTime.fromJSDate(args[0]);
+    if (typeof args[0] === 'string') return luxon.DateTime.fromISO(args[0]);
+  }
+
+  if (args.length === 2 && typeof args[0] === 'string' && typeof args[1] === 'string') {
+    return luxon.DateTime.fromFormat(args[0], args[1]);
+  }
+
+  return luxon.DateTime.invalid('wrong arguments');
+};

--- a/src/helpers/courseHistories.js
+++ b/src/helpers/courseHistories.js
@@ -1,5 +1,5 @@
 const pick = require('lodash/pick');
-const moment = require('../extensions/moment');
+const { CompaniDate } = require('./companiDates');
 const CourseHistory = require('../models/CourseHistory');
 const { SLOT_CREATION, SLOT_DELETION, SLOT_EDITION, TRAINEE_ADDITION, TRAINEE_DELETION } = require('./constants');
 
@@ -43,8 +43,8 @@ exports.createHistoryOnSlotEdition = async (slotFromDb, payload, userId) => {
     return exports.createHistoryOnSlotCreation({ ...slotFromDb, ...payload }, userId);
   }
 
-  const isDateUpdated = !moment(slotFromDb.startDate).isSame(payload.startDate, 'd');
-  const isHourUpdated = !moment(slotFromDb.startDate).isSame(payload.startDate, 'm');
+  const isDateUpdated = !CompaniDate(slotFromDb.startDate).isSame(payload.startDate, 'day');
+  const isHourUpdated = !CompaniDate(slotFromDb.startDate).isSame(payload.startDate, 'minute');
 
   if (!isDateUpdated && !isHourUpdated) return null;
 

--- a/tests/unit/helpers/companiDates.test.js
+++ b/tests/unit/helpers/companiDates.test.js
@@ -3,6 +3,28 @@ const luxon = require('luxon');
 const sinon = require('sinon');
 const CompaniDatesHelper = require('../../../src/helpers/companiDates');
 
+describe('CompaniDate', () => {
+  let _formatMiscToCompanyDate;
+
+  beforeEach(() => {
+    _formatMiscToCompanyDate = sinon.spy(CompaniDatesHelper, '_formatMiscToCompanyDate');
+  });
+
+  afterEach(() => {
+    _formatMiscToCompanyDate.restore();
+  });
+
+  it('should return dateTime', () => {
+    const date = new Date('2021-11-24T07:00:00.000Z');
+
+    const result = CompaniDatesHelper.CompaniDate(date);
+
+    expect(result)
+      .toEqual(expect.objectContaining({ _date: expect.any(luxon.DateTime), isSame: expect.any(Function) }));
+    sinon.assert.calledWithExactly(_formatMiscToCompanyDate.getCall(0), date);
+  });
+});
+
 describe('isSame', () => {
   let _formatMiscToCompanyDate;
   const date = new Date('2021-11-24T07:00:00.000Z');

--- a/tests/unit/helpers/companiDates.test.js
+++ b/tests/unit/helpers/companiDates.test.js
@@ -4,20 +4,38 @@ const sinon = require('sinon');
 const CompaniDatesHelper = require('../../../src/helpers/companiDates');
 
 describe('isSame', () => {
+  let _instantiateDateTimeFromMisc;
+  const date = new Date('2021-11-24T07:00:00.000Z');
+  const otherDate = new Date('2021-11-24T10:00:00.000Z');
+
+  beforeEach(() => {
+    _instantiateDateTimeFromMisc = sinon.stub(CompaniDatesHelper, '_instantiateDateTimeFromMisc');
+  });
+
+  afterEach(() => {
+    _instantiateDateTimeFromMisc.restore();
+  });
+
   it('should return true if same day', () => {
-    const date = new Date('2021-11-24T07:00:00.000Z');
-    const otherDate = new Date('2021-11-24T10:00:00.000Z');
+    _instantiateDateTimeFromMisc.onCall(0).returns(luxon.DateTime.fromJSDate(date));
+    _instantiateDateTimeFromMisc.onCall(1).returns(luxon.DateTime.fromJSDate(otherDate));
+
     const result = CompaniDatesHelper.CompaniDate(date).isSame(otherDate, 'day');
 
-    expect(result).toBeTruthy();
+    expect(result).toBe(true);
+    sinon.assert.calledWithExactly(_instantiateDateTimeFromMisc.getCall(0), date);
+    sinon.assert.calledWithExactly(_instantiateDateTimeFromMisc.getCall(1), otherDate);
   });
 
   it('should return false if different minute', () => {
-    const date = new Date('2021-11-24T07:00:00.000Z');
-    const otherDate = new Date('2021-11-24T10:00:00.000Z');
+    _instantiateDateTimeFromMisc.onCall(0).returns(luxon.DateTime.fromJSDate(date));
+    _instantiateDateTimeFromMisc.onCall(1).returns(luxon.DateTime.fromJSDate(otherDate));
+
     const result = CompaniDatesHelper.CompaniDate(date).isSame(otherDate, 'minute');
 
-    expect(result).toBeFalsy();
+    expect(result).toBe(false);
+    sinon.assert.calledWithExactly(_instantiateDateTimeFromMisc.getCall(0), date);
+    sinon.assert.calledWithExactly(_instantiateDateTimeFromMisc.getCall(1), otherDate);
   });
 });
 
@@ -27,6 +45,7 @@ describe('_instantiateDateTimeFromMisc', () => {
   let fromISO;
   let fromFormat;
   let invalid;
+  const date = new luxon.DateTime('');
 
   beforeEach(() => {
     now = sinon.stub(luxon.DateTime, 'now');
@@ -45,55 +64,96 @@ describe('_instantiateDateTimeFromMisc', () => {
   });
 
   it('should return dateTime.now if no arg', () => {
-    now.returns({ isLuxonDateTime: true });
+    now.returns(date);
+
     const result = CompaniDatesHelper._instantiateDateTimeFromMisc();
 
-    expect(result).toMatchObject({ isLuxonDateTime: true });
+    expect(result).toMatchObject(date);
+    sinon.assert.calledOnceWithExactly(now);
+    sinon.assert.notCalled(fromJSDate);
+    sinon.assert.notCalled(fromISO);
+    sinon.assert.notCalled(fromFormat);
+    sinon.assert.notCalled(invalid);
   });
 
   const dates = [
-    { type: 'object with dateTime', date: { _date: new luxon.DateTime('2021-11-24T07:00:00.000Z') } },
-    { type: 'dateTime', date: new luxon.DateTime('2021-11-24T07:00:00.000Z') },
-    { type: 'date', date: new Date('2021-11-24T07:00:00.000Z') },
+    { type: 'object with dateTime', date: { _date: date } },
+    { type: 'dateTime', date },
+    { type: 'date', date: new Date() },
     { type: 'string', date: '2021-11-24T07:00:00.000Z' },
   ];
   it(`should return dateTime if arg is ${dates[0].type}`, () => {
     const result = CompaniDatesHelper._instantiateDateTimeFromMisc(dates[0].date);
-    expect(result).toBe(dates[0].date._date);
+
+    expect(result).toMatchObject(dates[0].date._date);
+    sinon.assert.notCalled(now);
+    sinon.assert.notCalled(fromJSDate);
+    sinon.assert.notCalled(fromISO);
+    sinon.assert.notCalled(fromFormat);
+    sinon.assert.notCalled(invalid);
   });
 
   it(`should return dateTime if arg is ${dates[1].type}`, () => {
     const result = CompaniDatesHelper._instantiateDateTimeFromMisc(dates[1].date);
 
-    expect(result).toBe(dates[1].date);
+    expect(result).toMatchObject(dates[1].date);
+    sinon.assert.notCalled(now);
+    sinon.assert.notCalled(fromJSDate);
+    sinon.assert.notCalled(fromISO);
+    sinon.assert.notCalled(fromFormat);
+    sinon.assert.notCalled(invalid);
   });
 
   it(`should return dateTime if arg is ${dates[2].type}`, () => {
-    fromJSDate.returns({ isLuxonDateTime: true });
+    fromJSDate.returns(date);
+
     const result = CompaniDatesHelper._instantiateDateTimeFromMisc(dates[2].date);
 
-    expect(result).toMatchObject({ isLuxonDateTime: true });
+    expect(result).toMatchObject(date);
+    sinon.assert.calledOnceWithExactly(fromJSDate, dates[2].date);
+    sinon.assert.notCalled(now);
+    sinon.assert.notCalled(fromISO);
+    sinon.assert.notCalled(fromFormat);
+    sinon.assert.notCalled(invalid);
   });
 
   it(`should return dateTime if arg is ${dates[3].type}`, () => {
-    fromISO.returns({ isLuxonDateTime: true });
+    fromISO.returns(date);
+
     const result = CompaniDatesHelper._instantiateDateTimeFromMisc(dates[3].date);
 
-    expect(result).toMatchObject({ isLuxonDateTime: true });
+    expect(result).toMatchObject(date);
+    sinon.assert.calledOnceWithExactly(fromISO, dates[3].date);
+    sinon.assert.notCalled(now);
+    sinon.assert.notCalled(fromJSDate);
+    sinon.assert.notCalled(fromFormat);
+    sinon.assert.notCalled(invalid);
   });
 
   it('should return dateTime if 2 args', () => {
-    fromFormat.returns({ isLuxonDateTime: true });
+    fromFormat.returns(date);
+
     const result = CompaniDatesHelper._instantiateDateTimeFromMisc('2021-11-24T07:00:00.000Z', 'MMMM dd yyyy');
 
-    expect(result).toMatchObject({ isLuxonDateTime: true });
+    expect(result).toMatchObject(date);
+    sinon.assert.calledOnceWithExactly(fromFormat, '2021-11-24T07:00:00.000Z', 'MMMM dd yyyy');
+    sinon.assert.notCalled(now);
+    sinon.assert.notCalled(fromJSDate);
+    sinon.assert.notCalled(fromISO);
+    sinon.assert.notCalled(invalid);
   });
 
   it('should return dateTime if too many args', () => {
     invalid.returns({ invalid: { reason: 'wrong arguments', explanation: null } });
+
     const result = CompaniDatesHelper
       ._instantiateDateTimeFromMisc('2021-11-24T07:00:00.000Z', 'MMMM dd yyyy', { locale: 'fr' });
 
     expect(result).toMatchObject({ invalid: { reason: 'wrong arguments', explanation: null } });
+    sinon.assert.calledOnceWithExactly(invalid, 'wrong arguments');
+    sinon.assert.notCalled(now);
+    sinon.assert.notCalled(fromJSDate);
+    sinon.assert.notCalled(fromISO);
+    sinon.assert.notCalled(fromFormat);
   });
 });

--- a/tests/unit/helpers/companiDates.test.js
+++ b/tests/unit/helpers/companiDates.test.js
@@ -69,14 +69,9 @@ describe('_formatMiscToCompanyDate', () => {
     sinon.assert.notCalled(invalid);
   });
 
-  const dates = [
-    { type: 'object with dateTime', date: { _date: date } },
-    { type: 'dateTime', date },
-    { type: 'date', date: new Date('2021-11-24T07:00:00.000Z') },
-    { type: 'string', date: '2021-11-24T07:00:00.000Z' },
-  ];
-  it(`should return dateTime if arg is ${dates[0].type}`, () => {
-    const result = CompaniDatesHelper._formatMiscToCompanyDate(dates[0].date);
+  it('should return dateTime if arg is object with dateTime', () => {
+    const payload = { _date: date };
+    const result = CompaniDatesHelper._formatMiscToCompanyDate(payload);
 
     expect(result instanceof luxon.DateTime).toBe(true);
     expect(new luxon.DateTime(result).toJSDate()).toEqual(new Date('2021-11-24T07:00:00.000Z'));
@@ -87,8 +82,9 @@ describe('_formatMiscToCompanyDate', () => {
     sinon.assert.notCalled(invalid);
   });
 
-  it(`should return dateTime if arg is ${dates[1].type}`, () => {
-    const result = CompaniDatesHelper._formatMiscToCompanyDate(dates[1].date);
+  it('should return dateTime if arg is dateTime', () => {
+    const payload = date;
+    const result = CompaniDatesHelper._formatMiscToCompanyDate(payload);
 
     expect(result instanceof luxon.DateTime).toBe(true);
     expect(new luxon.DateTime(result).toJSDate()).toEqual(new Date('2021-11-24T07:00:00.000Z'));
@@ -99,24 +95,26 @@ describe('_formatMiscToCompanyDate', () => {
     sinon.assert.notCalled(invalid);
   });
 
-  it(`should return dateTime if arg is ${dates[2].type}`, () => {
-    const result = CompaniDatesHelper._formatMiscToCompanyDate(dates[2].date);
+  it('should return dateTime if arg is date', () => {
+    const payload = new Date('2021-11-24T07:00:00.000Z');
+    const result = CompaniDatesHelper._formatMiscToCompanyDate(payload);
 
     expect(result instanceof luxon.DateTime).toBe(true);
     expect(new luxon.DateTime(result).toJSDate()).toEqual(new Date('2021-11-24T07:00:00.000Z'));
-    sinon.assert.calledOnceWithExactly(fromJSDate, dates[2].date);
+    sinon.assert.calledOnceWithExactly(fromJSDate, payload);
     sinon.assert.notCalled(now);
     sinon.assert.notCalled(fromISO);
     sinon.assert.notCalled(fromFormat);
     sinon.assert.notCalled(invalid);
   });
 
-  it(`should return dateTime if arg is ${dates[3].type}`, () => {
-    const result = CompaniDatesHelper._formatMiscToCompanyDate(dates[3].date);
+  it('should return dateTime if arg is string', () => {
+    const payload = '2021-11-24T07:00:00.000Z';
+    const result = CompaniDatesHelper._formatMiscToCompanyDate(payload);
 
     expect(result instanceof luxon.DateTime).toBe(true);
     expect(new luxon.DateTime(result).toJSDate()).toEqual(new Date('2021-11-24T07:00:00.000Z'));
-    sinon.assert.calledOnceWithExactly(fromISO, dates[3].date);
+    sinon.assert.calledOnceWithExactly(fromISO, payload);
     sinon.assert.notCalled(now);
     sinon.assert.notCalled(fromJSDate);
     sinon.assert.notCalled(fromFormat);
@@ -143,7 +141,7 @@ describe('_formatMiscToCompanyDate', () => {
     sinon.assert.notCalled(invalid);
   });
 
-  it('should return dateTime if too many args', () => {
+  it('should return invalid if too many args', () => {
     const result = CompaniDatesHelper
       ._formatMiscToCompanyDate('2021-11-24T07:00:00.000Z', 'MMMM dd yyyy', { locale: 'fr' });
 

--- a/tests/unit/helpers/companiDates.test.js
+++ b/tests/unit/helpers/companiDates.test.js
@@ -1,0 +1,99 @@
+const expect = require('expect');
+const luxon = require('luxon');
+const sinon = require('sinon');
+const CompaniDatesHelper = require('../../../src/helpers/companiDates');
+
+describe('isSame', () => {
+  it('should return true if same day', () => {
+    const date = new Date('2021-11-24T07:00:00.000Z');
+    const otherDate = new Date('2021-11-24T10:00:00.000Z');
+    const result = CompaniDatesHelper.CompaniDate(date).isSame(otherDate, 'day');
+
+    expect(result).toBeTruthy();
+  });
+
+  it('should return false if different minute', () => {
+    const date = new Date('2021-11-24T07:00:00.000Z');
+    const otherDate = new Date('2021-11-24T10:00:00.000Z');
+    const result = CompaniDatesHelper.CompaniDate(date).isSame(otherDate, 'minute');
+
+    expect(result).toBeFalsy();
+  });
+});
+
+describe('_instantiateDateTimeFromMisc', () => {
+  let now;
+  let fromJSDate;
+  let fromISO;
+  let fromFormat;
+  let invalid;
+
+  beforeEach(() => {
+    now = sinon.stub(luxon.DateTime, 'now');
+    fromJSDate = sinon.stub(luxon.DateTime, 'fromJSDate');
+    fromISO = sinon.stub(luxon.DateTime, 'fromISO');
+    fromFormat = sinon.stub(luxon.DateTime, 'fromFormat');
+    invalid = sinon.stub(luxon.DateTime, 'invalid');
+  });
+
+  afterEach(() => {
+    now.restore();
+    fromJSDate.restore();
+    fromISO.restore();
+    fromFormat.restore();
+    invalid.restore();
+  });
+
+  it('should return dateTime.now if no arg', () => {
+    now.returns({ isLuxonDateTime: true });
+    const result = CompaniDatesHelper._instantiateDateTimeFromMisc();
+
+    expect(result).toMatchObject({ isLuxonDateTime: true });
+  });
+
+  const dates = [
+    { type: 'object with dateTime', date: { _date: new luxon.DateTime('2021-11-24T07:00:00.000Z') } },
+    { type: 'dateTime', date: new luxon.DateTime('2021-11-24T07:00:00.000Z') },
+    { type: 'date', date: new Date('2021-11-24T07:00:00.000Z') },
+    { type: 'string', date: '2021-11-24T07:00:00.000Z' },
+  ];
+  it(`should return dateTime if arg is ${dates[0].type}`, () => {
+    const result = CompaniDatesHelper._instantiateDateTimeFromMisc(dates[0].date);
+    expect(result).toBe(dates[0].date._date);
+  });
+
+  it(`should return dateTime if arg is ${dates[1].type}`, () => {
+    const result = CompaniDatesHelper._instantiateDateTimeFromMisc(dates[1].date);
+
+    expect(result).toBe(dates[1].date);
+  });
+
+  it(`should return dateTime if arg is ${dates[2].type}`, () => {
+    fromJSDate.returns({ isLuxonDateTime: true });
+    const result = CompaniDatesHelper._instantiateDateTimeFromMisc(dates[2].date);
+
+    expect(result).toMatchObject({ isLuxonDateTime: true });
+  });
+
+  it(`should return dateTime if arg is ${dates[3].type}`, () => {
+    fromISO.returns({ isLuxonDateTime: true });
+    const result = CompaniDatesHelper._instantiateDateTimeFromMisc(dates[3].date);
+
+    expect(result).toMatchObject({ isLuxonDateTime: true });
+  });
+
+  it('should return dateTime if 2 args', () => {
+    fromFormat.returns({ isLuxonDateTime: true });
+    const result = CompaniDatesHelper._instantiateDateTimeFromMisc('2021-11-24T07:00:00.000Z', 'MMMM dd yyyy');
+
+    expect(result).toMatchObject({ isLuxonDateTime: true });
+  });
+
+  it('should return dateTime if too many args', () => {
+    invalid.returns({ invalid: { reason: 'wrong arguments', explanation: null } });
+    const result = CompaniDatesHelper
+      ._instantiateDateTimeFromMisc('2021-11-24T07:00:00.000Z', 'MMMM dd yyyy', { locale: 'fr' });
+
+    expect(result).toMatchObject({ invalid: { reason: 'wrong arguments', explanation: null } });
+  });
+});

--- a/tests/unit/helpers/companiDates.test.js
+++ b/tests/unit/helpers/companiDates.test.js
@@ -27,7 +27,7 @@ describe('CompaniDate', () => {
 
 describe('isSame', () => {
   let _formatMiscToCompanyDate;
-  const date = new Date('2021-11-24T07:00:00.000Z');
+  const companiDate = CompaniDatesHelper.CompaniDate('2021-11-24T07:00:00.000Z');
   const otherDate = new Date('2021-11-24T10:00:00.000Z');
 
   beforeEach(() => {
@@ -39,19 +39,17 @@ describe('isSame', () => {
   });
 
   it('should return true if same day', () => {
-    const result = CompaniDatesHelper.CompaniDate(date).isSame(otherDate, 'day');
+    const result = companiDate.isSame(otherDate, 'day');
 
     expect(result).toBe(true);
-    sinon.assert.calledWithExactly(_formatMiscToCompanyDate.getCall(0), date);
-    sinon.assert.calledWithExactly(_formatMiscToCompanyDate.getCall(1), otherDate);
+    sinon.assert.calledWithExactly(_formatMiscToCompanyDate.getCall(0), otherDate);
   });
 
   it('should return false if different minute', () => {
-    const result = CompaniDatesHelper.CompaniDate(date).isSame(otherDate, 'minute');
+    const result = companiDate.isSame(otherDate, 'minute');
 
     expect(result).toBe(false);
-    sinon.assert.calledWithExactly(_formatMiscToCompanyDate.getCall(0), date);
-    sinon.assert.calledWithExactly(_formatMiscToCompanyDate.getCall(1), otherDate);
+    sinon.assert.calledWithExactly(_formatMiscToCompanyDate.getCall(0), otherDate);
   });
 });
 

--- a/tests/unit/helpers/companiDates.test.js
+++ b/tests/unit/helpers/companiDates.test.js
@@ -4,55 +4,49 @@ const sinon = require('sinon');
 const CompaniDatesHelper = require('../../../src/helpers/companiDates');
 
 describe('isSame', () => {
-  let _instantiateDateTimeFromMisc;
+  let _formatMiscToCompanyDate;
   const date = new Date('2021-11-24T07:00:00.000Z');
   const otherDate = new Date('2021-11-24T10:00:00.000Z');
 
   beforeEach(() => {
-    _instantiateDateTimeFromMisc = sinon.stub(CompaniDatesHelper, '_instantiateDateTimeFromMisc');
+    _formatMiscToCompanyDate = sinon.spy(CompaniDatesHelper, '_formatMiscToCompanyDate');
   });
 
   afterEach(() => {
-    _instantiateDateTimeFromMisc.restore();
+    _formatMiscToCompanyDate.restore();
   });
 
   it('should return true if same day', () => {
-    _instantiateDateTimeFromMisc.onCall(0).returns(luxon.DateTime.fromJSDate(date));
-    _instantiateDateTimeFromMisc.onCall(1).returns(luxon.DateTime.fromJSDate(otherDate));
-
     const result = CompaniDatesHelper.CompaniDate(date).isSame(otherDate, 'day');
 
     expect(result).toBe(true);
-    sinon.assert.calledWithExactly(_instantiateDateTimeFromMisc.getCall(0), date);
-    sinon.assert.calledWithExactly(_instantiateDateTimeFromMisc.getCall(1), otherDate);
+    sinon.assert.calledWithExactly(_formatMiscToCompanyDate.getCall(0), date);
+    sinon.assert.calledWithExactly(_formatMiscToCompanyDate.getCall(1), otherDate);
   });
 
   it('should return false if different minute', () => {
-    _instantiateDateTimeFromMisc.onCall(0).returns(luxon.DateTime.fromJSDate(date));
-    _instantiateDateTimeFromMisc.onCall(1).returns(luxon.DateTime.fromJSDate(otherDate));
-
     const result = CompaniDatesHelper.CompaniDate(date).isSame(otherDate, 'minute');
 
     expect(result).toBe(false);
-    sinon.assert.calledWithExactly(_instantiateDateTimeFromMisc.getCall(0), date);
-    sinon.assert.calledWithExactly(_instantiateDateTimeFromMisc.getCall(1), otherDate);
+    sinon.assert.calledWithExactly(_formatMiscToCompanyDate.getCall(0), date);
+    sinon.assert.calledWithExactly(_formatMiscToCompanyDate.getCall(1), otherDate);
   });
 });
 
-describe('_instantiateDateTimeFromMisc', () => {
+describe('_formatMiscToCompanyDate', () => {
   let now;
   let fromJSDate;
   let fromISO;
   let fromFormat;
   let invalid;
-  const date = new luxon.DateTime('');
+  const date = luxon.DateTime.fromISO('2021-11-24T07:00:00.000Z');
 
   beforeEach(() => {
-    now = sinon.stub(luxon.DateTime, 'now');
-    fromJSDate = sinon.stub(luxon.DateTime, 'fromJSDate');
-    fromISO = sinon.stub(luxon.DateTime, 'fromISO');
-    fromFormat = sinon.stub(luxon.DateTime, 'fromFormat');
-    invalid = sinon.stub(luxon.DateTime, 'invalid');
+    now = sinon.spy(luxon.DateTime, 'now');
+    fromJSDate = sinon.spy(luxon.DateTime, 'fromJSDate');
+    fromISO = sinon.spy(luxon.DateTime, 'fromISO');
+    fromFormat = sinon.spy(luxon.DateTime, 'fromFormat');
+    invalid = sinon.spy(luxon.DateTime, 'invalid');
   });
 
   afterEach(() => {
@@ -64,11 +58,10 @@ describe('_instantiateDateTimeFromMisc', () => {
   });
 
   it('should return dateTime.now if no arg', () => {
-    now.returns(date);
+    const result = CompaniDatesHelper._formatMiscToCompanyDate();
 
-    const result = CompaniDatesHelper._instantiateDateTimeFromMisc();
-
-    expect(result).toMatchObject(date);
+    expect(result instanceof luxon.DateTime).toBe(true);
+    expect(new luxon.DateTime(result).toJSDate() - new Date()).toBeLessThan(100);
     sinon.assert.calledOnceWithExactly(now);
     sinon.assert.notCalled(fromJSDate);
     sinon.assert.notCalled(fromISO);
@@ -79,13 +72,14 @@ describe('_instantiateDateTimeFromMisc', () => {
   const dates = [
     { type: 'object with dateTime', date: { _date: date } },
     { type: 'dateTime', date },
-    { type: 'date', date: new Date() },
+    { type: 'date', date: new Date('2021-11-24T07:00:00.000Z') },
     { type: 'string', date: '2021-11-24T07:00:00.000Z' },
   ];
   it(`should return dateTime if arg is ${dates[0].type}`, () => {
-    const result = CompaniDatesHelper._instantiateDateTimeFromMisc(dates[0].date);
+    const result = CompaniDatesHelper._formatMiscToCompanyDate(dates[0].date);
 
-    expect(result).toMatchObject(dates[0].date._date);
+    expect(result instanceof luxon.DateTime).toBe(true);
+    expect(new luxon.DateTime(result).toJSDate()).toEqual(new Date('2021-11-24T07:00:00.000Z'));
     sinon.assert.notCalled(now);
     sinon.assert.notCalled(fromJSDate);
     sinon.assert.notCalled(fromISO);
@@ -94,9 +88,10 @@ describe('_instantiateDateTimeFromMisc', () => {
   });
 
   it(`should return dateTime if arg is ${dates[1].type}`, () => {
-    const result = CompaniDatesHelper._instantiateDateTimeFromMisc(dates[1].date);
+    const result = CompaniDatesHelper._formatMiscToCompanyDate(dates[1].date);
 
-    expect(result).toMatchObject(dates[1].date);
+    expect(result instanceof luxon.DateTime).toBe(true);
+    expect(new luxon.DateTime(result).toJSDate()).toEqual(new Date('2021-11-24T07:00:00.000Z'));
     sinon.assert.notCalled(now);
     sinon.assert.notCalled(fromJSDate);
     sinon.assert.notCalled(fromISO);
@@ -105,11 +100,10 @@ describe('_instantiateDateTimeFromMisc', () => {
   });
 
   it(`should return dateTime if arg is ${dates[2].type}`, () => {
-    fromJSDate.returns(date);
+    const result = CompaniDatesHelper._formatMiscToCompanyDate(dates[2].date);
 
-    const result = CompaniDatesHelper._instantiateDateTimeFromMisc(dates[2].date);
-
-    expect(result).toMatchObject(date);
+    expect(result instanceof luxon.DateTime).toBe(true);
+    expect(new luxon.DateTime(result).toJSDate()).toEqual(new Date('2021-11-24T07:00:00.000Z'));
     sinon.assert.calledOnceWithExactly(fromJSDate, dates[2].date);
     sinon.assert.notCalled(now);
     sinon.assert.notCalled(fromISO);
@@ -118,11 +112,10 @@ describe('_instantiateDateTimeFromMisc', () => {
   });
 
   it(`should return dateTime if arg is ${dates[3].type}`, () => {
-    fromISO.returns(date);
+    const result = CompaniDatesHelper._formatMiscToCompanyDate(dates[3].date);
 
-    const result = CompaniDatesHelper._instantiateDateTimeFromMisc(dates[3].date);
-
-    expect(result).toMatchObject(date);
+    expect(result instanceof luxon.DateTime).toBe(true);
+    expect(new luxon.DateTime(result).toJSDate()).toEqual(new Date('2021-11-24T07:00:00.000Z'));
     sinon.assert.calledOnceWithExactly(fromISO, dates[3].date);
     sinon.assert.notCalled(now);
     sinon.assert.notCalled(fromJSDate);
@@ -131,12 +124,19 @@ describe('_instantiateDateTimeFromMisc', () => {
   });
 
   it('should return dateTime if 2 args', () => {
-    fromFormat.returns(date);
+    const result = CompaniDatesHelper._formatMiscToCompanyDate(
+      '2021-11-24T07:00:00.000Z',
+      'yyyy-MM-dd\'T\'hh:mm:ss.SSS\'Z\''
+    );
 
-    const result = CompaniDatesHelper._instantiateDateTimeFromMisc('2021-11-24T07:00:00.000Z', 'MMMM dd yyyy');
-
-    expect(result).toMatchObject(date);
-    sinon.assert.calledOnceWithExactly(fromFormat, '2021-11-24T07:00:00.000Z', 'MMMM dd yyyy');
+    expect(result instanceof luxon.DateTime).toBe(true);
+    expect(new luxon.DateTime(result).toJSDate()).toEqual(new Date('2021-11-24T07:00:00.000Z'));
+    sinon.assert.calledOnceWithExactly(
+      fromFormat,
+      '2021-11-24T07:00:00.000Z',
+      'yyyy-MM-dd\'T\'hh:mm:ss.SSS\'Z\'',
+      { zone: 'utc' }
+    );
     sinon.assert.notCalled(now);
     sinon.assert.notCalled(fromJSDate);
     sinon.assert.notCalled(fromISO);
@@ -144,12 +144,10 @@ describe('_instantiateDateTimeFromMisc', () => {
   });
 
   it('should return dateTime if too many args', () => {
-    invalid.returns({ invalid: { reason: 'wrong arguments', explanation: null } });
-
     const result = CompaniDatesHelper
-      ._instantiateDateTimeFromMisc('2021-11-24T07:00:00.000Z', 'MMMM dd yyyy', { locale: 'fr' });
+      ._formatMiscToCompanyDate('2021-11-24T07:00:00.000Z', 'MMMM dd yyyy', { locale: 'fr' });
 
-    expect(result).toMatchObject({ invalid: { reason: 'wrong arguments', explanation: null } });
+    expect(result instanceof luxon.DateTime).toBe(true);
     sinon.assert.calledOnceWithExactly(invalid, 'wrong arguments');
     sinon.assert.notCalled(now);
     sinon.assert.notCalled(fromJSDate);


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations : -np
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [ ] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES
- ~~Si mes changements impactent l'application formation :~~
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- ~~Si mes changements impactent l'application erp :~~
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME -np
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV
- ~~J'ai changé une constante :~~
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- ~~J'ai ajouté une variable d'environnement :~~
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : vendeur

- Périmetre roles : rof/admin

- Cas d'usage : installation de Luxon + dans courseHistories remplacement de moment par luxon
