### PR TITLE
COM-2471 - Add isCancelled

### DIFF
--- a/src/helpers/eventHistories.js
+++ b/src/helpers/eventHistories.js
@@ -1,5 +1,6 @@
 const moment = require('moment');
 const get = require('lodash/get');
+const has = require('lodash/has');
 const pickBy = require('lodash/pickBy');
 const omit = require('lodash/omit');
 const EventHistory = require('../models/EventHistory');
@@ -21,6 +22,8 @@ exports.list = async (query, credentials) => {
     return EventHistoryRepository.paginate({
       'event.eventId': query.eventId,
       company: get(credentials, 'company._id'),
+      ...(query.action && { action: { $in: query.action } }),
+      ...(has(query, 'isCancelled') && { isCancelled: get(query, 'isCancelled') }),
     });
   }
 

--- a/src/routes/eventHistories.js
+++ b/src/routes/eventHistories.js
@@ -5,7 +5,7 @@ Joi.objectId = require('joi-objectid')(Joi);
 const { list, update } = require('../controllers/eventHistoryController');
 const { EVENTS_HISTORY_ACTIONS } = require('../models/EventHistory');
 const { authorizeEventsHistoriesGet, authorizeEventHistoryCancellation } = require('./preHandlers/eventHistories');
-const { objectIdOrArray } = require('./validations/utils');
+const { objectIdOrArray, stringOrArray } = require('./validations/utils');
 
 exports.plugin = {
   name: 'routes-event-history',
@@ -21,7 +21,8 @@ exports.plugin = {
             sectors: objectIdOrArray,
             createdAt: Joi.date(),
             eventId: Joi.objectId(),
-            action: Joi.array().items(Joi.string().valid(...EVENTS_HISTORY_ACTIONS)),
+            action: stringOrArray(EVENTS_HISTORY_ACTIONS),
+            isCancelled: Joi.boolean().valid(false),
           }),
         },
         pre: [{ method: authorizeEventsHistoriesGet }],

--- a/src/routes/validations/utils.js
+++ b/src/routes/validations/utils.js
@@ -17,6 +17,11 @@ const addressValidation = Joi.object().keys({
 
 const objectIdOrArray = Joi.alternatives().try(Joi.objectId(), Joi.array().items(Joi.objectId()));
 
+const stringOrArray = valid => (valid
+  ? Joi.alternatives().try(Joi.string().valid(...valid), Joi.array().items(Joi.string().valid(...valid)))
+  : Joi.alternatives().try(Joi.string(), Joi.array().items(Joi.string()))
+);
+
 const expoTokenValidation = Joi.string().custom((value, helper) => (
   value.substring(0, 18) === 'ExponentPushToken['
     ? value
@@ -36,6 +41,7 @@ module.exports = {
   phoneNumberValidation,
   addressValidation,
   objectIdOrArray,
+  stringOrArray,
   expoTokenValidation,
   formDataPayload,
 };

--- a/tests/integration/seed/eventHistoriesSeed.js
+++ b/tests/integration/seed/eventHistoriesSeed.js
@@ -287,4 +287,5 @@ module.exports = {
   auxiliaryFromOtherCompany,
   sectorFromOtherCompany,
   sectors,
+  events,
 };

--- a/tests/unit/helpers/eventHistories.test.js
+++ b/tests/unit/helpers/eventHistories.test.js
@@ -46,7 +46,7 @@ describe('list', () => {
     const eventId = new ObjectID();
     const companyId = new ObjectID();
 
-    const query = { eventId };
+    const query = { eventId, action: [EVENT_CREATION], isCancelled: false };
     const credentials = { company: { _id: companyId } };
     paginateStub.returns([{ type: INTERVENTION }]);
 
@@ -54,7 +54,15 @@ describe('list', () => {
 
     expect(result).toEqual([{ type: INTERVENTION }]);
     sinon.assert.notCalled(getListQueryStub);
-    sinon.assert.calledOnceWithExactly(paginateStub, { 'event.eventId': eventId, company: companyId });
+    sinon.assert.calledOnceWithExactly(
+      paginateStub,
+      {
+        'event.eventId': eventId,
+        company: companyId,
+        action: { $in: [EVENT_CREATION] },
+        isCancelled: false,
+      }
+    );
   });
 });
 


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations :
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [x] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [x] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES
- ~~Si mes changements impactent l'application formation :~~
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- Si mes changements impactent l'application erp :
  - [x] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME
- [x] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [x] Je n'ai pas changé les droits de la route
  - [x] Je n'ai pas changé les droits dans le fichier rights.js
  - [x] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [x] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a: -np
- ~~J'ai supprimé une route :~~
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- ~~J'ai renommé une route :~~
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [x] J'ai géré le cas ou on ne l'envoie pas
- ~~J'ai rendu obligatoire un champs de la route :~~
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- ~~J'ai retiré un champ possible dans la route :~~
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- ~~J'ai supprimé un retour/un champs du retour de la route :~~
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### ~~MODIFICATIONS SUR LES MODÈLES~~
- ~~J'ai ajouté un modèle spécifique à une structure:~~
  - ~~[ ] J'ai ajouté le champ company ainsi que les preHooks associés~~
- ~~J'ai changé un modèle utilisé par l'app mobile:~~
  - ~~J'ai ajouté un champ possible :~~
    - ~~[ ] J'ai géré le cas où l'application ne l'envoie pas~~
  - ~~J'ai rendu obligatoire un champs :~~
    - ~~[ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)~~
  - ~~J'ai retiré un champ possible :~~
    - ~~[ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas~~

### ~~CONSTANTES ET VARIABLE D'ENV~~
- ~~J'ai changé une constante :~~
  - ~~[ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)~~

- ~~J'ai ajouté une variable d'environnement :~~
  - ~~[ ] J'ai précisé sur le slite de MES et MEP les modifications faites~~


### POUR TESTER LA PR
- Périmetre interface : compani outils

- Périmetre roles : auxiliaire / admin / coach

- Cas d'usage : 
Ajout des champs dans la route de récupération des historiques d'un évènement.