### PR TITLE
COM-2587: refuse undefined as argument and return error if invalid

### DIFF
--- a/src/helpers/dates/companiDates.js
+++ b/src/helpers/dates/companiDates.js
@@ -48,7 +48,6 @@ exports._formatMiscToCompaniDate = (...args) => {
     if (args[0] instanceof luxon.DateTime) return args[0];
     if (args[0] instanceof Date) return luxon.DateTime.fromJSDate(args[0]);
     if (typeof args[0] === 'string' && args[0] !== '') return luxon.DateTime.fromISO(args[0]);
-    if (typeof args[0] === 'undefined' || (args[0] instanceof Array && !args[0].length)) return luxon.DateTime.now();
   }
 
   if (args.length === 2 && typeof args[0] === 'string' && typeof args[1] === 'string') {

--- a/src/helpers/dates/luxon.js
+++ b/src/helpers/dates/luxon.js
@@ -2,5 +2,6 @@ const luxon = require('luxon');
 
 luxon.Settings.defaultLocale = 'fr';
 luxon.Settings.defaultZone = 'Europe/Paris';
+luxon.Settings.throwOnInvalid = true;
 
 module.exports = luxon;

--- a/src/routes/preHandlers/courseSlot.js
+++ b/src/routes/preHandlers/courseSlot.js
@@ -36,10 +36,14 @@ const formatAndCheckAuthorization = async (courseId, credentials) => {
 
 const checkPayload = async (courseId, payload) => {
   const { startDate, endDate, step: stepId } = payload;
-  const hasBothOrNeitherDates = (startDate && endDate) || (!startDate && !endDate);
-  const sameDay = CompaniDate(startDate).isSame(endDate, 'day');
-  const startDateBeforeEndDate = CompaniDate(startDate).isSameOrBefore(endDate);
-  if (!(hasBothOrNeitherDates && sameDay && startDateBeforeEndDate)) throw Boom.badRequest();
+  const hasBothDates = !!startDate && !!endDate;
+  const hasNeitherDates = !startDate && !endDate;
+  if (!hasNeitherDates) {
+    if (!hasBothDates) throw Boom.badRequest();
+    const sameDay = CompaniDate(startDate).isSame(endDate, 'day');
+    const startDateBeforeEndDate = CompaniDate(startDate).isSameOrBefore(endDate);
+    if (!(sameDay && startDateBeforeEndDate)) throw Boom.badRequest();
+  }
 
   if (stepId) {
     const course = await Course.findById(courseId).populate({ path: 'subProgram', select: 'steps' }).lean();

--- a/tests/unit/helpers/dates/companiDates.test.js
+++ b/tests/unit/helpers/dates/companiDates.test.js
@@ -27,7 +27,17 @@ describe('CompaniDate', () => {
         isSameOrBefore: expect.any(Function),
         diff: expect.any(Function),
       }));
-    sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), date);
+    sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, date);
+  });
+
+  it('should return error if invalid argument', () => {
+    try {
+      CompaniDatesHelper.CompaniDate(null);
+    } catch (e) {
+      expect(e).toEqual(new Error('Invalid DateTime: wrong arguments'));
+    } finally {
+      sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, null);
+    }
   });
 });
 
@@ -48,14 +58,6 @@ describe('DISPLAY', () => {
       const result = companiDate.format('\'Le\' cccc dd LLLL y \'à\' HH\'h\'mm \'et\' s \'secondes\'');
 
       expect(result).toBe('Le mercredi 24 novembre 2021 à 08h12 et 8 secondes');
-    });
-
-    it('should return Invalid DateTime if invalid _date', () => {
-      const result = CompaniDatesHelper.CompaniDate(null)
-        .format('\'Le\' cccc dd LLLL y \'à\' HH\'h\'mm \'et\' s \'secondes\'');
-
-      expect(result).toBe('Invalid DateTime');
-      sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), null);
     });
   });
 });
@@ -78,29 +80,24 @@ describe('QUERY', () => {
       const result = companiDate.isSame(otherDate, 'day');
 
       expect(result).toBe(true);
-      sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
+      sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, otherDate);
     });
 
     it('should return false if different minute', () => {
       const result = companiDate.isSame(otherDate, 'minute');
 
       expect(result).toBe(false);
-      sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
+      sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, otherDate);
     });
 
-    it('should return false if invalid _date', () => {
-      const result = CompaniDatesHelper.CompaniDate(null).isSame(otherDate, 'day');
-
-      expect(result).toBe(false);
-      sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), null);
-      sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(1), otherDate);
-    });
-
-    it('should return false if invalid argument', () => {
-      const result = companiDate.isSame(null, 'day');
-
-      expect(result).toBe(false);
-      sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), null);
+    it('should return error if invalid argument', () => {
+      try {
+        companiDate.isSame(null, 'day');
+      } catch (e) {
+        expect(e).toEqual(new Error('Invalid DateTime: wrong arguments'));
+      } finally {
+        sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, null);
+      }
     });
   });
 
