### PR TITLE
COM-2285: refacto populateDB

### DIFF
--- a/tests/integration/seed/eventsSeed.js
+++ b/tests/integration/seed/eventsSeed.js
@@ -149,7 +149,7 @@ const sectorHistories = [
 const auxiliaryFromOtherCompany = {
   _id: new ObjectID(),
   identity: { firstname: 'Jean', lastname: 'Martin' },
-  local: { email: 'j@m.com', password: '123456!eR' },
+  local: { email: 'j@m.com' },
   administrative: { driveFolder: { driveId: '1234567890' } },
   refreshToken: uuidv4(),
   role: { client: clientAdminRoleId },
@@ -1054,22 +1054,24 @@ const creditNoteFromOtherCompany = {
 const populateDB = async () => {
   await deleteNonAuthenticationSeeds();
 
-  await Event.insertMany([...eventsList, eventFromOtherCompany]);
-  await Repetition.insertMany(repetitions);
-  await Sector.insertMany(sectors);
-  await SectorHistory.insertMany([...sectorHistories, sectorHistoryFromOtherCompany]);
-  await DistanceMatrix.insertMany(distanceMatrixList);
-  await User.create([...auxiliaries, helpersCustomer, auxiliaryFromOtherCompany]);
-  await Contract.insertMany(contracts);
-  await Customer.insertMany([...customerAuxiliaries, customerFromOtherCompany]);
-  await ThirdPartyPayer.insertMany([thirdPartyPayer, thirdPartyPayerFromOtherCompany]);
-  await Service.insertMany([...services, serviceFromOtherCompany]);
-  await InternalHour.insertMany([internalHour, internalHourFromOtherCompany]);
-  await Helper.insertMany(helpersList);
-  await EventHistory.insertMany(eventHistoriesList);
-  await UserCompany.insertMany(userCompanies);
-  await CreditNote.insertMany([creditNote, creditNoteFromOtherCompany]);
-  await CustomerAbsence.insertMany(customerAbsences);
+  await Promise.all([
+    Event.create([...eventsList, eventFromOtherCompany]),
+    Repetition.create(repetitions),
+    Sector.create(sectors),
+    SectorHistory.create([...sectorHistories, sectorHistoryFromOtherCompany]),
+    DistanceMatrix.create(distanceMatrixList),
+    User.create([...auxiliaries, helpersCustomer, auxiliaryFromOtherCompany]),
+    Contract.create(contracts),
+    Customer.create([...customerAuxiliaries, customerFromOtherCompany]),
+    ThirdPartyPayer.create([thirdPartyPayer, thirdPartyPayerFromOtherCompany]),
+    Service.create([...services, serviceFromOtherCompany]),
+    InternalHour.create([internalHour, internalHourFromOtherCompany]),
+    Helper.create(helpersList),
+    EventHistory.create(eventHistoriesList),
+    UserCompany.create(userCompanies),
+    CreditNote.create([creditNote, creditNoteFromOtherCompany]),
+    CustomerAbsence.create(customerAbsences),
+  ]);
 };
 
 const getUserToken = async (userCredentials) => {

--- a/tests/integration/seed/exportsSeed.js
+++ b/tests/integration/seed/exportsSeed.js
@@ -126,7 +126,7 @@ const auxiliaryList = [{
     phone: '0123456789',
   },
   role: { client: auxiliaryRoleId },
-  local: { email: 'export_auxiliary_1@alenvi.io', password: '123456!eR' },
+  local: { email: 'export_auxiliary_1@alenvi.io' },
   refreshToken: uuidv4(),
   contracts: [contract1Id, contract2Id],
   origin: WEBAPP,
@@ -155,7 +155,7 @@ const auxiliaryList = [{
     phone: '0123456789',
   },
   role: { client: auxiliaryRoleId },
-  local: { email: 'export_auxiliary_2@alenvi.io', password: '123456!eR' },
+  local: { email: 'export_auxiliary_2@alenvi.io' },
   refreshToken: uuidv4(),
   contracts: [contract3Id],
   origin: WEBAPP,
@@ -825,7 +825,7 @@ const user = {
   _id: new ObjectID(),
   contact: { phone: '0123456789' },
   identity: { firstname: 'test', lastname: 'Toto' },
-  local: { email: 'toto@alenvi.io', password: '123456!eR' },
+  local: { email: 'toto@alenvi.io' },
   refreshToken: uuidv4(),
   role: { client: helperRoleId },
   origin: WEBAPP,
@@ -844,26 +844,28 @@ const userCompanies = [
 const populateDB = async () => {
   await deleteNonAuthenticationSeeds();
 
-  await Bill.insertMany(billsList);
-  await Contract.insertMany(contractList);
-  await CreditNote.insertMany(creditNotesList);
-  await Customer.insertMany(customersList);
-  await Establishment.create(establishment);
-  await Event.insertMany(eventList);
-  await EventHistory.insertMany(eventHistoriesList);
-  await FinalPay.insertMany(finalPayList);
-  await Helper.insertMany(helpersList);
-  await InternalHour.create(internalHour);
-  await Payment.insertMany(paymentsList);
-  await Pay.insertMany(payList);
-  await ReferentHistory.insertMany(referentList);
-  await Sector.create(sector);
-  await SectorHistory.insertMany(sectorHistories);
-  await Service.insertMany(serviceList);
-  await ThirdPartyPayer.create(thirdPartyPayer);
-  await User.create(user);
-  await User.insertMany(auxiliaryList);
-  await UserCompany.insertMany(userCompanies);
+  await Promise.all([
+    Bill.create(billsList),
+    Contract.create(contractList),
+    CreditNote.create(creditNotesList),
+    Customer.create(customersList),
+    Establishment.create(establishment),
+    Event.create(eventList),
+    EventHistory.create(eventHistoriesList),
+    FinalPay.create(finalPayList),
+    Helper.create(helpersList),
+    InternalHour.create(internalHour),
+    Payment.create(paymentsList),
+    Pay.create(payList),
+    ReferentHistory.create(referentList),
+    Sector.create(sector),
+    SectorHistory.create(sectorHistories),
+    Service.create(serviceList),
+    ThirdPartyPayer.create(thirdPartyPayer),
+    User.create(user),
+    User.create(auxiliaryList),
+    UserCompany.create(userCompanies),
+  ]);
 };
 
 module.exports = {

--- a/tests/integration/seed/finalPaySeed.js
+++ b/tests/integration/seed/finalPaySeed.js
@@ -24,7 +24,7 @@ const sectorId = new ObjectID();
 
 const user = {
   _id: new ObjectID(),
-  local: { email: 'test4@alenvi.io', password: '123456!eR' },
+  local: { email: 'test4@alenvi.io' },
   identity: { lastname: 'Toto' },
   refreshToken: uuidv4(),
   role: { client: coachRoleId },
@@ -35,7 +35,7 @@ const user = {
 const auxiliary = {
   _id: auxiliaryId,
   identity: { firstname: 'Test7', lastname: 'Test7' },
-  local: { email: 'test7@alenvi.io', password: '123456!eR' },
+  local: { email: 'test7@alenvi.io' },
   inactivityDate: '2019-06-01T00:00:00',
   refreshToken: uuidv4(),
   role: { client: auxiliaryRoleId },
@@ -47,7 +47,7 @@ const auxiliary = {
 const auxiliaryFromOtherCompany = {
   _id: new ObjectID(),
   identity: { firstname: 'Cricri', lastname: 'test' },
-  local: { email: 'othercompany@alenvi.io', password: '123456!eR' },
+  local: { email: 'othercompany@alenvi.io' },
   refreshToken: uuidv4(),
   role: { client: auxiliaryRoleId },
   contracts: contractId,
@@ -378,7 +378,7 @@ const populateDB = async () => {
     Service.create(serviceList),
     Surcharge.create(surcharge),
     User.create([user, auxiliary, auxiliaryFromOtherCompany]),
-    UserCompany.insertMany(userCompanyList),
+    UserCompany.create(userCompanyList),
   ]);
 };
 

--- a/tests/integration/seed/helpersSeed.js
+++ b/tests/integration/seed/helpersSeed.js
@@ -44,7 +44,7 @@ const customerFromOtherCompany = {
 const helperFromOtherCompany = {
   _id: new ObjectID(),
   identity: { firstname: 'Guigui', lastname: 'toto' },
-  local: { email: 'othercompany@alenvi.io', password: '123456!eR' },
+  local: { email: 'othercompany@alenvi.io' },
   role: { client: helperRoleId },
   refreshToken: uuidv4(),
   inactivityDate: null,
@@ -54,7 +54,7 @@ const helperFromOtherCompany = {
 const usersSeedList = [{
   _id: new ObjectID(),
   identity: { firstname: 'Helper1', lastname: 'Carolyn' },
-  local: { email: 'carolyn@alenvi.io', password: '123456!eR' },
+  local: { email: 'carolyn@alenvi.io' },
   refreshToken: uuidv4(),
   role: { client: helperRoleId },
   origin: WEBAPP,
@@ -85,17 +85,17 @@ const helpersList = [
 const populateDB = async () => {
   await deleteNonAuthenticationSeeds();
 
-  await User.create([...usersSeedList, helperFromOtherCompany]);
-  await Customer.create([customerFromOtherCompany, customer]);
-  await Helper.create(helpersList);
-  await UserCompany.insertMany(userCompanies);
+  await Promise.all([
+    User.create([...usersSeedList, helperFromOtherCompany]),
+    Customer.create([customerFromOtherCompany, customer]),
+    Helper.create(helpersList),
+    UserCompany.create(userCompanies),
+  ]);
 };
 
 module.exports = {
-  usersSeedList,
   populateDB,
   customer,
   customerFromOtherCompany,
-  helperFromOtherCompany,
   helpersList,
 };


### PR DESCRIPTION
Revue des tests et des seeds suivants :

events
exports
finalPay
helpers


Ce qui a été fait :
Ajout d'un Promise.all dans le populateDB
Changement des insertMany en create
Si on a des utilisateurs dans les seeds et qu’ils ne servent pas à l'authentification, pas besoin de leur assigner de mot de passe
pas de modification sur les seeds d'authentification