### PR TITLE
COM-2391 refacto 'getEvantSurcharges' + unit tests

### DIFF
--- a/src/helpers/surcharges.js
+++ b/src/helpers/surcharges.js
@@ -51,10 +51,9 @@ exports.getEventSurcharges = (event, surcharge) => {
   const start = moment(event.startDate);
 
   for (const surchargeCondition of surchargeConditions) {
-    const percentage = surcharge[surchargeCondition.key];
-    if (percentage && percentage > 0 && surchargeCondition.condition(start)) {
-      return [{ percentage, name: surchargeCondition.name }];
-    }
+    const percentage = surcharge[surchargeCondition.key] || 0;
+
+    if (surchargeCondition.condition(start)) return [{ percentage, name: surchargeCondition.name }];
   }
 
   const {

--- a/tests/unit/helpers/surcharges.test.js
+++ b/tests/unit/helpers/surcharges.test.js
@@ -181,7 +181,7 @@ describe('getEventSurcharges', () => {
     getCustomSurchargeStub.restore();
   });
 
-  it('should return no surcharges if the surcharge is empty', () => {
+  it('should return the matching surcharge, even if surcharge values are all 0', () => {
     const event = {
       startDate: '2019-05-01T16:00:00.000',
       endDate: '2019-05-01T23:00:00.000',
@@ -190,7 +190,10 @@ describe('getEventSurcharges', () => {
     getCustomSurchargeStub.returnsArg(4);
     getCustomSurchargeStub.returns();
 
-    expect(SurchargesHelper.getEventSurcharges(event, emptySurcharge)).toEqual([]);
+    expect(SurchargesHelper.getEventSurcharges(event, emptySurcharge)).toEqual([{
+      percentage: 0,
+      name: '1er Mai',
+    }]);
   });
 
   it('should return no surcharges if none match', () => {
@@ -244,15 +247,27 @@ describe('getEventSurcharges', () => {
     });
   });
 
-  it('should return holiday and not sunday surcharge', () => {
-    const event = { startDate: '2022-07-14T07:00:00', endDate: '2022-07-14T09:00:00' };
-    const surcharge = { sunday: 10, publicHoliday: 20 };
+  it('should return the surchage with the highest level', () => {
+    const event = { startDate: '2021-12-25T07:00:00', endDate: '2021-12-25T09:00:00' };
+    const surcharge = { saturday: 10, twentyFifthOfDecember: 30 };
 
     getCustomSurchargeStub.returnsArg(4);
 
     expect(SurchargesHelper.getEventSurcharges(event, surcharge)).toEqual([{
-      percentage: 20,
-      name: 'Jour férié',
+      percentage: 30,
+      name: '25 Décembre',
+    }]);
+  });
+
+  it('should return the surchage with the highest level, even if percentage is 0', () => {
+    const event = { startDate: '2021-12-25T07:00:00', endDate: '2021-12-25T09:00:00' };
+    const surcharge = { saturday: 10, twentyFifthOfDecember: 0 };
+
+    getCustomSurchargeStub.returnsArg(4);
+
+    expect(SurchargesHelper.getEventSurcharges(event, surcharge)).toEqual([{
+      percentage: 0,
+      name: '25 Décembre',
     }]);
   });
 


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations :
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [ ] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES
- Si mes changements impactent l'application formation :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- Si mes changements impactent l'application erp :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : client

- Périmetre roles : client admin

- Cas d'usage : on prend la surcharge de plus haut niveau, meme si les pourcentage de maj en a 0%.

 - pour tester sur la webapp:
     - modifier le plan de majoration d'Alenvi, mettre a 0% la majoration du 25 decembre 2021
     - trouver/créer un evenement daté du 25 decembre 2021
     - facturer cet evenement
     - sur la facture, dans la colonne "majoration" tu dois avoir "25 decembre (0%)" et non pas "jour ferier (25%)"
    
