### PR TITLE
COM-2559: add issameorbefore luxon

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "server.js",
   "scripts": {
-    "test:unit": "NODE_ENV=test mocha --timeout 999999 --colors --exit tests/unit/*",
+    "test:unit": "NODE_ENV=test mocha --timeout 999999 --colors --exit tests/unit/*/*",
     "test:integration": "NODE_ENV=test mocha --timeout 999999 --colors --exit --file tests/integration/helpers/initializeDB tests/integration/*",
     "test:tag": "NODE_ENV=test mocha --timeout 999999 --colors --recursive --exit --grep '#tag' --file tests/integration/helpers/initializeDB tests/*",
     "test": "NODE_ENV=test mocha --timeout 999999 --colors --recursive --exit --file tests/integration/helpers/initializeDB tests/*",

--- a/src/helpers/dates/companiDates.js
+++ b/src/helpers/dates/companiDates.js
@@ -22,6 +22,12 @@ const companiDateFactory = _date => ({
     if (typeFloat) return floatDiff;
     return floatDiff > 0 ? Math.floor(floatDiff) : Math.ceil(floatDiff);
   },
+
+  isSameOrBefore(miscTypeOtherDate) {
+    const otherDate = exports._formatMiscToCompaniDate(miscTypeOtherDate);
+
+    return this._date <= otherDate;
+  },
 });
 
 exports._formatMiscToCompaniDate = (...args) => {
@@ -31,7 +37,8 @@ exports._formatMiscToCompaniDate = (...args) => {
     if (args[0] instanceof Object && args[0]._date && args[0]._date instanceof luxon.DateTime) return args[0]._date;
     if (args[0] instanceof luxon.DateTime) return args[0];
     if (args[0] instanceof Date) return luxon.DateTime.fromJSDate(args[0]);
-    if (typeof args[0] === 'string') return luxon.DateTime.fromISO(args[0]);
+    if (typeof args[0] === 'string' && args[0] !== '') return luxon.DateTime.fromISO(args[0]);
+    if (typeof args[0] === 'undefined') return luxon.DateTime.now();
   }
 
   if (args.length === 2 && typeof args[0] === 'string' && typeof args[1] === 'string') {

--- a/src/helpers/dates/companiDates.js
+++ b/src/helpers/dates/companiDates.js
@@ -5,28 +5,31 @@ exports.CompaniDate = (...args) => companiDateFactory(exports._formatMiscToCompa
 const companiDateFactory = _date => ({
   _date,
 
+  // DISPLAY
   format(fmt) {
     return this._date.toFormat(fmt);
   },
 
+  // QUERY
   isSame(miscTypeOtherDate, unit) {
     const otherDate = exports._formatMiscToCompaniDate(miscTypeOtherDate);
 
     return this._date.hasSame(otherDate, unit);
   },
 
+  isSameOrBefore(miscTypeOtherDate) {
+    const otherDate = exports._formatMiscToCompaniDate(miscTypeOtherDate);
+
+    return this._date <= otherDate;
+  },
+
+  // MANIPULATE
   diff(miscTypeOtherDate, unit = 'milliseconds', typeFloat = false) {
     const otherDate = exports._formatMiscToCompaniDate(miscTypeOtherDate);
     const floatDiff = this._date.diff(otherDate, unit).as(unit);
 
     if (typeFloat) return floatDiff;
     return floatDiff > 0 ? Math.floor(floatDiff) : Math.ceil(floatDiff);
-  },
-
-  isSameOrBefore(miscTypeOtherDate) {
-    const otherDate = exports._formatMiscToCompaniDate(miscTypeOtherDate);
-
-    return this._date <= otherDate;
   },
 });
 

--- a/src/helpers/dates/companiDates.js
+++ b/src/helpers/dates/companiDates.js
@@ -17,10 +17,10 @@ const companiDateFactory = _date => ({
     return this._date.hasSame(otherDate, unit);
   },
 
-  isSameOrBefore(miscTypeOtherDate) {
+  isSameOrBefore(miscTypeOtherDate, unit = 'millisecond') {
     const otherDate = exports._formatMiscToCompaniDate(miscTypeOtherDate);
 
-    return this._date <= otherDate;
+    return (this._date.hasSame(otherDate, unit) || this._date.startOf(unit) < otherDate.startOf(unit));
   },
 
   // MANIPULATE

--- a/src/helpers/dates/companiDates.js
+++ b/src/helpers/dates/companiDates.js
@@ -41,7 +41,7 @@ exports._formatMiscToCompaniDate = (...args) => {
     if (args[0] instanceof luxon.DateTime) return args[0];
     if (args[0] instanceof Date) return luxon.DateTime.fromJSDate(args[0]);
     if (typeof args[0] === 'string' && args[0] !== '') return luxon.DateTime.fromISO(args[0]);
-    if (typeof args[0] === 'undefined') return luxon.DateTime.now();
+    if (typeof args[0] === 'undefined' || (args[0] instanceof Array && !args[0].length)) return luxon.DateTime.now();
   }
 
   if (args.length === 2 && typeof args[0] === 'string' && typeof args[1] === 'string') {

--- a/src/routes/preHandlers/courseSlot.js
+++ b/src/routes/preHandlers/courseSlot.js
@@ -1,6 +1,5 @@
 const Boom = require('@hapi/boom');
 const get = require('lodash/get');
-const moment = require('moment');
 const CourseSlot = require('../../models/CourseSlot');
 const Course = require('../../models/Course');
 const Step = require('../../models/Step');
@@ -8,6 +7,7 @@ const Attendance = require('../../models/Attendance');
 const translate = require('../../helpers/translate');
 const { checkAuthorization } = require('./courses');
 const { E_LEARNING, ON_SITE, REMOTE } = require('../../helpers/constants');
+const { CompaniDate } = require('../../helpers/dates/companiDates');
 
 const { language } = translate;
 
@@ -37,8 +37,8 @@ const formatAndCheckAuthorization = async (courseId, credentials) => {
 const checkPayload = async (courseId, payload) => {
   const { startDate, endDate, step: stepId } = payload;
   const hasBothOrNeitherDates = (startDate && endDate) || (!startDate && !endDate);
-  const sameDay = moment(startDate).isSame(endDate, 'day');
-  const startDateBeforeEndDate = moment(startDate).isSameOrBefore(endDate);
+  const sameDay = CompaniDate(startDate).isSame(endDate, 'day');
+  const startDateBeforeEndDate = CompaniDate(startDate).isSameOrBefore(endDate);
   if (!(hasBothOrNeitherDates && sameDay && startDateBeforeEndDate)) throw Boom.badRequest();
 
   if (stepId) {

--- a/tests/unit/helpers/dates/companiDates.test.js
+++ b/tests/unit/helpers/dates/companiDates.test.js
@@ -30,112 +30,204 @@ describe('CompaniDate', () => {
   });
 });
 
-describe('format', () => {
-  const companiDate = CompaniDatesHelper.CompaniDate('2021-11-24T07:12:08.000Z');
+describe('DISPLAY', () => {
+  describe('format', () => {
+    let _formatMiscToCompaniDate;
+    const companiDate = CompaniDatesHelper.CompaniDate('2021-11-24T07:12:08.000Z');
 
-  it('should return formated date in a string', () => {
-    const result = companiDate.format('\'Le\' cccc dd LLLL y \'à\' HH\'h\'mm \'et\' s \'secondes\'');
+    beforeEach(() => {
+      _formatMiscToCompaniDate = sinon.spy(CompaniDatesHelper, '_formatMiscToCompaniDate');
+    });
 
-    expect(result).toBe('Le mercredi 24 novembre 2021 à 08h12 et 8 secondes');
+    afterEach(() => {
+      _formatMiscToCompaniDate.restore();
+    });
+
+    it('should return formated date in a string', () => {
+      const result = companiDate.format('\'Le\' cccc dd LLLL y \'à\' HH\'h\'mm \'et\' s \'secondes\'');
+
+      expect(result).toBe('Le mercredi 24 novembre 2021 à 08h12 et 8 secondes');
+    });
+
+    it('should return Invalid DateTime if wrong _date', () => {
+      const result = CompaniDatesHelper.CompaniDate(null)
+        .format('\'Le\' cccc dd LLLL y \'à\' HH\'h\'mm \'et\' s \'secondes\'');
+
+      expect(result).toBe('Invalid DateTime');
+      sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), null);
+    });
   });
 });
 
-describe('isSame', () => {
-  let _formatMiscToCompaniDate;
-  const companiDate = CompaniDatesHelper.CompaniDate('2021-11-24T07:00:00.000Z');
-  const otherDate = new Date('2021-11-24T10:00:00.000Z');
+describe('QUERY', () => {
+  describe('isSame', () => {
+    let _formatMiscToCompaniDate;
+    const companiDate = CompaniDatesHelper.CompaniDate('2021-11-24T07:00:00.000Z');
+    const otherDate = new Date('2021-11-24T10:00:00.000Z');
 
-  beforeEach(() => {
-    _formatMiscToCompaniDate = sinon.spy(CompaniDatesHelper, '_formatMiscToCompaniDate');
+    beforeEach(() => {
+      _formatMiscToCompaniDate = sinon.spy(CompaniDatesHelper, '_formatMiscToCompaniDate');
+    });
+
+    afterEach(() => {
+      _formatMiscToCompaniDate.restore();
+    });
+
+    it('should return true if same day', () => {
+      const result = companiDate.isSame(otherDate, 'day');
+
+      expect(result).toBe(true);
+      sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
+    });
+
+    it('should return false if different minute', () => {
+      const result = companiDate.isSame(otherDate, 'minute');
+
+      expect(result).toBe(false);
+      sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
+    });
+
+    it('should return false if wrong _date', () => {
+      const result = CompaniDatesHelper.CompaniDate(null).isSame(otherDate, 'day');
+
+      expect(result).toBe(false);
+      sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), null);
+      sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(1), otherDate);
+    });
+
+    it('should return false if wrong argument', () => {
+      const result = companiDate.isSame(null, 'day');
+
+      expect(result).toBe(false);
+      sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), null);
+    });
   });
 
-  afterEach(() => {
-    _formatMiscToCompaniDate.restore();
-  });
+  describe('isSameOrBefore', () => {
+    let _formatMiscToCompaniDate;
+    const companiDate = CompaniDatesHelper.CompaniDate('2021-11-24T07:00:00.000Z');
+    let otherDate = new Date('2021-11-25T10:00:00.000Z');
 
-  it('should return true if same day', () => {
-    const result = companiDate.isSame(otherDate, 'day');
+    beforeEach(() => {
+      _formatMiscToCompaniDate = sinon.spy(CompaniDatesHelper, '_formatMiscToCompaniDate');
+    });
 
-    expect(result).toBe(true);
-    sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
-  });
+    afterEach(() => {
+      _formatMiscToCompaniDate.restore();
+    });
 
-  it('should return false if different minute', () => {
-    const result = companiDate.isSame(otherDate, 'minute');
+    it('should return true if same moment', () => {
+      otherDate = new Date('2021-11-24T07:00:00.000Z');
 
-    expect(result).toBe(false);
-    sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
-  });
+      const result = companiDate.isSameOrBefore(otherDate);
 
-  it('should return false if wrong argument', () => {
-    const result = companiDate.isSame(null, 'day');
+      expect(result).toBe(true);
+      sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
+    });
 
-    expect(result).toBe(false);
-    sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), null);
+    it('should return true if before', () => {
+      const result = companiDate.isSameOrBefore(otherDate);
+
+      expect(result).toBe(true);
+      sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
+    });
+
+    it('should return false if after', () => {
+      otherDate = new Date('2021-11-23T10:00:00.000Z');
+
+      const result = companiDate.isSameOrBefore(otherDate);
+
+      expect(result).toBe(false);
+      sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
+    });
+
+    it('should return false if wrong _date', () => {
+      const result = CompaniDatesHelper.CompaniDate(null).isSameOrBefore(otherDate);
+
+      expect(result).toBe(false);
+      sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), null);
+      sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(1), otherDate);
+    });
+
+    it('should return false if wrong argument', () => {
+      const result = companiDate.isSameOrBefore(null);
+
+      expect(result).toBe(false);
+      sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), null);
+    });
   });
 });
+describe('MANIPULATE', () => {
+  describe('diff', () => {
+    let _formatMiscToCompaniDate;
+    const companiDate = CompaniDatesHelper.CompaniDate('2021-11-24T10:00:00.000Z');
 
-describe('diff', () => {
-  let _formatMiscToCompaniDate;
-  const companiDate = CompaniDatesHelper.CompaniDate('2021-11-24T10:00:00.000Z');
+    beforeEach(() => {
+      _formatMiscToCompaniDate = sinon.spy(CompaniDatesHelper, '_formatMiscToCompaniDate');
+    });
 
-  beforeEach(() => {
-    _formatMiscToCompaniDate = sinon.spy(CompaniDatesHelper, '_formatMiscToCompaniDate');
-  });
+    afterEach(() => {
+      _formatMiscToCompaniDate.restore();
+    });
 
-  afterEach(() => {
-    _formatMiscToCompaniDate.restore();
-  });
+    it('should return diff in milliseconds, if no unit specified', () => {
+      const otherDate = new Date('2021-11-24T08:29:48.000Z');
+      const result = companiDate.diff(otherDate);
+      const expectedDiffInMillis = 1 * 60 * 60 * 1000 + 30 * 60 * 1000 + 12 * 1000;
 
-  it('should return diff in milliseconds, if no unit specified', () => {
-    const otherDate = new Date('2021-11-24T08:29:48.000Z');
-    const result = companiDate.diff(otherDate);
-    const expectedDiffInMillis = 1 * 60 * 60 * 1000 + 30 * 60 * 1000 + 12 * 1000;
+      expect(result).toBe(expectedDiffInMillis);
+      sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
+    });
 
-    expect(result).toBe(expectedDiffInMillis);
-    sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
-  });
+    it('should return difference in positive days', () => {
+      const otherDate = new Date('2021-11-20T10:00:00.000Z');
+      const result = companiDate.diff(otherDate, 'days');
 
-  it('should return difference in positive days', () => {
-    const otherDate = new Date('2021-11-20T10:00:00.000Z');
-    const result = companiDate.diff(otherDate, 'days');
+      expect(result).toBe(4);
+      sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
+    });
 
-    expect(result).toBe(4);
-    sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
-  });
+    it('should return difference in days. Result should be 0 if difference is less then 24h', () => {
+      const otherDate = new Date('2021-11-23T21:00:00.000Z');
+      const result = companiDate.diff(otherDate, 'days');
 
-  it('should return difference in days. Result should be 0 if difference is less then 24h', () => {
-    const otherDate = new Date('2021-11-23T21:00:00.000Z');
-    const result = companiDate.diff(otherDate, 'days');
+      expect(result).toBe(0);
+      sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
+    });
 
-    expect(result).toBe(0);
-    sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
-  });
+    it('should return difference in positive floated days', () => {
+      const otherDate = new Date('2021-11-22T21:00:00.000Z');
+      const result = companiDate.diff(otherDate, 'days', true);
 
-  it('should return difference in positive floated days', () => {
-    const otherDate = new Date('2021-11-22T21:00:00.000Z');
-    const result = companiDate.diff(otherDate, 'days', true);
+      expect(result).toBeGreaterThan(0);
+      expect(result - 1.54).toBeLessThan(0.01); // 1.54 days = 1 day and 13 hours
+      sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
+    });
 
-    expect(result).toBeGreaterThan(0);
-    expect(result - 1.54).toBeLessThan(0.01); // 1.54 days = 1 day and 13 hours
-    sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
-  });
+    it('should return difference in negative days', () => {
+      const otherDate = new Date('2021-11-30T10:00:00.000Z');
+      const result = companiDate.diff(otherDate, 'days');
 
-  it('should return difference in negative days', () => {
-    const otherDate = new Date('2021-11-30T10:00:00.000Z');
-    const result = companiDate.diff(otherDate, 'days');
+      expect(result).toBe(-6);
+      sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
+    });
 
-    expect(result).toBe(-6);
-    sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
-  });
+    it('should return difference in negative floated days', () => {
+      const otherDate = new Date('2021-11-30T08:00:00.000Z');
+      const result = companiDate.diff(otherDate, 'days', true);
 
-  it('should return difference in negative floated days', () => {
-    const otherDate = new Date('2021-11-30T08:00:00.000Z');
-    const result = companiDate.diff(otherDate, 'days', true);
+      expect(result).toBeLessThan(0);
+      expect(Math.abs(result) - 5.91).toBeLessThan(0.01); // 5.91 days = 5 days and 22 hours
+      sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
+    });
 
-    expect(result).toBeLessThan(0);
-    expect(Math.abs(result) - 5.91).toBeLessThan(0.01); // 5.91 days = 5 days and 22 hours
-    sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
+    it('should return NaN if wrong _date', () => {
+      const otherDate = new Date('2021-11-30T08:00:00.000Z');
+      const result = CompaniDatesHelper.CompaniDate(null).diff(otherDate, 'days', true);
+
+      expect(result).toBeNaN();
+      sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), null);
+    });
   });
 });
 
@@ -311,51 +403,5 @@ describe('_formatMiscToCompaniDate', () => {
     sinon.assert.notCalled(fromJSDate);
     sinon.assert.notCalled(fromISO);
     sinon.assert.notCalled(fromFormat);
-  });
-});
-
-describe('isSameOrBefore', () => {
-  let _formatMiscToCompaniDate;
-  const companiDate = CompaniDatesHelper.CompaniDate('2021-11-24T07:00:00.000Z');
-  let otherDate = new Date('2021-11-25T10:00:00.000Z');
-
-  beforeEach(() => {
-    _formatMiscToCompaniDate = sinon.spy(CompaniDatesHelper, '_formatMiscToCompaniDate');
-  });
-
-  afterEach(() => {
-    _formatMiscToCompaniDate.restore();
-  });
-
-  it('should return true if same moment', () => {
-    otherDate = new Date('2021-11-24T07:00:00.000Z');
-
-    const result = companiDate.isSameOrBefore(otherDate);
-
-    expect(result).toBe(true);
-    sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
-  });
-
-  it('should return true if before', () => {
-    const result = companiDate.isSameOrBefore(otherDate);
-
-    expect(result).toBe(true);
-    sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
-  });
-
-  it('should return false if after', () => {
-    otherDate = new Date('2021-11-23T10:00:00.000Z');
-
-    const result = companiDate.isSameOrBefore(otherDate);
-
-    expect(result).toBe(false);
-    sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
-  });
-
-  it('should return false if wrong argument', () => {
-    const result = companiDate.isSameOrBefore(null);
-
-    expect(result).toBe(false);
-    sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), null);
   });
 });

--- a/tests/unit/helpers/dates/companiDates.test.js
+++ b/tests/unit/helpers/dates/companiDates.test.js
@@ -66,6 +66,13 @@ describe('isSame', () => {
     expect(result).toBe(false);
     sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
   });
+
+  it('should return false if wrong argument', () => {
+    const result = companiDate.isSame('', 'day');
+
+    expect(result).toBe(false);
+    sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), '');
+  });
 });
 
 describe('diff', () => {
@@ -220,6 +227,18 @@ describe('_formatMiscToCompaniDate', () => {
     sinon.assert.notCalled(invalid);
   });
 
+  it('should return dateTime.now if arg is undefined', () => {
+    const result = CompaniDatesHelper._formatMiscToCompaniDate(undefined);
+
+    expect(result instanceof luxon.DateTime).toBe(true);
+    expect(new luxon.DateTime(result).toJSDate() - new Date()).toBeLessThan(100);
+    sinon.assert.calledOnceWithExactly(now);
+    sinon.assert.notCalled(fromJSDate);
+    sinon.assert.notCalled(fromISO);
+    sinon.assert.notCalled(fromFormat);
+    sinon.assert.notCalled(invalid);
+  });
+
   it('should return dateTime if 2 args, first argument doesn\'t finish with Z', () => {
     const result = CompaniDatesHelper._formatMiscToCompaniDate(
       '2021-11-24T07:00:00.000+03:00',
@@ -270,5 +289,62 @@ describe('_formatMiscToCompaniDate', () => {
     sinon.assert.notCalled(fromJSDate);
     sinon.assert.notCalled(fromISO);
     sinon.assert.notCalled(fromFormat);
+  });
+
+  it('should return invalid if wrong type of argument', () => {
+    const result = CompaniDatesHelper._formatMiscToCompaniDate(null);
+
+    expect(result instanceof luxon.DateTime).toBe(true);
+    sinon.assert.calledOnceWithExactly(invalid, 'wrong arguments');
+    sinon.assert.notCalled(now);
+    sinon.assert.notCalled(fromJSDate);
+    sinon.assert.notCalled(fromISO);
+    sinon.assert.notCalled(fromFormat);
+  });
+});
+
+describe('isSameOrBefore', () => {
+  let _formatMiscToCompaniDate;
+  const companiDate = CompaniDatesHelper.CompaniDate('2021-11-24T07:00:00.000Z');
+  let otherDate = new Date('2021-11-25T10:00:00.000Z');
+
+  beforeEach(() => {
+    _formatMiscToCompaniDate = sinon.spy(CompaniDatesHelper, '_formatMiscToCompaniDate');
+  });
+
+  afterEach(() => {
+    _formatMiscToCompaniDate.restore();
+  });
+
+  it('should return true if same moment', () => {
+    otherDate = new Date('2021-11-24T07:00:00.000Z');
+
+    const result = companiDate.isSameOrBefore(otherDate);
+
+    expect(result).toBe(true);
+    sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
+  });
+
+  it('should return true if before', () => {
+    const result = companiDate.isSameOrBefore(otherDate);
+
+    expect(result).toBe(true);
+    sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
+  });
+
+  it('should return false if after', () => {
+    otherDate = new Date('2021-11-23T10:00:00.000Z');
+
+    const result = companiDate.isSameOrBefore(otherDate);
+
+    expect(result).toBe(false);
+    sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
+  });
+
+  it('should return false if wrong argument', () => {
+    const result = companiDate.isSameOrBefore(null);
+
+    expect(result).toBe(false);
+    sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), null);
   });
 });

--- a/tests/unit/helpers/dates/companiDates.test.js
+++ b/tests/unit/helpers/dates/companiDates.test.js
@@ -24,6 +24,7 @@ describe('CompaniDate', () => {
         _date: expect.any(luxon.DateTime),
         format: expect.any(Function),
         isSame: expect.any(Function),
+        isSameOrBefore: expect.any(Function),
         diff: expect.any(Function),
       }));
     sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), date);
