### PR TITLE
COM-2562 keep only positive break duration

### DIFF
--- a/src/helpers/draftPay.js
+++ b/src/helpers/draftPay.js
@@ -173,7 +173,7 @@ exports.getPaidTransportInfo = async (event, prevEvent, dm) => {
     );
     const breakDuration = moment(event.startDate).diff(moment(prevEvent.endDate), 'minutes');
     const pickTransportDuration = breakDuration > (transport.duration + 15);
-    paidTransportDuration = pickTransportDuration ? transport.duration : breakDuration;
+    paidTransportDuration = pickTransportDuration ? transport.duration : Math.max(breakDuration, 0);
     paidKm = transportMode.shouldPayKm ? transport.distance : 0;
     travelledKm = transport.distance;
   }

--- a/tests/unit/helpers/draftPay.test.js
+++ b/tests/unit/helpers/draftPay.test.js
@@ -642,6 +642,26 @@ describe('getPaidTransportInfo', () => {
     expect(result).toEqual({ paidKm: 10, travelledKm: 10, duration: 70 });
   });
 
+  it('should return 0 if break duration is selected but is negative', async () => {
+    const event = {
+      hasFixedService: false,
+      startDate: '2019-01-18T16:10:00',
+      type: 'intervention',
+      auxiliary: { administrative: { transportInvoice: { transportType: 'private' } } },
+      address: { fullAddress: 'jébobolà' },
+    };
+    const prevEvent = {
+      hasFixedService: false,
+      type: 'intervention',
+      endDate: '2019-01-18T17:00:00',
+      address: { fullAddress: 'tamalou' },
+    };
+    getTransportInfo.resolves({ distance: 10, duration: 60 });
+    const result = await DraftPayHelper.getPaidTransportInfo(event, prevEvent, []);
+
+    expect(result).toEqual({ paidKm: 10, travelledKm: 10, duration: 0 });
+  });
+
   it('should return transport duration if transport duration is shorter than break duration', async () => {
     const event = {
       startDate: '2019-01-18T18:00:00',


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations : -np
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [ ] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES -np
- Si mes changements impactent l'application formation :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- Si mes changements impactent l'application erp :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME -np
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES -np
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV -np
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : client

- Périmetre roles : admin

- Cas d'usage : sur la paie, le temps de pause n'est pris en compte que si il est plus grand que 0. 
Pour tester : 
- avoir une intervention annulée (facturee et payé) 
- avoir un evenement en conflit qui commence avant l'intervention annulée 
- le temps de transport entre ces deux evenements doit etre de 0. (avec script export par jour ou paie sur une auxiliaire avec uniquement ces interventions par ex)
