### PR TITLE
COM-2284: remove password for users seeds

### DIFF
--- a/tests/integration/seed/coursesSeed.js
+++ b/tests/integration/seed/coursesSeed.js
@@ -44,7 +44,7 @@ const traineeFromOtherCompany = {
 const traineeFromAuthCompanyWithFormationExpoToken = {
   _id: new ObjectID(),
   identity: { firstname: 'Trainee', lastname: 'WithExpoToken' },
-  local: { email: 'traineeWithExpoToken@alenvi.io', password: '123456!eR' },
+  local: { email: 'traineeWithExpoToken@alenvi.io' },
   role: { client: auxiliaryRoleId },
   contact: { phone: '0734856751' },
   refreshToken: uuidv4(),
@@ -55,7 +55,7 @@ const traineeFromAuthCompanyWithFormationExpoToken = {
 const traineeWithoutCompany = {
   _id: new ObjectID(),
   identity: { firstname: 'Salut', lastname: 'Toi' },
-  local: { email: 'traineeWithoutCompany@alenvi.io', password: '123456!eR' },
+  local: { email: 'traineeWithoutCompany@alenvi.io' },
   role: { vendor: trainerRoleId },
   refreshToken: uuidv4(),
   origin: WEBAPP,


### PR DESCRIPTION
REFACTO populate DB : COURSES

- [x]  à la place des deleteMany dans les populateDB, on appelle deleteNonAuthenticationSeeds -  **(déjà fait)**

- [x]  on n'effectue pas de modification sur les seeds d'authentification - **(pas de modifications des users)**

- [x] on place les appels de populateDB dans des Promises.all  -  **(déjà fait)**

- [x]  Si on a des utilisateurs dans les seeds et qu’ils ne servent pas à l'authentification, pas besoin de leur assigner de mot de passe  -  **(2 changements)**

- [x]  on remplace les new MyModel(doc).save() par des MyModel.create(docs) -  **(déjà fait)**

- [x]  on remplace les insertMany(docs) par des MyModel.create(docs) -  **(déjà fait)**