### PR TITLE
Com 2561

### DIFF
--- a/src/helpers/courses.js
+++ b/src/helpers/courses.js
@@ -4,7 +4,6 @@ const omit = require('lodash/omit');
 const groupBy = require('lodash/groupBy');
 const fs = require('fs');
 const os = require('os');
-const moment = require('moment');
 const Boom = require('@hapi/boom');
 const { CompaniDate } = require('./dates/companiDates');
 const { CompaniDuration } = require('./dates/companiDurations');
@@ -494,8 +493,8 @@ exports.formatCourseForDocx = course => ({
   duration: exports.getCourseDuration(course.slots),
   learningGoals: get(course, 'subProgram.program.learningGoals') || '',
   programName: get(course, 'subProgram.program.name').toUpperCase() || '',
-  startDate: moment(course.slots[0].startDate).format('DD/MM/YYYY'),
-  endDate: moment(course.slots[course.slots.length - 1].endDate).format('DD/MM/YYYY'),
+  startDate: CompaniDate(course.slots[0].startDate).format('dd/LL/yyyy'),
+  endDate: CompaniDate(course.slots[course.slots.length - 1].endDate).format('dd/LL/yyyy'),
 });
 
 exports.generateCompletionCertificates = async (courseId) => {
@@ -516,7 +515,7 @@ exports.generateCompletionCertificates = async (courseId) => {
     const traineeIdentity = UtilsHelper.formatIdentity(trainee.identity, 'FL');
     const filePath = await DocxHelper.createDocx(
       certificateTemplatePath,
-      { ...courseData, traineeIdentity, date: moment().format('DD/MM/YYYY') }
+      { ...courseData, traineeIdentity, date: CompaniDate().format('dd/LL/yyyy') }
     );
 
     return { name: `Attestation - ${traineeIdentity}.docx`, file: fs.createReadStream(filePath) };

--- a/src/helpers/dates/companiDates.js
+++ b/src/helpers/dates/companiDates.js
@@ -2,36 +2,43 @@ const luxon = require('./luxon');
 
 exports.CompaniDate = (...args) => companiDateFactory(exports._formatMiscToCompaniDate(...args));
 
-const companiDateFactory = _date => ({
-  _date,
+const companiDateFactory = (inputDate) => {
+  const _date = inputDate;
 
-  // DISPLAY
-  format(fmt) {
-    return this._date.toFormat(fmt);
-  },
+  return ({
+    // GETTER
+    get _date() {
+      return _date;
+    },
 
-  // QUERY
-  isSame(miscTypeOtherDate, unit) {
-    const otherDate = exports._formatMiscToCompaniDate(miscTypeOtherDate);
+    // DISPLAY
+    format(fmt) {
+      return _date.toFormat(fmt);
+    },
 
-    return this._date.hasSame(otherDate, unit);
-  },
+    // QUERY
+    isSame(miscTypeOtherDate, unit) {
+      const otherDate = exports._formatMiscToCompaniDate(miscTypeOtherDate);
 
-  isSameOrBefore(miscTypeOtherDate, unit = 'millisecond') {
-    const otherDate = exports._formatMiscToCompaniDate(miscTypeOtherDate);
+      return _date.hasSame(otherDate, unit);
+    },
 
-    return (this._date.hasSame(otherDate, unit) || this._date.startOf(unit) < otherDate.startOf(unit));
-  },
+    isSameOrBefore(miscTypeOtherDate, unit = 'millisecond') {
+      const otherDate = exports._formatMiscToCompaniDate(miscTypeOtherDate);
 
-  // MANIPULATE
-  diff(miscTypeOtherDate, unit = 'milliseconds', typeFloat = false) {
-    const otherDate = exports._formatMiscToCompaniDate(miscTypeOtherDate);
-    const floatDiff = this._date.diff(otherDate, unit).as(unit);
+      return (_date.hasSame(otherDate, unit) || _date.startOf(unit) < otherDate.startOf(unit));
+    },
 
-    if (typeFloat) return floatDiff;
-    return floatDiff > 0 ? Math.floor(floatDiff) : Math.ceil(floatDiff);
-  },
-});
+    // MANIPULATE
+    diff(miscTypeOtherDate, unit = 'milliseconds', typeFloat = false) {
+      const otherDate = exports._formatMiscToCompaniDate(miscTypeOtherDate);
+      const floatDiff = _date.diff(otherDate, unit).as(unit);
+
+      if (typeFloat) return floatDiff;
+      return floatDiff > 0 ? Math.floor(floatDiff) : Math.ceil(floatDiff);
+    },
+  });
+};
 
 exports._formatMiscToCompaniDate = (...args) => {
   if (!args.length) return luxon.DateTime.now();

--- a/tests/unit/helpers/courses.test.js
+++ b/tests/unit/helpers/courses.test.js
@@ -4,8 +4,8 @@ const { ObjectID } = require('mongodb');
 const fs = require('fs');
 const os = require('os');
 const { PassThrough } = require('stream');
-const { fn: momentProto } = require('moment');
 const Boom = require('@hapi/boom');
+const luxon = require('../../../src/helpers/dates/luxon');
 const Course = require('../../../src/models/Course');
 const User = require('../../../src/models/User');
 const CourseSmsHistory = require('../../../src/models/CourseSmsHistory');
@@ -1802,7 +1802,7 @@ describe('generateCompletionCertificate', () => {
   let formatIdentity;
   let createDocx;
   let generateZip;
-  let momentFormat;
+  let luxonNow;
   let createReadStream;
   let downloadFileById;
   let tmpDir;
@@ -1812,7 +1812,7 @@ describe('generateCompletionCertificate', () => {
     formatIdentity = sinon.stub(UtilsHelper, 'formatIdentity');
     createDocx = sinon.stub(DocxHelper, 'createDocx');
     generateZip = sinon.stub(ZipHelper, 'generateZip');
-    momentFormat = sinon.stub(momentProto, 'format').returns('20/01/2020');
+    luxonNow = sinon.stub(luxon.DateTime, 'now');
     createReadStream = sinon.stub(fs, 'createReadStream');
     downloadFileById = sinon.stub(Drive, 'downloadFileById');
     tmpDir = sinon.stub(os, 'tmpdir').returns('/path');
@@ -1823,13 +1823,14 @@ describe('generateCompletionCertificate', () => {
     formatIdentity.restore();
     createDocx.restore();
     generateZip.restore();
-    momentFormat.restore();
+    luxonNow.restore();
     createReadStream.restore();
     downloadFileById.restore();
     tmpDir.restore();
   });
 
   it('should download completion certificates', async () => {
+    const currentTimeISO = '2020-01-20T07:00:00.000Z';
     const courseId = new ObjectID();
     const readable1 = new PassThrough();
     const readable2 = new PassThrough();
@@ -1851,7 +1852,7 @@ describe('generateCompletionCertificate', () => {
     createDocx.onCall(0).returns('1.docx');
     createDocx.onCall(1).returns('2.docx');
     createDocx.onCall(2).returns('3.docx');
-    momentFormat.returns('20/01/2020');
+    luxonNow.returns(luxon.DateTime.fromISO(currentTimeISO));
     formatIdentity.onCall(0).returns('trainee 1');
     formatIdentity.onCall(1).returns('trainee 2');
     formatIdentity.onCall(2).returns('trainee 3');


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations :
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [ ] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES
- Si mes changements impactent l'application formation :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- Si mes changements impactent l'application erp :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : vendeur

- Périmetre roles : rof

- Cas d'usage : 
   -  refacto, on remplace moment par luxon dans la genaration d'attestation de fin de formation
   -  _date est maintenant accessible uniquement par un getter. On ne peut pas modifier cette valeur directement. (concept d'encapsulation)
