### PR TITLE
Com 2545

### DIFF
--- a/src/models/ThirdPartyPayer.js
+++ b/src/models/ThirdPartyPayer.js
@@ -18,6 +18,7 @@ const ThirdPartyPayerSchema = mongoose.Schema({
   teletransmissionId: { type: String },
   companyCode: { type: String },
   teletransmissionType: { type: String, enum: TELETRANSMISSION_TYPES },
+  deliveryRound: { type: Number, default: 0 },
 }, { timestamps: true });
 
 const countFundings = async (docs) => {

--- a/src/routes/preHandlers/teletransmission.js
+++ b/src/routes/preHandlers/teletransmission.js
@@ -11,7 +11,7 @@ exports.authorizeDelivery = async (req) => {
   if (tppsQuery.length !== tpps.length) return Boom.notFound();
 
   if (tpps.some(t => !t.teletransmissionId)) return Boom.forbidden();
-  if (tpps.some(t => !t.teletransmissionType) || tpps.some(t => !t.companyCode)) return Boom.forbidden();
+  if (tpps.some(t => !t.teletransmissionType || !t.companyCode)) return Boom.forbidden();
 
   if ([...new Set(tpps.map(t => t.teletransmissionType))].length !== 1) return Boom.conflict();
   if ([...new Set(tpps.map(t => t.companyCode))].length !== 1) return Boom.conflict();

--- a/tests/integration/teletransmission.test.js
+++ b/tests/integration/teletransmission.test.js
@@ -22,16 +22,6 @@ describe('TELETRANSMISSION ROUTES - GET /teletransmission/delivery', () => {
       expect(response.statusCode).toBe(200);
     });
 
-    it('should return a 404 if tpp is not from the same company', async () => {
-      const response = await app.inject({
-        method: 'GET',
-        url: `/teletransmission/delivery?thirdPartyPayers=${teletransmissionTppList[2]._id}&month=09-2021`,
-        headers: { Cookie: `alenvi_token=${authToken}` },
-      });
-
-      expect(response.statusCode).toBe(404);
-    });
-
     it('should return a 400 if thirdPartyPayers is missing in query', async () => {
       const response = await app.inject({
         method: 'GET',
@@ -50,6 +40,16 @@ describe('TELETRANSMISSION ROUTES - GET /teletransmission/delivery', () => {
       });
 
       expect(response.statusCode).toBe(400);
+    });
+
+    it('should return a 404 if tpp is not from the same company', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/teletransmission/delivery?thirdPartyPayers=${teletransmissionTppList[2]._id}&month=09-2021`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(404);
     });
 
     it('should return a 403 if missing teletransmissionId', async () => {

--- a/tests/unit/helpers/delivery.test.js
+++ b/tests/unit/helpers/delivery.test.js
@@ -12,6 +12,26 @@ const ThirdPartyPayer = require('../../../src/models/ThirdPartyPayer');
 const User = require('../../../src/models/User');
 const { NOT_INVOICED_AND_NOT_PAID } = require('../../../src/helpers/constants');
 
+describe('computeBilledQuantity', () => {
+  it('should round event duration if third party payer has specific rule', () => {
+    const event = { startDate: '2021-11-02T13:39:16', endDate: '2021-11-02T15:06:22' };
+    const thirdPartyPayer = { deliveryRound: 15 };
+
+    const result = DeliveryHelper.computeBilledQuantity(event, thirdPartyPayer);
+
+    expect(result).toEqual(1.5);
+  });
+
+  it('should return exact event duration if third party payer does not have specific rule', () => {
+    const event = { startDate: '2021-11-02T13:39:16', endDate: '2021-11-02T15:06:22' };
+    const thirdPartyPayer = {};
+
+    const result = DeliveryHelper.computeBilledQuantity(event, thirdPartyPayer);
+
+    expect(result).toEqual(1.45);
+  });
+});
+
 describe('formatEvents', () => {
   let findUsers;
   let findCustomers;
@@ -92,7 +112,10 @@ describe('formatEvents', () => {
             { 'contact.primaryAddress': 1, identity: 1, fundings: 1, serialNumber: 1, subscriptions: 1 },
           ],
         },
-        { query: 'populate', args: [{ path: 'fundings.thirdPartyPayer', select: 'teletransmissionId name type' }] },
+        {
+          query: 'populate',
+          args: [{ path: 'fundings.thirdPartyPayer', select: 'teletransmissionId name type deliveryRound' }],
+        },
         { query: 'populate', args: [{ path: 'subscriptions.service' }] },
         { query: 'lean' },
       ]


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations :
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [x] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES
- Si mes changements impactent l'application formation :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- Si mes changements impactent l'application erp :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : Client

- Périmetre roles : Admin

- Cas d'usage : Quand un tpp a un arrondi a 15min pour la télétransmission : 
si une intervention dure 52 min alors elle est arrondie a 45min dans le fichier de télétransmission
si une intervention dure 53 min alors elle est arrondie a 1h dans le fichier de télétransmission