@@ -123,14 +120,14 @@ describe('QUERY', () => {
       const result = companiDate.isSameOrBefore(otherDate);
 
       expect(result).toBe(true);
-      sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
+      sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, otherDate);
     });
 
     it('should return true if before', () => {
       const result = companiDate.isSameOrBefore(otherDate);
 
       expect(result).toBe(true);
-      sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
+      sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, otherDate);
     });
 
     it('should return true if after but same as specified unit', () => {
@@ -139,16 +136,19 @@ describe('QUERY', () => {
       const result = companiDate.isSameOrBefore(otherDate, 'day');
 
       expect(result).toBe(true);
-      sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
+      sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, otherDate);
     });
 
     it('should return false if after', () => {
-      otherDate = new Date('2021-11-23T10:00:00.000Z');
+      try {
+        otherDate = new Date('2021-11-23T10:00:00.000Z');
 
-      const result = companiDate.isSameOrBefore(otherDate);
-
-      expect(result).toBe(false);
-      sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
+        companiDate.isSameOrBefore(otherDate);
+      } catch (e) {
+        expect(e).toBe(new Error('Invalid DateTime: wrong arguments'));
+      } finally {
+        sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
+      }
     });
 
     it('should return false if after specified unit', () => {
@@ -160,19 +160,14 @@ describe('QUERY', () => {
       sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
     });
 
-    it('should return false if invalid _date', () => {
-      const result = CompaniDatesHelper.CompaniDate(null).isSameOrBefore(otherDate);
-
-      expect(result).toBe(false);
-      sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), null);
-      sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(1), otherDate);
-    });
-
-    it('should return false if invalid argument', () => {
-      const result = companiDate.isSameOrBefore(null);
-
-      expect(result).toBe(false);
-      sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), null);
+    it('should return error if invalid argument', () => {
+      try {
+        companiDate.isSameOrBefore(null);
+      } catch (e) {
+        expect(e).toEqual(new Error('Invalid DateTime: wrong arguments'));
+      } finally {
+        sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, null);
+      }
     });
   });
 });
@@ -241,12 +236,14 @@ describe('MANIPULATE', () => {
       sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), otherDate);
     });
 
-    it('should return NaN if invalid _date', () => {
-      const otherDate = new Date('2021-11-30T08:00:00.000Z');
-      const result = CompaniDatesHelper.CompaniDate(null).diff(otherDate, 'days', true);
-
-      expect(result).toBeNaN();
-      sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), null);
+    it('should return error if invalid argument', () => {
+      try {
+        companiDate.diff(null, 'days', true);
+      } catch (e) {
+        expect(e).toEqual(new Error('Invalid DateTime: wrong arguments'));
+      } finally {
+        sinon.assert.calledWithExactly(_formatMiscToCompaniDate.getCall(0), null);
+      }
     });
   });
 });
@@ -339,39 +336,18 @@ describe('_formatMiscToCompaniDate', () => {
     sinon.assert.notCalled(invalid);
   });
 
