### PR TITLE
Com 2530

### DIFF
--- a/src/helpers/authentication.js
+++ b/src/helpers/authentication.js
@@ -26,7 +26,7 @@ exports.authenticate = async (payload) => {
     .lean();
   const correctPassword = get(user, 'local.password') || '';
   const isCorrect = await bcrypt.compare(payload.password, correctPassword);
-  if (!user || !user.refreshToken || !correctPassword || !isCorrect) throw Boom.unauthorized();
+  // if (!user || !user.refreshToken || !correctPassword || !isCorrect) throw Boom.unauthorized();
 
   const tokenPayload = { _id: user._id.toHexString() };
   const token = exports.encode(tokenPayload, TOKEN_EXPIRE_TIME);

--- a/src/helpers/authentication.js
+++ b/src/helpers/authentication.js
@@ -26,7 +26,7 @@ exports.authenticate = async (payload) => {
     .lean();
   const correctPassword = get(user, 'local.password') || '';
   const isCorrect = await bcrypt.compare(payload.password, correctPassword);
-  // if (!user || !user.refreshToken || !correctPassword || !isCorrect) throw Boom.unauthorized();
+  if (!user || !user.refreshToken || !correctPassword || !isCorrect) throw Boom.unauthorized();
 
   const tokenPayload = { _id: user._id.toHexString() };
   const token = exports.encode(tokenPayload, TOKEN_EXPIRE_TIME);

--- a/src/helpers/courseHistories.js
+++ b/src/helpers/courseHistories.js
@@ -1,5 +1,5 @@
 const pick = require('lodash/pick');
-const { CompaniDate } = require('./companiDates');
+const { CompaniDate } = require('./dates/companiDates');
 const CourseHistory = require('../models/CourseHistory');
 const { SLOT_CREATION, SLOT_DELETION, SLOT_EDITION, TRAINEE_ADDITION, TRAINEE_DELETION } = require('./constants');
 

--- a/src/helpers/courses.js
+++ b/src/helpers/courses.js
@@ -7,6 +7,8 @@ const os = require('os');
 const moment = require('moment');
 const flat = require('flat');
 const Boom = require('@hapi/boom');
+const { CompaniDate } = require('./dates/companiDates');
+const { CompaniDuration } = require('./dates/companiDurations');
 const Course = require('../models/Course');
 const User = require('../models/User');
 const Questionnaire = require('../models/Questionnaire');
@@ -389,28 +391,28 @@ exports.formatIntraCourseSlotsForPdf = slot => ({
 });
 
 exports.formatInterCourseSlotsForPdf = (slot) => {
-  const duration = moment.duration(moment(slot.endDate).diff(slot.startDate));
+  const duration = CompaniDuration(CompaniDate(slot.endDate).diff(slot.startDate));
 
   return {
     address: get(slot, 'address.fullAddress') || null,
-    date: moment(slot.startDate).format('DD/MM/YYYY'),
-    startHour: moment(slot.startDate).format('HH:mm'),
-    endHour: moment(slot.endDate).format('HH:mm'),
-    duration: UtilsHelper.formatDuration(duration),
+    date: CompaniDate(slot.startDate).format('dd/LL/yyyy'),
+    startHour: CompaniDate(slot.startDate).format('HH:mm'),
+    endHour: CompaniDate(slot.endDate).format('HH:mm'),
+    duration: duration.format(),
   };
 };
 
 exports.getCourseDuration = (slots) => {
   const duration = slots.reduce(
-    (acc, slot) => acc.add(moment.duration(moment(slot.endDate).diff(slot.startDate))),
-    moment.duration()
+    (acc, slot) => acc.add(CompaniDuration(CompaniDate(slot.endDate).diff(slot.startDate))),
+    CompaniDuration()
   );
 
-  return UtilsHelper.formatDuration(duration);
+  return duration.format();
 };
 
 exports.groupSlotsByDate = (slots) => {
-  const group = groupBy(slots, slot => moment(slot.startDate).format('DD/MM/YYYY'));
+  const group = groupBy(slots, slot => CompaniDate(slot.startDate).format('dd/LL/yyyy'));
 
   return Object.values(group).sort((a, b) => new Date(a[0].startDate) - new Date(b[0].startDate));
 };
@@ -433,7 +435,7 @@ exports.formatIntraCourseForPdf = (course) => {
       course: { ...courseData },
       address: get(groupedSlots[0], 'address.fullAddress') || '',
       slots: groupedSlots.map(slot => exports.formatIntraCourseSlotsForPdf(slot)),
-      date: moment(groupedSlots[0].startDate).format('DD/MM/YYYY'),
+      date: CompaniDate(groupedSlots[0].startDate).format('dd/LL/yyyy'),
     })),
   };
 };
@@ -451,9 +453,9 @@ exports.formatInterCourseForPdf = (course) => {
     name,
     slots: filteredSlots.map(exports.formatInterCourseSlotsForPdf),
     trainer: course.trainer ? UtilsHelper.formatIdentity(course.trainer.identity, 'FL') : '',
-    firstDate: filteredSlots.length ? moment(filteredSlots[0].startDate).format('DD/MM/YYYY') : '',
+    firstDate: filteredSlots.length ? CompaniDate(filteredSlots[0].startDate).format('dd/LL/yyyy') : '',
     lastDate: filteredSlots.length
-      ? moment(filteredSlots[filteredSlots.length - 1].startDate).format('DD/MM/YYYY')
+      ? CompaniDate(filteredSlots[filteredSlots.length - 1].startDate).format('dd/LL/yyyy')
       : '',
     duration: exports.getCourseDuration(filteredSlots),
   };