@@ -49,7 +50,7 @@ describe('DISPLAY', () => {
       expect(result).toBe('Le mercredi 24 novembre 2021 à 08h12 et 8 secondes');
     });
 
-    it('should return Invalid DateTime if wrong _date', () => {
+    it('should return Invalid DateTime if invalid _date', () => {
       const result = CompaniDatesHelper.CompaniDate(null)
         .format('\'Le\' cccc dd LLLL y \'à\' HH\'h\'mm \'et\' s \'secondes\'');
 
@@ -87,7 +88,7 @@ describe('QUERY', () => {
       sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
     });
 
-    it('should return false if wrong _date', () => {
+    it('should return false if invalid _date', () => {
       const result = CompaniDatesHelper.CompaniDate(null).isSame(otherDate, 'day');
 
       expect(result).toBe(false);
@@ -95,7 +96,7 @@ describe('QUERY', () => {
       sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(1), otherDate);
     });
 
-    it('should return false if wrong argument', () => {
+    it('should return false if invalid argument', () => {
       const result = companiDate.isSame(null, 'day');
 
       expect(result).toBe(false);
@@ -141,7 +142,7 @@ describe('QUERY', () => {
       sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
     });
 
-    it('should return false if wrong _date', () => {
+    it('should return false if invalid _date', () => {
       const result = CompaniDatesHelper.CompaniDate(null).isSameOrBefore(otherDate);
 
       expect(result).toBe(false);
@@ -149,7 +150,7 @@ describe('QUERY', () => {
       sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(1), otherDate);
     });
 
-    it('should return false if wrong argument', () => {
+    it('should return false if invalid argument', () => {
       const result = companiDate.isSameOrBefore(null);
 
       expect(result).toBe(false);
@@ -221,7 +222,7 @@ describe('MANIPULATE', () => {
       sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
     });
 
-    it('should return NaN if wrong _date', () => {
+    it('should return NaN if invalid _date', () => {
       const otherDate = new Date('2021-11-30T08:00:00.000Z');
       const result = CompaniDatesHelper.CompaniDate(null).diff(otherDate, 'days', true);
 
@@ -319,7 +320,7 @@ describe('_formatMiscToCompaniDate', () => {
     sinon.assert.notCalled(invalid);
   });
 
-  it('should return dateTime if arg is empty string', () => {
+  it('should return invalid if arg is empty string', () => {
     const result = CompaniDatesHelper._formatMiscToCompaniDate('');
 
     expect(result instanceof luxon.DateTime).toBe(true);
@@ -332,6 +333,18 @@ describe('_formatMiscToCompaniDate', () => {
 
   it('should return dateTime.now if arg is undefined', () => {
     const result = CompaniDatesHelper._formatMiscToCompaniDate(undefined);
+
+    expect(result instanceof luxon.DateTime).toBe(true);
+    expect(new luxon.DateTime(result).toJSDate() - new Date()).toBeLessThan(100);
+    sinon.assert.calledOnceWithExactly(now);
+    sinon.assert.notCalled(fromJSDate);
+    sinon.assert.notCalled(fromISO);
+    sinon.assert.notCalled(fromFormat);
+    sinon.assert.notCalled(invalid);
+  });
+
+  it('should return dateTime.now if arg is []', () => {
+    const result = CompaniDatesHelper._formatMiscToCompaniDate([]);
 
     expect(result instanceof luxon.DateTime).toBe(true);
     expect(new luxon.DateTime(result).toJSDate() - new Date()).toBeLessThan(100);
@@ -394,7 +407,7 @@ describe('_formatMiscToCompaniDate', () => {
     sinon.assert.notCalled(fromFormat);
   });
 
-  it('should return invalid if wrong type of argument', () => {
+  it('should return invalid if invalid type of argument', () => {
     const result = CompaniDatesHelper._formatMiscToCompaniDate(null);
 
     expect(result instanceof luxon.DateTime).toBe(true);

--- a/tests/unit/helpers/dates/companiDates.test.js
+++ b/tests/unit/helpers/dates/companiDates.test.js
@@ -133,10 +133,28 @@ describe('QUERY', () => {
       sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
     });
 
+    it('should return true if after but same as specified unit', () => {
+      otherDate = new Date('2021-11-24T06:00:00.000Z');
+
+      const result = companiDate.isSameOrBefore(otherDate, 'day');
+
+      expect(result).toBe(true);
+      sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
+    });
+
     it('should return false if after', () => {
       otherDate = new Date('2021-11-23T10:00:00.000Z');
 
       const result = companiDate.isSameOrBefore(otherDate);
+
+      expect(result).toBe(false);
+      sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
+    });
+
+    it('should return false if after specified unit', () => {
+      otherDate = new Date('2021-11-24T06:00:00.000Z');
+
+      const result = companiDate.isSameOrBefore(otherDate, 'minute');
 
       expect(result).toBe(false);
       sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
@@ -158,6 +176,7 @@ describe('QUERY', () => {
     });
   });
 });
+
 describe('MANIPULATE', () => {
   describe('diff', () => {
     let _formatMiscToCompaniDate;

--- a/tests/unit/helpers/dates/companiDates.test.js
+++ b/tests/unit/helpers/dates/companiDates.test.js
@@ -68,10 +68,10 @@ describe('isSame', () => {
   });
 
   it('should return false if wrong argument', () => {
-    const result = companiDate.isSame('', 'day');
+    const result = companiDate.isSame(null, 'day');
 
     expect(result).toBe(false);
-    sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), '');
+    sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), null);
   });
 });
 
@@ -225,6 +225,17 @@ describe('_formatMiscToCompaniDate', () => {
     sinon.assert.notCalled(fromJSDate);
     sinon.assert.notCalled(fromFormat);
     sinon.assert.notCalled(invalid);
+  });
+
+  it('should return dateTime if arg is empty string', () => {
+    const result = CompaniDatesHelper._formatMiscToCompaniDate('');
+
+    expect(result instanceof luxon.DateTime).toBe(true);
+    sinon.assert.calledOnceWithExactly(invalid, 'wrong arguments');
+    sinon.assert.notCalled(now);
+    sinon.assert.notCalled(fromJSDate);
+    sinon.assert.notCalled(fromISO);
+    sinon.assert.notCalled(fromFormat);
   });
 
   it('should return dateTime.now if arg is undefined', () => {


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations :
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [x] J'ai bien fait les tests
  - ~~C'est une ancienne route utilisée par une des apps mobiles~~
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES
- ~~Si mes changements impactent l'application formation :~~
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- ~~Si mes changements impactent l'application erp :~~
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME -np
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES
- ~~J'ai ajouté un modèle spécifique à une structure:~~
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- ~~J'ai changé un modèle utilisé par l'app mobile:~~
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV
- ~~J'ai changé une constante :~~
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- ~~J'ai ajouté une variable d'environnement :~~
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : vendeur/client

- Périmetre roles : coach/admin/rof/formateur

- Cas d'usage : remplacement de isSameOrBefore de moment par luxon : 
- Création de la fonction isSameOrBefore de luxon 
- modification de _formatMiscToCompaniDate (ajout de conditions)
 - dans moment, pour isSame et isSameOrBefore si les arguments sont undefined (c'est le cas dans les créneaux à planifier par exemple), moment considère que cela équivaut à la date à l'instant T. J'ai donc rajouter une condition si l'argument est undefined dans _formatMiscToCompaniDate pour que cela renvoie la date du moment. J'ai également modifier la condition sur les strings pour que cela renvoie un format invalid si la string est vide. En effet, dans moment, une string vide ou un null est considéré (à l'inverse de undefined) comme un argument non valide). Est-ce-que cela vous convient ?
- ajout de tests pour _formatMiscToCompaniDate et isSame
  - dans la continuité du point précédent j'ai rajouté un test pour _formatMiscToCompaniDate dans le cas où l'argument est undefined et j'ai fait de même pour la fonction isSame et isSameOrBefore en me basant sur le comportement de moment => dans moment cela renvoie false
  - Si vous validez ces changements, il faudra les mettre en place sur mobile 
  
  cas considérés comme Date.now par moment : 
<img width="582" alt="Capture d’écran 2021-12-14 à 12 38 25" src="https://user-images.githubusercontent.com/70574422/145991761-43596fb1-a685-4c30-9d4d-d586ae14f759.png">

  