### PR TITLE
COM-2286: refacto populateDB

### DIFF
--- a/tests/integration/seed/internalHoursSeed.js
+++ b/tests/integration/seed/internalHoursSeed.js
@@ -20,7 +20,7 @@ const internalHourUsers = [{
 }, {
   _id: new ObjectID(),
   identity: { firstname: 'internal', lastname: 'Test' },
-  local: { email: 'auxiliary_internal_hour@alenvi.io', password: '123456!eR' },
+  local: { email: 'auxiliary_internal_hour@alenvi.io' },
   refreshToken: uuidv4(),
   role: { client: auxiliaryRoleId },
   origin: WEBAPP,
@@ -73,10 +73,12 @@ const eventList = [
 const populateDB = async () => {
   await deleteNonAuthenticationSeeds();
 
-  await Event.insertMany(eventList);
-  await InternalHour.insertMany([...internalHoursList, ...authInternalHoursList]);
-  await User.create(internalHourUsers);
-  await UserCompany.insertMany(internalHourUserCompanies);
+  await Promise.all([
+    Event.create(eventList),
+    InternalHour.create([...internalHoursList, ...authInternalHoursList]),
+    User.create(internalHourUsers),
+    UserCompany.create(internalHourUserCompanies),
+  ]);
 };
 
 module.exports = {

--- a/tests/integration/seed/partnerOrganizationsSeed.js
+++ b/tests/integration/seed/partnerOrganizationsSeed.js
@@ -24,7 +24,7 @@ const partnerOrganizationsList = [
 const populateDB = async () => {
   await deleteNonAuthenticationSeeds();
 
-  await PartnerOrganization.insertMany(partnerOrganizationsList);
+  await PartnerOrganization.create(partnerOrganizationsList);
 };
 
 module.exports = {

--- a/tests/integration/seed/partnersSeed.js
+++ b/tests/integration/seed/partnersSeed.js
@@ -23,7 +23,7 @@ const partnersList = [
 const populateDB = async () => {
   await deleteNonAuthenticationSeeds();
 
-  await Partner.insertMany(partnersList);
+  await Partner.create(partnersList);
 };
 
 module.exports = {

--- a/tests/integration/seed/payDocumentsSeed.js
+++ b/tests/integration/seed/payDocumentsSeed.js
@@ -12,7 +12,7 @@ const payDocumentUsers = [
   {
     _id: new ObjectID(),
     identity: { firstname: 'Bob', lastname: 'Marley' },
-    local: { email: 'paydocumentauxiliary@alenvi.io', password: '123456!eR' },
+    local: { email: 'paydocumentauxiliary@alenvi.io' },
     role: { client: auxiliaryRoleId },
     refreshToken: uuidv4(),
     origin: WEBAPP,
@@ -38,7 +38,7 @@ const userFromOtherCompany = {
   company: otherCompanyId,
   _id: new ObjectID(),
   identity: { firstname: 'test', lastname: 'toto' },
-  local: { email: 'test@alenvi.io', password: '123456!eR' },
+  local: { email: 'test@alenvi.io' },
   role: { client: clientAdminRoleId },
   refreshToken: uuidv4(),
   origin: WEBAPP,
@@ -93,9 +93,11 @@ const payDocumentsList = [{
 const populateDB = async () => {
   await deleteNonAuthenticationSeeds();
 
-  await User.create([...payDocumentUsers, userFromOtherCompany]);
-  await UserCompany.insertMany(payDocumentUserCompanies);
-  await PayDocument.insertMany(payDocumentsList);
+  await Promise.all([
+    User.create([...payDocumentUsers, userFromOtherCompany]),
+    UserCompany.create(payDocumentUserCompanies),
+    PayDocument.create(payDocumentsList),
+  ]);
 };
 
 module.exports = {

--- a/tests/integration/seed/paySeed.js
+++ b/tests/integration/seed/paySeed.js
@@ -30,7 +30,7 @@ const sectorFromOtherCompany = { _id: new ObjectID(), name: 'Titi', company: oth
 
 const user = {
   _id: new ObjectID(),
-  local: { email: 'test4@alenvi.io', password: '123456!eR' },
+  local: { email: 'test4@alenvi.io' },
   identity: { lastname: 'Toto' },
   refreshToken: uuidv4(),
   role: { client: coachRoleId },
@@ -41,7 +41,7 @@ const auxiliaries = [
   {
     _id: auxiliaryId0,
     identity: { firstname: 'Test7', lastname: 'auxiliary' },
-    local: { email: 'test7@alenvi.io', password: '123456!eR' },
+    local: { email: 'test7@alenvi.io' },
     refreshToken: uuidv4(),
     role: { client: auxiliaryRoleId },
     contracts: [contractId0],
@@ -50,7 +50,7 @@ const auxiliaries = [
   {
     _id: auxiliaryId1,
     identity: { firstname: 'OtherTest', lastname: 'Test8' },
-    local: { email: 'test8@alenvi.io', password: '123456!eR' },
+    local: { email: 'test8@alenvi.io' },
     refreshToken: uuidv4(),
     role: { client: auxiliaryRoleId },
     contracts: [contractId1],
@@ -61,7 +61,7 @@ const auxiliaries = [
 const auxiliaryFromOtherCompany = {
   _id: new ObjectID(),
   identity: { firstname: 'otherCompany', lastname: 'Chloe' },
-  local: { email: 'othercompany@alenvi.io', password: '123456!eR' },
+  local: { email: 'othercompany@alenvi.io' },
   refreshToken: uuidv4(),
   role: { client: auxiliaryRoleId },
   contracts: [contractId1],
@@ -343,15 +343,17 @@ const payList = [
 const populateDB = async () => {
   await deleteNonAuthenticationSeeds();
 
-  await Sector.create([...sectors, sectorFromOtherCompany]);
-  await SectorHistory.create(sectorHistories);
-  await User.create([user, ...auxiliaries, auxiliaryFromOtherCompany]);
-  await Customer.create(customer);
-  await Service.create(service);
-  await Event.create([event, ...absences]);
-  await Contract.insertMany(contracts);
-  await Pay.insertMany(payList);
-  await UserCompany.insertMany(userCompanyList);
+  await Promise.all([
+    Sector.create([...sectors, sectorFromOtherCompany]),
+    SectorHistory.create(sectorHistories),
+    User.create([user, ...auxiliaries, auxiliaryFromOtherCompany]),
+    Customer.create(customer),
+    Service.create(service),
+    Event.create([event, ...absences]),
+    Contract.create(contracts),
+    Pay.create(payList),
+    UserCompany.create(userCompanyList),
+  ]);
 };
 
 module.exports = {

--- a/tests/integration/seed/paymentsSeed.js
+++ b/tests/integration/seed/paymentsSeed.js
@@ -173,7 +173,7 @@ const paymentNumberList = [
 const paymentUser = {
   _id: new ObjectID(),
   identity: { firstname: 'HelperForCustomer', lastname: 'Test' },
-  local: { email: 'helper_for_customer_payment@alenvi.io', password: '123456!eR' },
+  local: { email: 'helper_for_customer_payment@alenvi.io' },
   refreshToken: uuidv4(),
   role: { client: helperRoleId },
   company: authCompany._id,
@@ -229,22 +229,23 @@ const tppFromOtherCompany = {
 const populateDB = async () => {
   await deleteNonAuthenticationSeeds();
 
-  await Customer.insertMany(paymentCustomerList);
-  await ThirdPartyPayer.insertMany(paymentTppList);
-  await Payment.insertMany(paymentsList);
-  await PaymentNumber.insertMany(paymentNumberList);
-  await UserCompany.insertMany(userCompanies);
-  await Helper.insertMany(helpersList);
-  await User.create(paymentUser, userFromOtherCompany);
-  await Customer.create(customerFromOtherCompany);
-  await ThirdPartyPayer.create(tppFromOtherCompany);
+  await Promise.all([
+    Customer.create(paymentCustomerList),
+    ThirdPartyPayer.create(paymentTppList),
+    Payment.create(paymentsList),
+    PaymentNumber.create(paymentNumberList),
+    UserCompany.create(userCompanies),
+    Helper.create(helpersList),
+    User.create(paymentUser, userFromOtherCompany),
+    Customer.create(customerFromOtherCompany),
+    ThirdPartyPayer.create(tppFromOtherCompany),
+  ]);
 };
 
 module.exports = {
   paymentsList,
   populateDB,
   paymentCustomerList,
-  paymentUser,
   userFromOtherCompany,
   customerFromOtherCompany,
   tppFromOtherCompany,

--- a/tests/integration/seed/programsSeed.js
+++ b/tests/integration/seed/programsSeed.js
@@ -116,14 +116,16 @@ const course = {
 const populateDB = async () => {
   await deleteNonAuthenticationSeeds();
 
-  await SubProgram.insertMany(subProgramsList);
-  await Program.insertMany(programsList);
-  await Step.insertMany(stepsList);
-  await Activity.insertMany(activitiesList);
-  await Category.insertMany(categoriesList);
-  await ActivityHistory.insertMany(activityHistoriesList);
-  await Card.insertMany(cards);
-  await Course.create(course);
+  await Promise.all([
+    SubProgram.create(subProgramsList),
+    Program.create(programsList),
+    Step.create(stepsList),
+    Activity.create(activitiesList),
+    Category.create(categoriesList),
+    ActivityHistory.create(activityHistoriesList),
+    Card.create(cards),
+    Course.create(course),
+  ]);
 };
 
 module.exports = {


### PR DESCRIPTION
Revue des tests et des seeds suivants :

internalHours
partnerOrganizations
partners
pay
payDocuments
payments
programs

Ce qui a été fait :
Ajout d'un Promise.all dans le populateDB
Changement des insertMany en create
Si on a des utilisateurs dans les seeds et qu’ils ne servent pas à l'authentification, pas besoin de leur assigner de mot de passe
pas de modification sur les seeds d'authentification