--- a/src/helpers/dates/companiDates.js
+++ b/src/helpers/dates/companiDates.js
@@ -12,6 +12,13 @@ const companiDateFactory = _date => ({
 
     return this._date.hasSame(otherDate, unit);
   },
+  diff(miscTypeOtherDate, unit = 'milliseconds', typeFloat = false) {
+    const otherDate = exports._formatMiscToCompaniDate(miscTypeOtherDate);
+    const floatDiff = this._date.diff(otherDate, unit).as(unit);
+
+    if (typeFloat) return floatDiff;
+    return floatDiff > 0 ? Math.floor(floatDiff) : Math.ceil(floatDiff);
+  },
 });
 
 exports._formatMiscToCompaniDate = (...args) => {

--- a/src/helpers/dates/companiDates.js
+++ b/src/helpers/dates/companiDates.js
@@ -1,7 +1,4 @@
-const luxon = require('luxon');
-
-luxon.Settings.defaultLocale = 'fr';
-luxon.Settings.defaultZone = 'Europe/Paris';
+const luxon = require('./luxon');
 
 exports.CompaniDate = (...args) => companiDateFactory(exports._formatMiscToCompaniDate(...args));
 

--- a/src/helpers/dates/companiDates.js
+++ b/src/helpers/dates/companiDates.js
@@ -1,6 +1,7 @@
 const luxon = require('luxon');
 
 luxon.Settings.defaultLocale = 'fr';
+luxon.Settings.defaultZone = 'Europe/Paris';
 
 exports.CompaniDate = (...args) => companiDateFactory(exports._formatMiscToCompaniDate(...args));
 

--- a/src/helpers/dates/companiDates.js
+++ b/src/helpers/dates/companiDates.js
@@ -7,6 +7,9 @@ exports.CompaniDate = (...args) => companiDateFactory(exports._formatMiscToCompa
 const companiDateFactory = _date => ({
   _date,
 
+  format(fmt) {
+    return this._date.toFormat(fmt);
+  },
   isSame(miscTypeOtherDate, unit) {
     const otherDate = exports._formatMiscToCompaniDate(miscTypeOtherDate);
 

--- a/src/helpers/dates/companiDates.js
+++ b/src/helpers/dates/companiDates.js
@@ -1,5 +1,7 @@
 const luxon = require('luxon');
 
+luxon.Settings.defaultLocale = 'fr';
+
 exports.CompaniDate = (...args) => companiDateFactory(exports._formatMiscToCompanyDate(...args));
 
 const companiDateFactory = _date => ({
@@ -23,7 +25,8 @@ exports._formatMiscToCompanyDate = (...args) => {
   }
 
   if (args.length === 2 && typeof args[0] === 'string' && typeof args[1] === 'string') {
-    return luxon.DateTime.fromFormat(args[0], args[1], { zone: 'utc' });
+    const options = args[0].endsWith('Z') ? { zone: 'utc' } : {};
+    return luxon.DateTime.fromFormat(args[0], args[1], options);
   }
 
   return luxon.DateTime.invalid('wrong arguments');

--- a/src/helpers/dates/companiDates.js
+++ b/src/helpers/dates/companiDates.js
@@ -11,11 +11,13 @@ const companiDateFactory = _date => ({
   format(fmt) {
     return this._date.toFormat(fmt);
   },
+
   isSame(miscTypeOtherDate, unit) {
     const otherDate = exports._formatMiscToCompaniDate(miscTypeOtherDate);
 
     return this._date.hasSame(otherDate, unit);
   },
+
   diff(miscTypeOtherDate, unit = 'milliseconds', typeFloat = false) {
     const otherDate = exports._formatMiscToCompaniDate(miscTypeOtherDate);
     const floatDiff = this._date.diff(otherDate, unit).as(unit);

--- a/src/helpers/dates/companiDates.js
+++ b/src/helpers/dates/companiDates.js
@@ -2,19 +2,19 @@ const luxon = require('luxon');
 
 luxon.Settings.defaultLocale = 'fr';
 
-exports.CompaniDate = (...args) => companiDateFactory(exports._formatMiscToCompanyDate(...args));
+exports.CompaniDate = (...args) => companiDateFactory(exports._formatMiscToCompaniDate(...args));
 
 const companiDateFactory = _date => ({
   _date,
 
   isSame(miscTypeOtherDate, unit) {
-    const otherDate = exports._formatMiscToCompanyDate(miscTypeOtherDate);
+    const otherDate = exports._formatMiscToCompaniDate(miscTypeOtherDate);
 
     return this._date.hasSame(otherDate, unit);
   },
 });
 
-exports._formatMiscToCompanyDate = (...args) => {
+exports._formatMiscToCompaniDate = (...args) => {
   if (!args.length) return luxon.DateTime.now();
 
   if (args.length === 1) {

--- a/src/helpers/dates/companiDurations.js
+++ b/src/helpers/dates/companiDurations.js
@@ -11,12 +11,20 @@ const companiDurationFactory = _duration => ({
 
     return _duration.toFormat(format);
   },
+  add(miscTypeOtherDuration) {
+    const otherDuration = exports._formatMiscToCompaniDuration(miscTypeOtherDuration);
+
+    return companiDurationFactory(_duration.plus(otherDuration));
+  },
 });
 
 exports._formatMiscToCompaniDuration = (...args) => {
   if (args.length === 0) return luxon.Duration.fromObject({});
 
   if (args.length === 1) {
+    if (args[0] instanceof Object && args[0]._duration && args[0]._duration instanceof luxon.Duration) {
+      return args[0]._duration;
+    }
     if (typeof args[0] === 'number') {
       return luxon.Duration.fromMillis(args[0]);
     }

--- a/src/helpers/dates/companiDurations.js
+++ b/src/helpers/dates/companiDurations.js
@@ -4,6 +4,13 @@ exports.CompaniDuration = (...args) => companiDurationFactory(exports._formatMis
 
 const companiDurationFactory = _duration => ({
   _duration,
+
+  format() {
+    const durationInHoursAndMinutes = this._duration.shiftTo('hours', 'minutes');
+    const format = Math.floor(durationInHoursAndMinutes.get('minutes')) > 0 ? 'h\'h\'mm' : 'h\'h\'';
+
+    return _duration.toFormat(format);
+  },
 });
 
 exports._formatMiscToCompaniDuration = (...args) => {

--- a/src/helpers/dates/companiDurations.js
+++ b/src/helpers/dates/companiDurations.js
@@ -1,12 +1,12 @@
 const luxon = require('luxon');
 
-exports.CompaniDuration = (...args) => companiDurationFactory(exports._formatMiscToCompanyDuration(...args));
+exports.CompaniDuration = (...args) => companiDurationFactory(exports._formatMiscToCompaniDuration(...args));
 
 const companiDurationFactory = _duration => ({
   _duration,
 });
 
-exports._formatMiscToCompanyDuration = (...args) => {
+exports._formatMiscToCompaniDuration = (...args) => {
   if (args.length === 1) {
     if (typeof args[0] === 'number') {
       return luxon.Duration.fromMillis(args[0]);

--- a/src/helpers/dates/companiDurations.js
+++ b/src/helpers/dates/companiDurations.js
@@ -14,6 +14,8 @@ const companiDurationFactory = _duration => ({
 });
 
 exports._formatMiscToCompaniDuration = (...args) => {
+  if (args.length === 0) return luxon.Duration.fromObject({});
+
   if (args.length === 1) {
     if (typeof args[0] === 'number') {
       return luxon.Duration.fromMillis(args[0]);

--- a/src/helpers/dates/companiDurations.js
+++ b/src/helpers/dates/companiDurations.js
@@ -1,4 +1,4 @@
-const luxon = require('luxon');
+const luxon = require('./luxon');
 
 exports.CompaniDuration = (...args) => companiDurationFactory(exports._formatMiscToCompaniDuration(...args));
 

--- a/src/helpers/dates/companiDurations.js
+++ b/src/helpers/dates/companiDurations.js
@@ -11,6 +11,7 @@ const companiDurationFactory = _duration => ({
 
     return this._duration.toFormat(format);
   },
+
   add(miscTypeOtherDuration) {
     const otherDuration = exports._formatMiscToCompaniDuration(miscTypeOtherDuration);
 

--- a/src/helpers/dates/companiDurations.js
+++ b/src/helpers/dates/companiDurations.js
@@ -9,12 +9,12 @@ const companiDurationFactory = _duration => ({
     const durationInHoursAndMinutes = this._duration.shiftTo('hours', 'minutes');
     const format = Math.floor(durationInHoursAndMinutes.get('minutes')) > 0 ? 'h\'h\'mm' : 'h\'h\'';
 
-    return _duration.toFormat(format);
+    return this._duration.toFormat(format);
   },
   add(miscTypeOtherDuration) {
     const otherDuration = exports._formatMiscToCompaniDuration(miscTypeOtherDuration);
 
-    return companiDurationFactory(_duration.plus(otherDuration));
+    return companiDurationFactory(this._duration.plus(otherDuration));
   },
 });
 

--- a/src/helpers/dates/companiDurations.js
+++ b/src/helpers/dates/companiDurations.js
@@ -14,7 +14,9 @@ const companiDurationFactory = _duration => ({
   add(miscTypeOtherDuration) {
     const otherDuration = exports._formatMiscToCompaniDuration(miscTypeOtherDuration);
 
-    return companiDurationFactory(this._duration.plus(otherDuration));
+    this._duration = this._duration.plus(otherDuration);
+
+    return this;
   },
 });
 

--- a/src/helpers/dates/companiDurations.js
+++ b/src/helpers/dates/companiDurations.js
@@ -1,0 +1,16 @@
+const luxon = require('luxon');
+
+exports.CompaniDuration = (...args) => companiDurationFactory(exports._formatMiscToCompanyDuration(...args));
+
+const companiDurationFactory = _duration => ({
+  _duration,
+});
+
+exports._formatMiscToCompanyDuration = (...args) => {
+  if (args.length === 1) {
+    if (typeof args[0] === 'number') {
+      return luxon.Duration.fromMillis(args[0]);
+    }
+  }
+  return luxon.Duration.invalid('wrong arguments');
+};

--- a/src/helpers/dates/luxon.js
+++ b/src/helpers/dates/luxon.js
@@ -1,0 +1,6 @@
+const luxon = require('luxon');
+
+luxon.Settings.defaultLocale = 'fr';
+luxon.Settings.defaultZone = 'Europe/Paris';
+
+module.exports = luxon;

--- a/src/routes/preHandlers/attendanceSheets.js
+++ b/src/routes/preHandlers/attendanceSheets.js
@@ -1,6 +1,6 @@
 const Boom = require('@hapi/boom');
-const moment = require('moment');
 const get = require('lodash/get');
+const { CompaniDate } = require('../../helpers/dates/companiDates');
 const UtilsHelper = require('../../helpers/utils');
 const Course = require('../../models/Course');
 const AttendanceSheet = require('../../models/AttendanceSheet');
@@ -32,7 +32,7 @@ exports.authorizeAttendanceSheetCreation = async (req) => {
 
   if (course.type === INTRA) {
     if (req.payload.trainee) return Boom.badRequest();
-    const courseDates = course.slots.filter(slot => moment(slot.startDate).isSame(req.payload.date, 'day'));
+    const courseDates = course.slots.filter(slot => CompaniDate(slot.startDate).isSame(req.payload.date, 'day'));
     if (!courseDates.length) return Boom.forbidden();
 
     return null;

--- a/tests/unit/helpers/courses.test.js
+++ b/tests/unit/helpers/courses.test.js
@@ -5,7 +5,6 @@ const fs = require('fs');
 const os = require('os');
 const { PassThrough } = require('stream');
 const { fn: momentProto } = require('moment');
-const moment = require('moment');
 const Boom = require('@hapi/boom');
 const Course = require('../../../src/models/Course');
 const User = require('../../../src/models/User');
@@ -1399,61 +1398,45 @@ describe('formatInterCourseSlotsForPdf', () => {
 });
 
 describe('getCourseDuration', () => {
-  let formatDuration;
-  beforeEach(() => {
-    formatDuration = sinon.stub(UtilsHelper, 'formatDuration');
-  });
-  afterEach(() => {
-    formatDuration.restore();
-  });
-
   it('should return course duration with minutes', () => {
     const slots = [
       { startDate: '2020-03-20T09:00:00', endDate: '2020-03-20T11:00:00' },
       { startDate: '2020-04-21T09:00:00', endDate: '2020-04-21T11:30:00' },
     ];
-    formatDuration.returns('4h30');
 
     const result = CourseHelper.getCourseDuration(slots);
 
     expect(result).toEqual('4h30');
-    sinon.assert.calledOnceWithExactly(formatDuration, moment.duration({ hours: 4, minutes: 30 }));
   });
   it('should return course duration with leading zero minutes', () => {
     const slots = [
       { startDate: '2020-03-20T09:00:00', endDate: '2020-03-20T11:08:00' },
       { startDate: '2020-04-21T09:00:00', endDate: '2020-04-21T11:00:00' },
     ];
-    formatDuration.returns('4h08');
 
     const result = CourseHelper.getCourseDuration(slots);
 
     expect(result).toEqual('4h08');
-    sinon.assert.calledOnceWithExactly(formatDuration, moment.duration({ hours: 4, minutes: 8 }));
   });
   it('should return course duration without minutes', () => {
     const slots = [
       { startDate: '2020-03-20T09:00:00', endDate: '2020-03-20T11:00:00' },
       { startDate: '2020-04-21T09:00:00', endDate: '2020-04-21T11:00:00' },
     ];
-    formatDuration.returns('4h');
 
     const result = CourseHelper.getCourseDuration(slots);
 
     expect(result).toEqual('4h');
-    sinon.assert.calledOnceWithExactly(formatDuration, moment.duration({ hours: 4 }));
   });
   it('should return course duration with days', () => {
     const slots = [
       { startDate: '2020-03-20T07:00:00', endDate: '2020-03-20T22:00:00' },
       { startDate: '2020-04-21T07:00:00', endDate: '2020-04-21T22:00:00' },
     ];
-    formatDuration.returns('30h');
 
     const result = CourseHelper.getCourseDuration(slots);
 
     expect(result).toEqual('30h');
-    sinon.assert.calledOnceWithExactly(formatDuration, moment.duration({ hours: 30 }));
   });
 });
 

--- a/tests/unit/helpers/dates/companiDates.test.js
+++ b/tests/unit/helpers/dates/companiDates.test.js
@@ -20,7 +20,11 @@ describe('CompaniDate', () => {
     const result = CompaniDatesHelper.CompaniDate(date);
 
     expect(result)
-      .toEqual(expect.objectContaining({ _date: expect.any(luxon.DateTime), isSame: expect.any(Function) }));
+      .toEqual(expect.objectContaining({
+        _date: expect.any(luxon.DateTime),
+        isSame: expect.any(Function),
+        diff: expect.any(Function),
+      }));
     sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), date);
   });
 });
@@ -49,6 +53,70 @@ describe('isSame', () => {
     const result = companiDate.isSame(otherDate, 'minute');
 
     expect(result).toBe(false);
+    sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
+  });
+});
+
+describe('diff', () => {
+  let _formatMiscToCompaniDate;
+  const companiDate = CompaniDatesHelper.CompaniDate('2021-11-24T10:00:00.000Z');
+
+  beforeEach(() => {
+    _formatMiscToCompaniDate = sinon.spy(CompaniDatesHelper, '_formatMiscToCompaniDate');
+  });
+
+  afterEach(() => {
+    _formatMiscToCompaniDate.restore();
+  });
+
+  it('should return diff in milliseconds, if no unit specified', () => {
+    const otherDate = new Date('2021-11-24T08:29:48.000Z');
+    const result = companiDate.diff(otherDate);
+    const expectedDiffInMillis = 1 * 60 * 60 * 1000 + 30 * 60 * 1000 + 12 * 1000;
+
+    expect(result).toBe(expectedDiffInMillis);
+    sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
+  });
+
+  it('should return difference in positive days', () => {
+    const otherDate = new Date('2021-11-20T08:00:00.000Z');
+    const result = companiDate.diff(otherDate, 'days');
+
+    expect(result).toBe(4);
+    sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
+  });
+
+  it('should return difference in days. Result should be 0 if difference is less then 24h', () => {
+    const otherDate = new Date('2021-11-23T21:00:00.000Z');
+    const result = companiDate.diff(otherDate, 'days');
+
+    expect(result).toBe(0);
+    sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
+  });
+
+  it('should return difference in positive floated days', () => {
+    const otherDate = new Date('2021-11-22T21:00:00.000Z');
+    const result = companiDate.diff(otherDate, 'days', true);
+
+    expect(result).toBeGreaterThan(0);
+    expect(result - 1.54).toBeLessThan(0.01);
+    sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
+  });
+
+  it('should return difference in negative days', () => {
+    const otherDate = new Date('2021-11-30T08:00:00.000Z');
+    const result = companiDate.diff(otherDate, 'days');
+
+    expect(result).toBe(-5);
+    sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
+  });
+
+  it('should return difference in negative floated days', () => {
+    const otherDate = new Date('2021-11-30T08:00:00.000Z');
+    const result = companiDate.diff(otherDate, 'days', true);
+
+    expect(result).toBeLessThan(0);
+    expect(Math.abs(result) - 5.91).toBeLessThan(0.01);
     sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
   });
 });

--- a/tests/unit/helpers/dates/companiDates.test.js
+++ b/tests/unit/helpers/dates/companiDates.test.js
@@ -1,7 +1,7 @@
 const expect = require('expect');
 const luxon = require('luxon');
 const sinon = require('sinon');
-const CompaniDatesHelper = require('../../../src/helpers/companiDates');
+const CompaniDatesHelper = require('../../../../src/helpers/dates/companiDates');
 
 describe('CompaniDate', () => {
   let _formatMiscToCompanyDate;
@@ -141,7 +141,27 @@ describe('_formatMiscToCompanyDate', () => {
     sinon.assert.notCalled(invalid);
   });
 
-  it('should return dateTime if 2 args', () => {
+  it('should return dateTime if 2 args, first argument doesn\'t finish with Z', () => {
+    const result = CompaniDatesHelper._formatMiscToCompanyDate(
+      '2021-11-24T07:00:00.000+03:00',
+      'yyyy-MM-dd\'T\'hh:mm:ss.SSSZZ'
+    );
+
+    expect(result instanceof luxon.DateTime).toBe(true);
+    expect(new luxon.DateTime(result).toJSDate()).toEqual(new Date('2021-11-24T07:00:00.000+03:00'));
+    sinon.assert.calledOnceWithExactly(
+      fromFormat,
+      '2021-11-24T07:00:00.000+03:00',
+      'yyyy-MM-dd\'T\'hh:mm:ss.SSSZZ',
+      {}
+    );
+    sinon.assert.notCalled(now);
+    sinon.assert.notCalled(fromJSDate);
+    sinon.assert.notCalled(fromISO);
+    sinon.assert.notCalled(invalid);
+  });
+
+  it('should return dateTime if 2 args, first arguments finish with Z', () => {
     const result = CompaniDatesHelper._formatMiscToCompanyDate(
       '2021-11-24T07:00:00.000Z',
       'yyyy-MM-dd\'T\'hh:mm:ss.SSS\'Z\''

--- a/tests/unit/helpers/dates/companiDates.test.js
+++ b/tests/unit/helpers/dates/companiDates.test.js
@@ -4,14 +4,14 @@ const sinon = require('sinon');
 const CompaniDatesHelper = require('../../../../src/helpers/dates/companiDates');
 
 describe('CompaniDate', () => {
-  let _formatMiscToCompanyDate;
+  let _formatMiscToCompaniDate;
 
   beforeEach(() => {
-    _formatMiscToCompanyDate = sinon.spy(CompaniDatesHelper, '_formatMiscToCompanyDate');
+    _formatMiscToCompaniDate = sinon.spy(CompaniDatesHelper, '_formatMiscToCompaniDate');
   });
 
   afterEach(() => {
-    _formatMiscToCompanyDate.restore();
+    _formatMiscToCompaniDate.restore();
   });
 
   it('should return dateTime', () => {
@@ -21,39 +21,39 @@ describe('CompaniDate', () => {
 
     expect(result)
       .toEqual(expect.objectContaining({ _date: expect.any(luxon.DateTime), isSame: expect.any(Function) }));
-    sinon.assert.calledWithExactly(_formatMiscToCompanyDate.getCall(0), date);
+    sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), date);
   });
 });
 
 describe('isSame', () => {
-  let _formatMiscToCompanyDate;
+  let _formatMiscToCompaniDate;
   const companiDate = CompaniDatesHelper.CompaniDate('2021-11-24T07:00:00.000Z');
   const otherDate = new Date('2021-11-24T10:00:00.000Z');
 
   beforeEach(() => {
-    _formatMiscToCompanyDate = sinon.spy(CompaniDatesHelper, '_formatMiscToCompanyDate');
+    _formatMiscToCompaniDate = sinon.spy(CompaniDatesHelper, '_formatMiscToCompaniDate');
   });
 
   afterEach(() => {
-    _formatMiscToCompanyDate.restore();
+    _formatMiscToCompaniDate.restore();
   });
 
   it('should return true if same day', () => {
     const result = companiDate.isSame(otherDate, 'day');
 
     expect(result).toBe(true);
-    sinon.assert.calledWithExactly(_formatMiscToCompanyDate.getCall(0), otherDate);
+    sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
   });
 
   it('should return false if different minute', () => {
     const result = companiDate.isSame(otherDate, 'minute');
 
     expect(result).toBe(false);
-    sinon.assert.calledWithExactly(_formatMiscToCompanyDate.getCall(0), otherDate);
+    sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
   });
 });
 
-describe('_formatMiscToCompanyDate', () => {
+describe('_formatMiscToCompaniDate', () => {
   let now;
   let fromJSDate;
   let fromISO;
@@ -78,7 +78,7 @@ describe('_formatMiscToCompanyDate', () => {
   });
 
   it('should return dateTime.now if no arg', () => {
-    const result = CompaniDatesHelper._formatMiscToCompanyDate();
+    const result = CompaniDatesHelper._formatMiscToCompaniDate();
 
     expect(result instanceof luxon.DateTime).toBe(true);
     expect(new luxon.DateTime(result).toJSDate() - new Date()).toBeLessThan(100);
@@ -91,7 +91,7 @@ describe('_formatMiscToCompanyDate', () => {
 
   it('should return dateTime if arg is object with dateTime', () => {
     const payload = { _date: date };
-    const result = CompaniDatesHelper._formatMiscToCompanyDate(payload);
+    const result = CompaniDatesHelper._formatMiscToCompaniDate(payload);
 
     expect(result instanceof luxon.DateTime).toBe(true);
     expect(new luxon.DateTime(result).toJSDate()).toEqual(new Date('2021-11-24T07:00:00.000Z'));
@@ -104,7 +104,7 @@ describe('_formatMiscToCompanyDate', () => {
 
   it('should return dateTime if arg is dateTime', () => {
     const payload = date;
-    const result = CompaniDatesHelper._formatMiscToCompanyDate(payload);
+    const result = CompaniDatesHelper._formatMiscToCompaniDate(payload);
 
     expect(result instanceof luxon.DateTime).toBe(true);
     expect(new luxon.DateTime(result).toJSDate()).toEqual(new Date('2021-11-24T07:00:00.000Z'));
@@ -117,7 +117,7 @@ describe('_formatMiscToCompanyDate', () => {
 
   it('should return dateTime if arg is date', () => {
     const payload = new Date('2021-11-24T07:00:00.000Z');
-    const result = CompaniDatesHelper._formatMiscToCompanyDate(payload);
+    const result = CompaniDatesHelper._formatMiscToCompaniDate(payload);
 
     expect(result instanceof luxon.DateTime).toBe(true);
     expect(new luxon.DateTime(result).toJSDate()).toEqual(new Date('2021-11-24T07:00:00.000Z'));
@@ -130,7 +130,7 @@ describe('_formatMiscToCompanyDate', () => {
 
   it('should return dateTime if arg is string', () => {
     const payload = '2021-11-24T07:00:00.000Z';
-    const result = CompaniDatesHelper._formatMiscToCompanyDate(payload);
+    const result = CompaniDatesHelper._formatMiscToCompaniDate(payload);
 
     expect(result instanceof luxon.DateTime).toBe(true);
     expect(new luxon.DateTime(result).toJSDate()).toEqual(new Date('2021-11-24T07:00:00.000Z'));
@@ -142,7 +142,7 @@ describe('_formatMiscToCompanyDate', () => {
   });
 
   it('should return dateTime if 2 args, first argument doesn\'t finish with Z', () => {
-    const result = CompaniDatesHelper._formatMiscToCompanyDate(
+    const result = CompaniDatesHelper._formatMiscToCompaniDate(
       '2021-11-24T07:00:00.000+03:00',
       'yyyy-MM-dd\'T\'hh:mm:ss.SSSZZ'
     );
@@ -162,7 +162,7 @@ describe('_formatMiscToCompanyDate', () => {
   });
 
   it('should return dateTime if 2 args, first arguments finish with Z', () => {
-    const result = CompaniDatesHelper._formatMiscToCompanyDate(
+    const result = CompaniDatesHelper._formatMiscToCompaniDate(
       '2021-11-24T07:00:00.000Z',
       'yyyy-MM-dd\'T\'hh:mm:ss.SSS\'Z\''
     );
@@ -183,7 +183,7 @@ describe('_formatMiscToCompanyDate', () => {
 
   it('should return invalid if too many args', () => {
     const result = CompaniDatesHelper
-      ._formatMiscToCompanyDate('2021-11-24T07:00:00.000Z', 'MMMM dd yyyy', { locale: 'fr' });
+      ._formatMiscToCompaniDate('2021-11-24T07:00:00.000Z', 'MMMM dd yyyy', { locale: 'fr' });
 
     expect(result instanceof luxon.DateTime).toBe(true);
     sinon.assert.calledOnceWithExactly(invalid, 'wrong arguments');

--- a/tests/unit/helpers/dates/companiDates.test.js
+++ b/tests/unit/helpers/dates/companiDates.test.js
@@ -1,6 +1,6 @@
 const expect = require('expect');
-const luxon = require('luxon');
 const sinon = require('sinon');
+const luxon = require('../../../../src/helpers/dates/luxon');
 const CompaniDatesHelper = require('../../../../src/helpers/dates/companiDates');
 
 describe('CompaniDate', () => {

--- a/tests/unit/helpers/dates/companiDates.test.js
+++ b/tests/unit/helpers/dates/companiDates.test.js
@@ -31,12 +31,12 @@ describe('CompaniDate', () => {
 });
 
 describe('format', () => {
-  const companiDate = CompaniDatesHelper.CompaniDate('2021-11-24T07:00:00.000Z');
+  const companiDate = CompaniDatesHelper.CompaniDate('2021-11-24T07:12:08.000Z');
 
   it('should return formated date in a string', () => {
-    const result = companiDate.format('\'Le\' cccc dd LLLL y');
+    const result = companiDate.format('\'Le\' cccc dd LLLL y \'à\' HH\'h\'mm \'et\' s \'secondes\'');
 
-    expect(result).toBe('Le mercredi 24 novembre 2021');
+    expect(result).toBe('Le mercredi 24 novembre 2021 à 08h12 et 8 secondes');
   });
 });
 
@@ -90,7 +90,7 @@ describe('diff', () => {
   });
 
   it('should return difference in positive days', () => {
-    const otherDate = new Date('2021-11-20T08:00:00.000Z');
+    const otherDate = new Date('2021-11-20T10:00:00.000Z');
     const result = companiDate.diff(otherDate, 'days');
 
     expect(result).toBe(4);
@@ -110,15 +110,15 @@ describe('diff', () => {
     const result = companiDate.diff(otherDate, 'days', true);
 
     expect(result).toBeGreaterThan(0);
-    expect(result - 1.54).toBeLessThan(0.01);
+    expect(result - 1.54).toBeLessThan(0.01); // 1.54 days = 1 day and 13 hours
     sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
   });
 
   it('should return difference in negative days', () => {
-    const otherDate = new Date('2021-11-30T08:00:00.000Z');
+    const otherDate = new Date('2021-11-30T10:00:00.000Z');
     const result = companiDate.diff(otherDate, 'days');
 
-    expect(result).toBe(-5);
+    expect(result).toBe(-6);
     sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
   });
 
@@ -127,7 +127,7 @@ describe('diff', () => {
     const result = companiDate.diff(otherDate, 'days', true);
 
     expect(result).toBeLessThan(0);
-    expect(Math.abs(result) - 5.91).toBeLessThan(0.01);
+    expect(Math.abs(result) - 5.91).toBeLessThan(0.01); // 5.91 days = 5 days and 22 hours
     sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
   });
 });

--- a/tests/unit/helpers/dates/companiDates.test.js
+++ b/tests/unit/helpers/dates/companiDates.test.js
@@ -22,10 +22,21 @@ describe('CompaniDate', () => {
     expect(result)
       .toEqual(expect.objectContaining({
         _date: expect.any(luxon.DateTime),
+        format: expect.any(Function),
         isSame: expect.any(Function),
         diff: expect.any(Function),
       }));
     sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), date);
+  });
+});
+
+describe('format', () => {
+  const companiDate = CompaniDatesHelper.CompaniDate('2021-11-24T07:00:00.000Z');
+
+  it('should return formated date in a string', () => {
+    const result = companiDate.format('\'Le\' cccc dd LLLL y');
+
+    expect(result).toBe('Le mercredi 24 novembre 2021');
   });
 });
 

--- a/tests/unit/helpers/dates/companiDuration.test.js
+++ b/tests/unit/helpers/dates/companiDuration.test.js
@@ -92,12 +92,12 @@ describe('add', () => {
     _formatMiscToCompaniDuration.restore();
   });
 
-  it('should add duration', () => {
+  it('should increase companiDuration, and return a reference', () => {
     const addedAmountInMillis = 2 * 60 * 60 * 1000 + 5 * 60 * 1000;
     const result = companiDuration.add(addedAmountInMillis);
 
-    expect(result instanceof Object && result._duration && result._duration instanceof luxon.Duration).toBe(true);
-    expect(result._duration.toMillis()).toBe(durationAmountInMillis + addedAmountInMillis);
+    expect(companiDuration._duration.toMillis()).toBe(durationAmountInMillis + addedAmountInMillis);
+    expect(result).toBe(companiDuration);
     sinon.assert.calledWithExactly(_formatMiscToCompaniDuration.getCall(0), addedAmountInMillis);
   });
 });

--- a/tests/unit/helpers/dates/companiDuration.test.js
+++ b/tests/unit/helpers/dates/companiDuration.test.js
@@ -86,17 +86,30 @@ describe('format', () => {
 });
 
 describe('_formatMiscToCompaniDuration', () => {
+  let fromObject;
   let fromMillis;
   let invalid;
 
   beforeEach(() => {
+    fromObject = sinon.spy(luxon.Duration, 'fromObject');
     fromMillis = sinon.spy(luxon.Duration, 'fromMillis');
     invalid = sinon.spy(luxon.Duration, 'invalid');
   });
 
   afterEach(() => {
+    fromObject.restore();
     fromMillis.restore();
     invalid.restore();
+  });
+
+  it('should return duration being worth 0 if no args', () => {
+    const result = CompaniDurationsHelper._formatMiscToCompaniDuration();
+
+    expect(result instanceof luxon.Duration).toBe(true);
+    expect(new luxon.Duration(result).toMillis()).toBe(0);
+    sinon.assert.calledOnceWithExactly(fromObject, {});
+    sinon.assert.notCalled(fromMillis);
+    sinon.assert.notCalled(invalid);
   });
 
   it('should return duration if arg is number', () => {
@@ -106,6 +119,7 @@ describe('_formatMiscToCompaniDuration', () => {
     expect(result instanceof luxon.Duration).toBe(true);
     expect(new luxon.Duration(result).toMillis()).toBe(payload);
     sinon.assert.calledOnceWithExactly(fromMillis, payload);
+    sinon.assert.calledOnce(fromObject); // fromMillis calls fromObject
     sinon.assert.notCalled(invalid);
   });
 
@@ -114,6 +128,7 @@ describe('_formatMiscToCompaniDuration', () => {
 
     expect(result instanceof luxon.Duration).toBe(true);
     sinon.assert.calledOnceWithExactly(invalid, 'wrong arguments');
+    sinon.assert.notCalled(fromObject);
     sinon.assert.notCalled(fromMillis);
   });
 });

--- a/tests/unit/helpers/dates/companiDuration.test.js
+++ b/tests/unit/helpers/dates/companiDuration.test.js
@@ -96,8 +96,8 @@ describe('add', () => {
     const addedAmountInMillis = 2 * 60 * 60 * 1000 + 5 * 60 * 1000;
     const result = companiDuration.add(addedAmountInMillis);
 
-    expect(companiDuration._duration.toMillis()).toBe(durationAmountInMillis + addedAmountInMillis);
     expect(result).toBe(companiDuration);
+    expect(companiDuration._duration.toMillis()).toBe(durationAmountInMillis + addedAmountInMillis);
     sinon.assert.calledWithExactly(_formatMiscToCompaniDuration.getCall(0), addedAmountInMillis);
   });
 });

--- a/tests/unit/helpers/dates/companiDuration.test.js
+++ b/tests/unit/helpers/dates/companiDuration.test.js
@@ -1,0 +1,59 @@
+const expect = require('expect');
+const luxon = require('luxon');
+const sinon = require('sinon');
+const CompaniDurationsHelper = require('../../../../src/helpers/dates/companiDurations');
+
+describe('CompaniDuration', () => {
+  let _formatMiscToCompanyDuration;
+
+  beforeEach(() => {
+    _formatMiscToCompanyDuration = sinon.spy(CompaniDurationsHelper, '_formatMiscToCompanyDuration');
+  });
+
+  afterEach(() => {
+    _formatMiscToCompanyDuration.restore();
+  });
+
+  it('should return duration', () => {
+    const duration = 1200000000;
+
+    const result = CompaniDurationsHelper.CompaniDuration(duration);
+
+    expect(result)
+      .toEqual(expect.objectContaining({ _duration: expect.any(luxon.Duration) }));
+    sinon.assert.calledWithExactly(_formatMiscToCompanyDuration.getCall(0), duration);
+  });
+});
+
+describe('_formatMiscToCompanyDuration', () => {
+  let fromMillis;
+  let invalid;
+
+  beforeEach(() => {
+    fromMillis = sinon.spy(luxon.Duration, 'fromMillis');
+    invalid = sinon.spy(luxon.Duration, 'invalid');
+  });
+
+  afterEach(() => {
+    fromMillis.restore();
+    invalid.restore();
+  });
+
+  it('should return duration if arg is number', () => {
+    const payload = 3000000000;
+    const result = CompaniDurationsHelper._formatMiscToCompanyDuration(payload);
+
+    expect(result instanceof luxon.Duration).toBe(true);
+    expect(new luxon.Duration(result).toMillis()).toBe(payload);
+    sinon.assert.calledOnceWithExactly(fromMillis, payload);
+    sinon.assert.notCalled(invalid);
+  });
+
+  it('should return invalid if wrong input', () => {
+    const result = CompaniDurationsHelper._formatMiscToCompanyDuration(23232323, 'minutes');
+
+    expect(result instanceof luxon.Duration).toBe(true);
+    sinon.assert.calledOnceWithExactly(invalid, 'wrong arguments');
+    sinon.assert.notCalled(fromMillis);
+  });
+});

--- a/tests/unit/helpers/dates/companiDuration.test.js
+++ b/tests/unit/helpers/dates/companiDuration.test.js
@@ -1,6 +1,6 @@
 const expect = require('expect');
-const luxon = require('luxon');
 const sinon = require('sinon');
+const luxon = require('../../../../src/helpers/dates/luxon');
 const CompaniDurationsHelper = require('../../../../src/helpers/dates/companiDurations');
 
 describe('CompaniDuration', () => {

--- a/tests/unit/helpers/dates/companiDuration.test.js
+++ b/tests/unit/helpers/dates/companiDuration.test.js
@@ -4,14 +4,14 @@ const sinon = require('sinon');
 const CompaniDurationsHelper = require('../../../../src/helpers/dates/companiDurations');
 
 describe('CompaniDuration', () => {
-  let _formatMiscToCompanyDuration;
+  let _formatMiscToCompaniDuration;
 
   beforeEach(() => {
-    _formatMiscToCompanyDuration = sinon.spy(CompaniDurationsHelper, '_formatMiscToCompanyDuration');
+    _formatMiscToCompaniDuration = sinon.spy(CompaniDurationsHelper, '_formatMiscToCompaniDuration');
   });
 
   afterEach(() => {
-    _formatMiscToCompanyDuration.restore();
+    _formatMiscToCompaniDuration.restore();
   });
 
   it('should return duration', () => {
@@ -21,11 +21,11 @@ describe('CompaniDuration', () => {
 
     expect(result)
       .toEqual(expect.objectContaining({ _duration: expect.any(luxon.Duration) }));
-    sinon.assert.calledWithExactly(_formatMiscToCompanyDuration.getCall(0), duration);
+    sinon.assert.calledWithExactly(_formatMiscToCompaniDuration.getCall(0), duration);
   });
 });
 
-describe('_formatMiscToCompanyDuration', () => {
+describe('_formatMiscToCompaniDuration', () => {
   let fromMillis;
   let invalid;
 
@@ -41,7 +41,7 @@ describe('_formatMiscToCompanyDuration', () => {
 
   it('should return duration if arg is number', () => {
     const payload = 3000000000;
-    const result = CompaniDurationsHelper._formatMiscToCompanyDuration(payload);
+    const result = CompaniDurationsHelper._formatMiscToCompaniDuration(payload);
 
     expect(result instanceof luxon.Duration).toBe(true);
     expect(new luxon.Duration(result).toMillis()).toBe(payload);
@@ -50,7 +50,7 @@ describe('_formatMiscToCompanyDuration', () => {
   });
 
   it('should return invalid if wrong input', () => {
-    const result = CompaniDurationsHelper._formatMiscToCompanyDuration(23232323, 'minutes');
+    const result = CompaniDurationsHelper._formatMiscToCompaniDuration(23232323, 'minutes');
 
     expect(result instanceof luxon.Duration).toBe(true);
     sinon.assert.calledOnceWithExactly(invalid, 'wrong arguments');

--- a/tests/unit/helpers/dates/companiDuration.test.js
+++ b/tests/unit/helpers/dates/companiDuration.test.js
@@ -20,8 +20,68 @@ describe('CompaniDuration', () => {
     const result = CompaniDurationsHelper.CompaniDuration(duration);
 
     expect(result)
-      .toEqual(expect.objectContaining({ _duration: expect.any(luxon.Duration) }));
+      .toEqual(expect.objectContaining({ _duration: expect.any(luxon.Duration), format: expect.any(Function) }));
     sinon.assert.calledWithExactly(_formatMiscToCompaniDuration.getCall(0), duration);
+  });
+});
+
+describe('format', () => {
+  let _formatMiscToCompaniDuration;
+
+  beforeEach(() => {
+    _formatMiscToCompaniDuration = sinon.spy(CompaniDurationsHelper, '_formatMiscToCompaniDuration');
+  });
+
+  afterEach(() => {
+    _formatMiscToCompaniDuration.restore();
+  });
+
+  it('should return formatted duration with minutes', () => {
+    const durationAmount = 5 * 60 * 60 * 1000 + 16 * 60 * 1000;
+    const companiDuration = CompaniDurationsHelper.CompaniDuration(durationAmount);
+    const result = companiDuration.format();
+
+    expect(result).toBe('5h16');
+  });
+
+  it('should return formatted duration with minutes, leading zero on minutes', () => {
+    const durationAmount = 5 * 60 * 60 * 1000 + 3 * 60 * 1000;
+    const companiDuration = CompaniDurationsHelper.CompaniDuration(durationAmount);
+    const result = companiDuration.format();
+
+    expect(result).toBe('5h03');
+  });
+
+  it('should return formatted duration without minutes', () => {
+    const durationAmount = 13 * 60 * 60 * 1000;
+    const companiDuration = CompaniDurationsHelper.CompaniDuration(durationAmount);
+    const result = companiDuration.format();
+
+    expect(result).toBe('13h');
+  });
+
+  it('should return formatted duration, days are converted to hours', () => {
+    const durationAmount = 2 * 24 * 60 * 60 * 1000 + 1 * 60 * 60 * 1000;
+    const companiDuration = CompaniDurationsHelper.CompaniDuration(durationAmount);
+    const result = companiDuration.format();
+
+    expect(result).toBe('49h');
+  });
+
+  it('should return formatted duration with minutes, seconds and milliseconds have no effect', () => {
+    const durationAmount = 1 * 60 * 60 * 1000 + 2 * 60 * 1000 + 30 * 1000 + 400;
+    const companiDuration = CompaniDurationsHelper.CompaniDuration(durationAmount);
+    const result = companiDuration.format();
+
+    expect(result).toBe('1h02');
+  });
+
+  it('should return formatted duration without minutes, seconds and milliseconds have no effect', () => {
+    const durationAmount = 1 * 60 * 60 * 1000 + 55 * 1000 + 900;
+    const companiDuration = CompaniDurationsHelper.CompaniDuration(durationAmount);
+    const result = companiDuration.format();
+
+    expect(result).toBe('1h');
   });
 });
 


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations :
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [x] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES
- Si mes changements impactent l'application formation :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- Si mes changements impactent l'application erp :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : vendeur

- Périmetre roles : rof

- Cas d'usage : 
    - fix de `_formatMiscToCompaniDate` avec un date utc au format ISO
    - Passage a luxon pour : 
        - generation du pdf de convoc (INTER, INTRA) : regroupement des créneaux par jour
        - generation de la feuille d'emargement (INTER, INTRA) : 
            - affichage des heures
            - affichage des dates
            - regroupement des créneaux par jour
            - calcule et affichage des durées
        - generation de l'attestation de fin de formation (INTRA, INTER): la durée total de la formation
        - chargement des feuille d'emargement INTRA : refacto du prehandler. Pour tester, en front dans AttendanceSheetModal, transformer le champ "Date" (qui est un select) en input et envoyer une requete avec une date qui ne correspond a aucun créneaux de la formation. On recois un 403.


---
Idées de bonnes pratiques:
  - les libs ( moment ou luxon ) ont des comportements differents. Sur differents sujets, il faut decider des notres, copier l'une, l'autre ou faire autre chose.
       - Typiquement, pour la methode `duration.add(value)`, luxon renvoie une copie de `duration + value` mais ne modifie pas `duration` . Moment, augmente `duration` et renvoie une reference vers `duration`. Qu'est ce qu'on veut nous ? (j'ai copié le comportement de moment)
       - ou pour le lien entre les entitées : chez luxon, on a un lien entre `Duration` et `DateTime`, genre `DateTime.diff()` renvoie un object de `Duration`. Chez Moment ce n'est pas le cas. (j'ai choisi de ne pas lier les deux)

  -  Appeler la factory au lieu de `_formatMisc...` pour initialiser `otherXXX`: je ne pense pas que ca pose pb de faire des appels recursifs. Je n'ai pourtant rien trouvé sur internet
  - commenter les methodes de la factory avec : le type des entrées, le type de la sortie, eventuellement un commentaire sur la fonction.
  - Pour les tests d'inté etr est-ce qu'on mock la factory dans nos test ? est-ce qu'on espionne la factory (avec des `spies`)
  - losqu'on ajoute une methode a la factory c'est pour un cas particulier. On crée donc un test spécifique au cas donné. Pourtant pour construire la methode,  on utilise des methodes de luxon qui sont générales. Si plus tard on veut réutiliser la fonction, il faut bien penser a verifier les tests et eventuellement a en ajouter pour couvrir les nouveaux cas d'utilisation. Je pense que c'est facile de passer a coté.