### PR TITLE
COM-2516: send notification for new elearning course

### DIFF
--- a/src/controllers/programController.js
+++ b/src/controllers/programController.js
@@ -21,7 +21,7 @@ const list = async (req) => {
 
 const listELearning = async (req) => {
   try {
-    const programs = await ProgramHelper.listELearning(req.auth.credentials);
+    const programs = await ProgramHelper.listELearning(req.auth.credentials, req.query);
 
     return {
       message: programs.length ? translate[language].programsFound : translate[language].programsNotFound,

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -427,6 +427,7 @@ module.exports = {
   },
   // NOTIFICATION
   BLENDED_COURSE_REGISTRATION: 'blended_course_registration',
+  NEW_ELEARNING_COURSE: 'new_elearning_course',
   // TIMESTAMP
   MANUAL_TIME_STAMPING: 'manual_time_stamping',
   QR_CODE_TIME_STAMPING: 'qr_code_time_stamping',

--- a/src/helpers/notifications.js
+++ b/src/helpers/notifications.js
@@ -58,7 +58,7 @@ exports.sendNewElearningCourseNotification = async (courseId) => {
       notifications.push(
         this.sendNotificationToUser({
           title: 'Une nouvelle formation est disponible',
-          body: `Rendez-vous dans l'onglet Explorer pour découvrir la nouvelle formation ${courseName}.`,
+          body: `Découvrez notre nouvelle formation : ${courseName}.`,
           data: { _id: course.subProgram.program._id, type: NEW_ELEARNING_COURSE },
           expoToken,
         })

--- a/src/helpers/notifications.js
+++ b/src/helpers/notifications.js
@@ -1,7 +1,8 @@
 const get = require('lodash/get');
 const axios = require('axios');
 const Course = require('../models/Course');
-const { BLENDED_COURSE_REGISTRATION } = require('./constants');
+const User = require('../models/User');
+const { BLENDED_COURSE_REGISTRATION, NEW_ELEARNING_COURSE } = require('./constants');
 
 const EXPO_NOTIFICATION_API_URL = 'https://exp.host/--/api/v2/push/send/';
 
@@ -12,6 +13,8 @@ exports.sendNotificationToUser = async (payload) => {
   await this.sendNotificationToAPI(expoPayload);
 };
 
+const getCourseName = course => `${get(course, 'subProgram.program.name')}${course.misc ? ` - ${course.misc}` : ''}`;
+
 exports.sendBlendedCourseRegistrationNotification = async (trainee, courseId) => {
   if (!get(trainee, 'formationExpoTokenList.length')) return;
 
@@ -19,7 +22,7 @@ exports.sendBlendedCourseRegistrationNotification = async (trainee, courseId) =>
     .populate({ path: 'subProgram', select: 'program', populate: { path: 'program', select: 'name' } })
     .lean({ virtuals: true });
 
-  const courseName = `${get(course, 'subProgram.program.name')}${course.misc ? ` - ${course.misc}` : ''}`;
+  const courseName = getCourseName(course);
 
   const notifications = [];
   for (const expoToken of trainee.formationExpoTokenList) {
@@ -31,6 +34,32 @@ exports.sendBlendedCourseRegistrationNotification = async (trainee, courseId) =>
         expoToken,
       })
     );
+  }
+
+  await Promise.all(notifications);
+};
+
+exports.sendNewElearningCourseNotification = async (courseId) => {
+  const course = await Course.findOne({ _id: courseId })
+    .populate({ path: 'subProgram', select: 'program', populate: { path: 'program', select: 'name' } })
+    .lean({ virtuals: true });
+  const trainees = await User.find({ formationExpoTokenList: { $exists: true } }).lean();
+
+  const courseName = getCourseName(course);
+
+  const notifications = [];
+  for (const trainee of trainees) {
+    if (!get(trainee, 'formationExpoTokenList.length')) continue;
+    for (const expoToken of trainee.formationExpoTokenList) {
+      notifications.push(
+        this.sendNotificationToUser({
+          title: 'Une nouvelle formation est disponible',
+          body: `Rendez-vous dans l'onglet Explorer pour découvrir la nouvelle formation ${courseName}.`,
+          data: { _id: courseId, type: NEW_ELEARNING_COURSE },
+          expoToken,
+        })
+      );
+    }
   }
 
   await Promise.all(notifications);

--- a/src/helpers/notifications.js
+++ b/src/helpers/notifications.js
@@ -55,7 +55,7 @@ exports.sendNewElearningCourseNotification = async (courseId) => {
         this.sendNotificationToUser({
           title: 'Une nouvelle formation est disponible',
           body: `Rendez-vous dans l'onglet Explorer pour découvrir la nouvelle formation ${courseName}.`,
-          data: { _id: courseId, type: NEW_ELEARNING_COURSE },
+          data: { _id: course.subProgram.program._id, type: NEW_ELEARNING_COURSE },
           expoToken,
         })
       );

--- a/src/helpers/programs.js
+++ b/src/helpers/programs.js
@@ -15,7 +15,10 @@ exports.list = async () => Program.find({})
 
 exports.listELearning = async (credentials, query) => {
   const eLearningCourse = await Course
-    .find({ format: STRICTLY_E_LEARNING, $or: [{ accessRules: [] }, { accessRules: get(credentials, 'company._id') }] })
+    .find(
+      { format: STRICTLY_E_LEARNING, $or: [{ accessRules: [] }, { accessRules: get(credentials, 'company._id') }] },
+      'subProgram'
+    )
     .lean();
   const subPrograms = eLearningCourse.map(course => course.subProgram);
 

--- a/src/helpers/programs.js
+++ b/src/helpers/programs.js
@@ -13,13 +13,13 @@ exports.list = async () => Program.find({})
   .populate({ path: 'subPrograms', select: 'name' })
   .lean();
 
-exports.listELearning = async (credentials) => {
+exports.listELearning = async (credentials, query) => {
   const eLearningCourse = await Course
     .find({ format: STRICTLY_E_LEARNING, $or: [{ accessRules: [] }, { accessRules: get(credentials, 'company._id') }] })
     .lean();
   const subPrograms = eLearningCourse.map(course => course.subProgram);
 
-  return Program.find({ subPrograms: { $in: subPrograms } })
+  return Program.find({ ...query, subPrograms: { $in: subPrograms } })
     .populate({
       path: 'subPrograms',
       select: 'name',

--- a/src/helpers/subPrograms.js
+++ b/src/helpers/subPrograms.js
@@ -26,7 +26,7 @@ exports.updateSubProgram = async (subProgramId, payload) => {
       format: STRICTLY_E_LEARNING,
       accessRules: payload.accessCompany ? [payload.accessCompany] : [],
     });
-    if (!payload.accessCompany) NotificationHelper.sendNewElearningCourseNotification(course._id);
+    if (!payload.accessCompany) await NotificationHelper.sendNewElearningCourseNotification(course._id);
   }
 
   await Step.updateMany({ _id: { $in: subProgram.steps.map(step => step._id) } }, { status: payload.status });

--- a/src/routes/programs.js
+++ b/src/routes/programs.js
@@ -42,6 +42,9 @@ exports.plugin = {
       path: '/e-learning',
       options: {
         auth: { mode: 'required' },
+        validate: {
+          query: Joi.object({ _id: Joi.objectId() }),
+        },
       },
       handler: listELearning,
     });

--- a/tests/integration/programs.test.js
+++ b/tests/integration/programs.test.js
@@ -156,6 +156,18 @@ describe('PROGRAMS ROUTES - GET /programs/e-learning', () => {
       expect(response.statusCode).toBe(200);
       expect(response.result.data.programs.length).toEqual(2);
     });
+
+    it('should get a specific e-learning program', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/programs/e-learning?_id=${programsList[2]._id}`,
+        headers: { 'x-access-token': authToken },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.result.data.programs.length).toEqual(1);
+      expect(response.result.data.programs[0]._id).toEqual(programsList[2]._id);
+    });
   });
 });
 

--- a/tests/unit/helpers/notifications.test.js
+++ b/tests/unit/helpers/notifications.test.js
@@ -169,7 +169,7 @@ describe('sendNewElearningCourseNotification', () => {
     const courseId = new ObjectID();
     const course = {
       _id: courseId,
-      subProgram: { program: { name: 'La communication avec Patrick' } },
+      subProgram: { program: { _id: new ObjectID(), name: 'La communication avec Patrick' } },
       misc: 'skusku',
       slots: [{ startDate: '2020-01-02' }],
     };
@@ -203,7 +203,7 @@ describe('sendNewElearningCourseNotification', () => {
         title: 'Une nouvelle formation est disponible',
         body: 'Rendez-vous dans l\'onglet Explorer pour découvrir la nouvelle formation '
         + 'La communication avec Patrick - skusku.',
-        data: { _id: courseId, type: NEW_ELEARNING_COURSE },
+        data: { _id: course.subProgram.program._id, type: NEW_ELEARNING_COURSE },
         expoToken: 'ExponentPushToken[jeSuisUnTokenExpo]',
       }
     );
@@ -213,7 +213,7 @@ describe('sendNewElearningCourseNotification', () => {
         title: 'Une nouvelle formation est disponible',
         body: 'Rendez-vous dans l\'onglet Explorer pour découvrir la nouvelle formation '
         + 'La communication avec Patrick - skusku.',
-        data: { _id: courseId, type: NEW_ELEARNING_COURSE },
+        data: { _id: course.subProgram.program._id, type: NEW_ELEARNING_COURSE },
         expoToken: 'ExponentPushToken[jeSuisUnAutreTokenExpo]',
       }
     );

--- a/tests/unit/helpers/notifications.test.js
+++ b/tests/unit/helpers/notifications.test.js
@@ -109,7 +109,7 @@ describe('sendBlendedCourseRegistrationNotification', () => {
           query: 'populate',
           args: [{ path: 'subProgram', select: 'program', populate: { path: 'program', select: 'name' } }],
         },
-        { query: 'lean', args: [{ virtuals: true }] },
+        { query: 'lean', args: [] },
       ]
     );
     sinon.assert.calledWithExactly(
@@ -187,13 +187,19 @@ describe('sendNewElearningCourseNotification', () => {
           query: 'populate',
           args: [{ path: 'subProgram', select: 'program', populate: { path: 'program', select: 'name' } }],
         },
-        { query: 'lean', args: [{ virtuals: true }] },
+        { query: 'lean', args: [] },
       ]
     );
     SinonMongoose.calledWithExactly(
       userFind,
       [
-        { query: 'find', args: [{ formationExpoTokenList: { $exists: true } }] },
+        {
+          query: 'find',
+          args: [
+            { formationExpoTokenList: { $exists: true }, $where: 'this.formationExpoTokenList.length > 0' },
+            'formationExpoTokenList',
+          ],
+        },
         { query: 'lean', args: [] },
       ]
     );
@@ -242,13 +248,19 @@ describe('sendNewElearningCourseNotification', () => {
           query: 'populate',
           args: [{ path: 'subProgram', select: 'program', populate: { path: 'program', select: 'name' } }],
         },
-        { query: 'lean', args: [{ virtuals: true }] },
+        { query: 'lean', args: [] },
       ]
     );
     SinonMongoose.calledWithExactly(
       userFind,
       [
-        { query: 'find', args: [{ formationExpoTokenList: { $exists: true } }] },
+        {
+          query: 'find',
+          args: [
+            { formationExpoTokenList: { $exists: true }, $where: 'this.formationExpoTokenList.length > 0' },
+            'formationExpoTokenList',
+          ],
+        },
         { query: 'lean', args: [] },
       ]
     );

--- a/tests/unit/helpers/notifications.test.js
+++ b/tests/unit/helpers/notifications.test.js
@@ -207,8 +207,7 @@ describe('sendNewElearningCourseNotification', () => {
       sendNotificationToUser.getCall(0),
       {
         title: 'Une nouvelle formation est disponible',
-        body: 'Rendez-vous dans l\'onglet Explorer pour découvrir la nouvelle formation '
-        + 'La communication avec Patrick - skusku.',
+        body: 'Découvrez notre nouvelle formation : La communication avec Patrick - skusku.',
         data: { _id: course.subProgram.program._id, type: NEW_ELEARNING_COURSE },
         expoToken: 'ExponentPushToken[jeSuisUnTokenExpo]',
       }
@@ -217,16 +216,14 @@ describe('sendNewElearningCourseNotification', () => {
       sendNotificationToUser.getCall(1),
       {
         title: 'Une nouvelle formation est disponible',
-        body: 'Rendez-vous dans l\'onglet Explorer pour découvrir la nouvelle formation '
-        + 'La communication avec Patrick - skusku.',
+        body: 'Découvrez notre nouvelle formation : La communication avec Patrick - skusku.',
         data: { _id: course.subProgram.program._id, type: NEW_ELEARNING_COURSE },
         expoToken: 'ExponentPushToken[jeSuisUnAutreTokenExpo]',
       }
     );
   });
 
-  it('should do nothing if trainee has no formationExpoTokenList', async () => {
-    const trainees = [{ formationExpoTokenList: [] }];
+  it('should do nothing if no trainee', async () => {
     const courseId = new ObjectID();
     const course = {
       _id: courseId,
@@ -236,7 +233,7 @@ describe('sendNewElearningCourseNotification', () => {
     };
 
     courseFindOne.returns(SinonMongoose.stubChainedQueries([course]));
-    userFind.returns(SinonMongoose.stubChainedQueries([trainees], ['lean']));
+    userFind.returns(SinonMongoose.stubChainedQueries([[]], ['lean']));
 
     await NotificationHelper.sendNewElearningCourseNotification(courseId);
 

--- a/tests/unit/helpers/programs.test.js
+++ b/tests/unit/helpers/programs.test.js
@@ -83,7 +83,10 @@ describe('listELearning', () => {
       [
         {
           query: 'find',
-          args: [{ format: 'strictly_e_learning', $or: [{ accessRules: [] }, { accessRules: companyId }] }],
+          args: [
+            { format: 'strictly_e_learning', $or: [{ accessRules: [] }, { accessRules: companyId }] },
+            'subProgram',
+          ],
         },
         { query: 'lean' },
       ]
@@ -136,7 +139,10 @@ describe('listELearning', () => {
       [
         {
           query: 'find',
-          args: [{ format: 'strictly_e_learning', $or: [{ accessRules: [] }, { accessRules: companyId }] }],
+          args: [
+            { format: 'strictly_e_learning', $or: [{ accessRules: [] }, { accessRules: companyId }] },
+            'subProgram',
+          ],
         },
         { query: 'lean' },
       ]


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations : -np
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [ ] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES
- Si mes changements impactent l'application formation :
  - [x] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [x] Affichage des pages explorer/mes formations/About/CourseProfile
    - [x] Inscription a une formation e-learning
    - [x] Possibilité de faire une activité

- ~~Si mes changements impactent l'application erp :~~
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME
- [x] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [x] Je n'ai pas changé les droits de la route
  - [x] Je n'ai pas changé les droits dans le fichier rights.js
  - [x] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [x] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - ~~Justification des breaking changes s'il y en a:~~
- ~~J'ai supprimé une route :~~
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- ~~J'ai renommé une route :~~
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
-~~ J'ai ajouté un champ possible dans la route :~~
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- ~~J'ai rendu obligatoire un champs de la route :~~
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- ~~J'ai retiré un champ possible dans la route :~~
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- ~~J'ai supprimé un retour/un champs du retour de la route :~~
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES
- ~~J'ai ajouté un modèle spécifique à une structure:~~
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- ~~J'ai changé un modèle utilisé par l'app mobile:~~
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV
- ~~J'ai changé une constante :~~
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- ~~J'ai ajouté une variable d'environnement :~~
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : mobile formation

- Périmetre roles : tous

- Cas d'usage : quand une formation strictement elearning sans règle d'accès est ajouté, je reçois une notif sur l'appli mobile. 