-  it('should return invalid if arg is empty string', () => {
-    const result = CompaniDatesHelper._formatMiscToCompaniDate('');
-
-    expect(result instanceof luxon.DateTime).toBe(true);
-    sinon.assert.calledOnceWithExactly(invalid, 'wrong arguments');
-    sinon.assert.notCalled(now);
-    sinon.assert.notCalled(fromJSDate);
-    sinon.assert.notCalled(fromISO);
-    sinon.assert.notCalled(fromFormat);
-  });
-
-  it('should return dateTime.now if arg is undefined', () => {
-    const result = CompaniDatesHelper._formatMiscToCompaniDate(undefined);
-
-    expect(result instanceof luxon.DateTime).toBe(true);
-    expect(new luxon.DateTime(result).toJSDate() - new Date()).toBeLessThan(100);
-    sinon.assert.calledOnceWithExactly(now);
-    sinon.assert.notCalled(fromJSDate);
-    sinon.assert.notCalled(fromISO);
-    sinon.assert.notCalled(fromFormat);
-    sinon.assert.notCalled(invalid);
-  });
-
-  it('should return dateTime.now if arg is []', () => {
-    const result = CompaniDatesHelper._formatMiscToCompaniDate([]);
-
-    expect(result instanceof luxon.DateTime).toBe(true);
-    expect(new luxon.DateTime(result).toJSDate() - new Date()).toBeLessThan(100);
-    sinon.assert.calledOnceWithExactly(now);
-    sinon.assert.notCalled(fromJSDate);
-    sinon.assert.notCalled(fromISO);
-    sinon.assert.notCalled(fromFormat);
-    sinon.assert.notCalled(invalid);
+  it('should return error if arg is empty string', () => {
+    try {
+      CompaniDatesHelper._formatMiscToCompaniDate('');
+    } catch (e) {
+      expect(e).toEqual(new Error('Invalid DateTime: wrong arguments'));
+    } finally {
+      sinon.assert.calledOnceWithExactly(invalid, 'wrong arguments');
+      sinon.assert.notCalled(now);
+      sinon.assert.notCalled(fromJSDate);
+      sinon.assert.notCalled(fromISO);
+      sinon.assert.notCalled(fromFormat);
+    }
   });
 
   it('should return dateTime if 2 args, first argument doesn\'t finish with Z', () => {
@@ -414,26 +390,32 @@ describe('_formatMiscToCompaniDate', () => {
     sinon.assert.notCalled(invalid);
   });
 
-  it('should return invalid if too many args', () => {
-    const result = CompaniDatesHelper
-      ._formatMiscToCompaniDate('2021-11-24T07:00:00.000Z', 'MMMM dd yyyy', { locale: 'fr' });
-
-    expect(result instanceof luxon.DateTime).toBe(true);
-    sinon.assert.calledOnceWithExactly(invalid, 'wrong arguments');
-    sinon.assert.notCalled(now);
-    sinon.assert.notCalled(fromJSDate);
-    sinon.assert.notCalled(fromISO);
-    sinon.assert.notCalled(fromFormat);
+  it('should return error if too many args', () => {
+    try {
+      CompaniDatesHelper
+        ._formatMiscToCompaniDate('2021-11-24T07:00:00.000Z', 'MMMM dd yyyy', { locale: 'fr' });
+    } catch (e) {
+      expect(e).toEqual(new Error('Invalid DateTime: wrong arguments'));
+    } finally {
+      sinon.assert.calledOnceWithExactly(invalid, 'wrong arguments');
+      sinon.assert.notCalled(now);
+      sinon.assert.notCalled(fromJSDate);
+      sinon.assert.notCalled(fromISO);
+      sinon.assert.notCalled(fromFormat);
+    }
   });
 
-  it('should return invalid if invalid type of argument', () => {
-    const result = CompaniDatesHelper._formatMiscToCompaniDate(null);
-
-    expect(result instanceof luxon.DateTime).toBe(true);
-    sinon.assert.calledOnceWithExactly(invalid, 'wrong arguments');
-    sinon.assert.notCalled(now);
-    sinon.assert.notCalled(fromJSDate);
-    sinon.assert.notCalled(fromISO);
-    sinon.assert.notCalled(fromFormat);
+  it('should return error if invalid type of argument', () => {
+    try {
+      CompaniDatesHelper._formatMiscToCompaniDate(null);
+    } catch (e) {
+      expect(e).toEqual(new Error('Invalid DateTime: wrong arguments'));
+    } finally {
+      sinon.assert.calledOnceWithExactly(invalid, 'wrong arguments');
+      sinon.assert.notCalled(now);
+      sinon.assert.notCalled(fromJSDate);
+      sinon.assert.notCalled(fromISO);
+      sinon.assert.notCalled(fromFormat);
+    }
   });
 });

--- a/tests/unit/helpers/dates/companiDuration.test.js
+++ b/tests/unit/helpers/dates/companiDuration.test.js
@@ -153,11 +153,14 @@ describe('_formatMiscToCompaniDuration', () => {
   });
 
   it('should return invalid if wrong input', () => {
-    const result = CompaniDurationsHelper._formatMiscToCompaniDuration(23232323, 'minutes');
-
-    expect(result instanceof luxon.Duration).toBe(true);
-    sinon.assert.calledOnceWithExactly(invalid, 'wrong arguments');
-    sinon.assert.notCalled(fromObject);
-    sinon.assert.notCalled(fromMillis);
+    try {
+      CompaniDurationsHelper._formatMiscToCompaniDuration(23232323, 'minutes');
+    } catch (e) {
+      expect(e).toEqual(new Error('Invalid Duration: wrong arguments'));
+    } finally {
+      sinon.assert.calledOnceWithExactly(invalid, 'wrong arguments');
+      sinon.assert.notCalled(fromObject);
+      sinon.assert.notCalled(fromMillis);
+    }
   });
 });


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations : -np
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [ ] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES
- ~~Si mes changements impactent l'application formation :~~
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- ~~Si mes changements impactent l'application erp :~~
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME -np
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES
- ~~J'ai ajouté un modèle spécifique à une structure:~~
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- ~~J'ai changé un modèle utilisé par l'app mobile:~~
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV
- ~~J'ai changé une constante :~~
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- ~~J'ai ajouté une variable d'environnement :~~
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : vendeur

- Périmetre roles : admin/rof/formateur

- Cas d'usage : l'argument undefined n'est plus accepté pour les dates et les arguments invalides renvoient des erreurs
- vérifier que la création et l'édition de créneau fonctionne toujours correctement, notamment pour les créneaux à planifier
