### PR TITLE
Com 2590

### DIFF
--- a/src/helpers/dates/companiDates.js
+++ b/src/helpers/dates/companiDates.js
@@ -16,6 +16,14 @@ const CompaniDateFactory = (inputDate) => {
       return _date.toFormat(fmt);
     },
 
+    toDate() {
+      return _date.toUTC().toJSDate();
+    },
+
+    toISO() {
+      return _date.toUTC().toISO();
+    },
+
     // QUERY
     isBefore(miscTypeOtherDate) {
       const otherDate = exports._formatMiscToCompaniDate(miscTypeOtherDate);
@@ -42,6 +50,14 @@ const CompaniDateFactory = (inputDate) => {
     },
 
     // MANIPULATE
+    startOf(unit) {
+      return CompaniDateFactory(_date.startOf(unit));
+    },
+
+    endOf(unit) {
+      return CompaniDateFactory(_date.endOf(unit));
+    },
+
     diff(miscTypeOtherDate, unit = 'milliseconds', typeFloat = false) {
       const otherDate = exports._formatMiscToCompaniDate(miscTypeOtherDate);
       const floatDiff = _date.diff(otherDate, unit).as(unit);

--- a/src/helpers/dates/companiDates.js
+++ b/src/helpers/dates/companiDates.js
@@ -1,14 +1,13 @@
-const pick = require('lodash/pick');
 const luxon = require('./luxon');
 
-exports.CompaniDate = (...args) => companiDateFactory(exports._formatMiscToCompaniDate(...args));
+exports.CompaniDate = (...args) => CompaniDateFactory(exports._formatMiscToCompaniDate(...args));
 
-const companiDateFactory = (inputDate) => {
+const CompaniDateFactory = (inputDate) => {
   const _date = inputDate;
 
   return ({
     // GETTER
-    get _date() {
+    get _getDate() {
       return _date;
     },
 
@@ -18,6 +17,18 @@ const companiDateFactory = (inputDate) => {
     },
 
     // QUERY
+    isBefore(miscTypeOtherDate) {
+      const otherDate = exports._formatMiscToCompaniDate(miscTypeOtherDate);
+
+      return _date < otherDate;
+    },
+
+    isAfter(miscTypeOtherDate) {
+      const otherDate = exports._formatMiscToCompaniDate(miscTypeOtherDate);
+
+      return _date > otherDate;
+    },
+
     isSame(miscTypeOtherDate, unit) {
       const otherDate = exports._formatMiscToCompaniDate(miscTypeOtherDate);
 
@@ -45,7 +56,9 @@ exports._formatMiscToCompaniDate = (...args) => {
   if (!args.length) return luxon.DateTime.now();
 
   if (args.length === 1) {
-    if (args[0] instanceof Object && args[0]._date && args[0]._date instanceof luxon.DateTime) return args[0]._date;
+    if (args[0] instanceof Object && args[0]._getDate && args[0]._getDate instanceof luxon.DateTime) {
+      return args[0]._getDate;
+    }
     if (args[0] instanceof Date) return luxon.DateTime.fromJSDate(args[0]);
     if (typeof args[0] === 'string' && args[0] !== '') return luxon.DateTime.fromISO(args[0]);
   }

--- a/src/helpers/dates/companiDates.js
+++ b/src/helpers/dates/companiDates.js
@@ -65,6 +65,11 @@ const CompaniDateFactory = (inputDate) => {
       if (typeFloat) return floatDiff;
       return floatDiff > 0 ? Math.floor(floatDiff) : Math.ceil(floatDiff);
     },
+
+    add(amount) {
+      if (amount instanceof Number) throw Error('Invalid argument: expected to be an object, got number');
+      return CompaniDateFactory(_date.plus(amount));
+    },
   });
 };
 

--- a/src/helpers/dates/companiDates.js
+++ b/src/helpers/dates/companiDates.js
@@ -1,3 +1,4 @@
+const pick = require('lodash/pick');
 const luxon = require('./luxon');
 
 exports.CompaniDate = (...args) => companiDateFactory(exports._formatMiscToCompaniDate(...args));
@@ -45,7 +46,6 @@ exports._formatMiscToCompaniDate = (...args) => {
 
   if (args.length === 1) {
     if (args[0] instanceof Object && args[0]._date && args[0]._date instanceof luxon.DateTime) return args[0]._date;
-    if (args[0] instanceof luxon.DateTime) return args[0];
     if (args[0] instanceof Date) return luxon.DateTime.fromJSDate(args[0]);
     if (typeof args[0] === 'string' && args[0] !== '') return luxon.DateTime.fromISO(args[0]);
   }

--- a/src/helpers/dates/companiDates.js
+++ b/src/helpers/dates/companiDates.js
@@ -1,3 +1,4 @@
+const pick = require('lodash/pick');
 const luxon = require('./luxon');
 
 exports.CompaniDate = (...args) => CompaniDateFactory(exports._formatMiscToCompaniDate(...args));
@@ -9,6 +10,10 @@ const CompaniDateFactory = (inputDate) => {
     // GETTER
     get _getDate() {
       return _date;
+    },
+
+    getUnits(units) {
+      return pick(_date.toObject(), units);
     },
 
     // DISPLAY
@@ -69,6 +74,10 @@ const CompaniDateFactory = (inputDate) => {
     add(amount) {
       if (amount instanceof Number) throw Error('Invalid argument: expected to be an object, got number');
       return CompaniDateFactory(_date.plus(amount));
+    },
+
+    set(values) {
+      return CompaniDateFactory(_date.set(values));
     },
   });
 };

--- a/tests/unit/helpers/dates/companiDates.test.js
+++ b/tests/unit/helpers/dates/companiDates.test.js
@@ -51,16 +51,35 @@ describe('CompaniDate', () => {
 });
 
 describe('GETTER', () => {
-  describe('getUnits', () => {
-    const companiDate = CompaniDatesHelper.CompaniDate('2021-11-24T07:12:08.000Z');
+  describe('getDate', () => {
+    it('should return _date', () => {
+      const companiDate = CompaniDatesHelper.CompaniDate('2021-11-24T07:12:08.000Z');
+      const result = companiDate._getDate;
 
+      expect(result).toEqual(expect.any(luxon.DateTime));
+      expect(result).toEqual(luxon.DateTime.fromISO('2021-11-24T07:12:08.000Z'));
+    });
+
+    it('should not mutate _date', () => {
+      const isoDate = '2021-11-24T07:12:08.000Z';
+      const otherIsoDate = '2022-01-03T07:12:08.000Z';
+      const companiDate = CompaniDatesHelper.CompaniDate(isoDate);
+      companiDate._date = luxon.DateTime.fromISO(otherIsoDate);
+
+      expect(companiDate._getDate.toUTC().toISO()).toEqual(isoDate);
+    });
+  });
+
+  describe('getUnits', () => {
     it('should return units', () => {
+      const companiDate = CompaniDatesHelper.CompaniDate('2021-11-24T07:12:08.000Z');
       const result = companiDate.getUnits(['day', 'second']);
 
       expect(result).toEqual({ day: 24, second: 8 });
     });
 
-    it('should return empty if unit is plural or invalid', () => {
+    it('should return only valid units', () => {
+      const companiDate = CompaniDatesHelper.CompaniDate('2021-11-24T07:12:08.000Z');
       const result = companiDate.getUnits(['days', 'second', 'mois']);
 
       expect(result).toEqual({ second: 8 });
@@ -70,9 +89,8 @@ describe('GETTER', () => {
 
 describe('DISPLAY', () => {
   describe('format', () => {
-    const companiDate = CompaniDatesHelper.CompaniDate('2021-11-24T07:12:08.000Z');
-
     it('should return formated date in a string', () => {
+      const companiDate = CompaniDatesHelper.CompaniDate('2021-11-24T07:12:08.000Z');
       const result = companiDate.format('\'Le\' cccc dd LLLL y \'à\' HH\'h\'mm \'et\' s \'secondes\'');
 
       expect(result).toBe('Le mercredi 24 novembre 2021 à 08h12 et 8 secondes');

--- a/tests/unit/helpers/dates/companiDates.test.js
+++ b/tests/unit/helpers/dates/companiDates.test.js
@@ -14,59 +14,62 @@ describe('CompaniDate', () => {
     _formatMiscToCompaniDate.restore();
   });
 
-  it('should return dateTime', () => {
-    const date = '2021-11-24T07:00:00.000Z';
+  it('should not mutate _date', () => {
+    const isoDate = '2021-11-24T07:12:08.000Z';
+    const otherIsoDate = '2022-01-03T07:12:08.000Z';
+    const companiDate = CompaniDatesHelper.CompaniDate(isoDate);
+    companiDate._date = luxon.DateTime.fromISO(otherIsoDate);
 
-    const result = CompaniDatesHelper.CompaniDate(date);
-
-    expect(result)
-      .toEqual(expect.objectContaining({
-        _getDate: expect.any(luxon.DateTime),
-        getUnits: expect.any(Function),
-        format: expect.any(Function),
-        toDate: expect.any(Function),
-        toISO: expect.any(Function),
-        isBefore: expect.any(Function),
-        isAfter: expect.any(Function),
-        isSame: expect.any(Function),
-        isSameOrBefore: expect.any(Function),
-        startOf: expect.any(Function),
-        endOf: expect.any(Function),
-        diff: expect.any(Function),
-        add: expect.any(Function),
-        set: expect.any(Function),
-      }));
-    sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, date);
+    expect(companiDate._getDate.toUTC().toISO()).toEqual(isoDate);
   });
 
-  it('should return error if invalid argument', () => {
-    try {
-      CompaniDatesHelper.CompaniDate(null);
-    } catch (e) {
-      expect(e).toEqual(new Error('Invalid DateTime: wrong arguments'));
-    } finally {
-      sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, null);
-    }
+  describe('Constructor', () => {
+    it('should return dateTime', () => {
+      const date = '2021-11-24T07:00:00.000Z';
+
+      const result = CompaniDatesHelper.CompaniDate(date);
+
+      expect(result)
+        .toEqual(expect.objectContaining({
+          _getDate: expect.any(luxon.DateTime),
+          getUnits: expect.any(Function),
+          format: expect.any(Function),
+          toDate: expect.any(Function),
+          toISO: expect.any(Function),
+          isBefore: expect.any(Function),
+          isAfter: expect.any(Function),
+          isSame: expect.any(Function),
+          isSameOrBefore: expect.any(Function),
+          startOf: expect.any(Function),
+          endOf: expect.any(Function),
+          diff: expect.any(Function),
+          add: expect.any(Function),
+          set: expect.any(Function),
+        }));
+      sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, date);
+    });
+
+    it('should return error if invalid argument', () => {
+      try {
+        CompaniDatesHelper.CompaniDate(null);
+      } catch (e) {
+        expect(e).toEqual(new Error('Invalid DateTime: wrong arguments'));
+      } finally {
+        sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, null);
+      }
+    });
   });
 });
 
 describe('GETTER', () => {
   describe('getDate', () => {
     it('should return _date', () => {
-      const companiDate = CompaniDatesHelper.CompaniDate('2021-11-24T07:12:08.000Z');
+      const isoDate = '2021-11-24T07:12:08.000Z';
+      const companiDate = CompaniDatesHelper.CompaniDate(isoDate);
       const result = companiDate._getDate;
 
       expect(result).toEqual(expect.any(luxon.DateTime));
-      expect(result).toEqual(luxon.DateTime.fromISO('2021-11-24T07:12:08.000Z'));
-    });
-
-    it('should not mutate _date', () => {
-      const isoDate = '2021-11-24T07:12:08.000Z';
-      const otherIsoDate = '2022-01-03T07:12:08.000Z';
-      const companiDate = CompaniDatesHelper.CompaniDate(isoDate);
-      companiDate._date = luxon.DateTime.fromISO(otherIsoDate);
-
-      expect(companiDate._getDate.toUTC().toISO()).toEqual(isoDate);
+      expect(result).toEqual(luxon.DateTime.fromISO(isoDate));
     });
   });
 

--- a/tests/unit/helpers/dates/companiDates.test.js
+++ b/tests/unit/helpers/dates/companiDates.test.js
@@ -98,9 +98,8 @@ describe('DISPLAY', () => {
   });
 
   describe('toDate', () => {
-    const companiDate = CompaniDatesHelper.CompaniDate('2021-11-24T07:00:00.000+01:00');
-
     it('should return a JSDate equivalent to companiDate (in utc)', () => {
+      const companiDate = CompaniDatesHelper.CompaniDate('2021-11-24T07:00:00.000+01:00');
       const result = companiDate.toDate();
 
       expect(result).toEqual(new Date('2021-11-24T06:00:00.000Z'));
@@ -108,9 +107,8 @@ describe('DISPLAY', () => {
   });
 
   describe('toISO', () => {
-    const companiDate = CompaniDatesHelper.CompaniDate('2021-12-24T12:00:00.000+03:00');
-
     it('should return a string ISO 8601 equivalent to companiDate (in utc)', () => {
+      const companiDate = CompaniDatesHelper.CompaniDate('2021-12-24T12:00:00.000+03:00');
       const result = companiDate.toISO();
 
       expect(result).toEqual('2021-12-24T09:00:00.000Z');

--- a/tests/unit/helpers/dates/companiDates.test.js
+++ b/tests/unit/helpers/dates/companiDates.test.js
@@ -32,6 +32,7 @@ describe('CompaniDate', () => {
         startOf: expect.any(Function),
         endOf: expect.any(Function),
         diff: expect.any(Function),
+        add: expect.any(Function),
       }));
     sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, date);
   });
@@ -423,6 +424,33 @@ describe('MANIPULATE', () => {
         expect(e).toEqual(new Error('Invalid unit jour'));
       } finally {
         sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, otherDate);
+      }
+    });
+  });
+
+  describe('add', () => {
+    const companiDate = CompaniDatesHelper.CompaniDate('2021-12-01T07:00:00.000Z');
+
+    it('should return a newly constructed companiDate, inscreased by amout', () => {
+      const result = companiDate.add({ months: 1, hours: 2 });
+
+      expect(result).toEqual(expect.objectContaining({ _getDate: expect.any(luxon.DateTime) }));
+      expect(result._getDate.toUTC().toISO()).toEqual('2022-01-01T09:00:00.000Z');
+    });
+
+    it('should return error if invalid unit', () => {
+      try {
+        companiDate.add({ jour: 1, hours: 2 });
+      } catch (e) {
+        expect(e).toEqual(new Error('Invalid unit jour'));
+      }
+    });
+
+    it('should return error if amount is number', () => {
+      try {
+        companiDate.add(11111);
+      } catch (e) {
+        expect(e).toEqual(new Error('Invalid argument: expected to be an object, got number'));
       }
     });
   });

--- a/tests/unit/helpers/dates/companiDates.test.js
+++ b/tests/unit/helpers/dates/companiDates.test.js
@@ -294,19 +294,6 @@ describe('_formatMiscToCompaniDate', () => {
     sinon.assert.notCalled(invalid);
   });
 
-  it('should return dateTime if arg is dateTime', () => {
-    const payload = date;
-    const result = CompaniDatesHelper._formatMiscToCompaniDate(payload);
-
-    expect(result instanceof luxon.DateTime).toBe(true);
-    expect(new luxon.DateTime(result).toJSDate()).toEqual(new Date('2021-11-24T07:00:00.000Z'));
-    sinon.assert.notCalled(now);
-    sinon.assert.notCalled(fromJSDate);
-    sinon.assert.notCalled(fromISO);
-    sinon.assert.notCalled(fromFormat);
-    sinon.assert.notCalled(invalid);
-  });
-
   it('should return dateTime if arg is date', () => {
     const payload = new Date('2021-11-24T07:00:00.000Z');
     const result = CompaniDatesHelper._formatMiscToCompaniDate(payload);
@@ -385,6 +372,20 @@ describe('_formatMiscToCompaniDate', () => {
     sinon.assert.notCalled(fromJSDate);
     sinon.assert.notCalled(fromISO);
     sinon.assert.notCalled(invalid);
+  });
+
+  it('should return error if arg is dateTime', () => {
+    try {
+      const payload = date;
+      CompaniDatesHelper._formatMiscToCompaniDate(payload);
+    } catch (e) {
+      expect(e).toEqual(new Error('Invalid DateTime: wrong arguments'));
+    } finally {
+      sinon.assert.notCalled(now);
+      sinon.assert.notCalled(fromJSDate);
+      sinon.assert.notCalled(fromISO);
+      sinon.assert.notCalled(fromFormat);
+    }
   });
 
   it('should return error if too many args', () => {

--- a/tests/unit/helpers/dates/companiDates.test.js
+++ b/tests/unit/helpers/dates/companiDates.test.js
@@ -21,7 +21,7 @@ describe('CompaniDate', () => {
 
     expect(result)
       .toEqual(expect.objectContaining({
-        _date: expect.any(luxon.DateTime),
+        _getDate: expect.any(luxon.DateTime),
         format: expect.any(Function),
         isSame: expect.any(Function),
         isSameOrBefore: expect.any(Function),
@@ -63,6 +63,84 @@ describe('DISPLAY', () => {
 });
 
 describe('QUERY', () => {
+  describe('isBefore', () => {
+    let _formatMiscToCompaniDate;
+    const companiDate = CompaniDatesHelper.CompaniDate('2021-08-01T07:00:00.000Z');
+
+    beforeEach(() => {
+      _formatMiscToCompaniDate = sinon.spy(CompaniDatesHelper, '_formatMiscToCompaniDate');
+    });
+
+    afterEach(() => {
+      _formatMiscToCompaniDate.restore();
+    });
+
+    it('should return true if date is before other date', () => {
+      const dateBefore = new Date('2021-08-01T10:00:00.000Z');
+      const result = companiDate.isBefore(dateBefore);
+
+      expect(result).toBe(true);
+      sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, dateBefore);
+    });
+
+    it('should return false is date is not before other date', () => {
+      const dateAfter = new Date('2021-08-01T05:00:00.000Z');
+      const result = companiDate.isBefore(dateAfter);
+
+      expect(result).toBe(false);
+      sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, dateAfter);
+    });
+
+    it('should return error if invalid argument', () => {
+      try {
+        companiDate.isBefore(null, 'day');
+      } catch (e) {
+        expect(e).toEqual(new Error('Invalid DateTime: wrong arguments'));
+      } finally {
+        sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, null);
+      }
+    });
+  });
+
+  describe('isAfter', () => {
+    let _formatMiscToCompaniDate;
+    const companiDate = CompaniDatesHelper.CompaniDate('2021-08-01T07:00:00.000Z');
+
+    beforeEach(() => {
+      _formatMiscToCompaniDate = sinon.spy(CompaniDatesHelper, '_formatMiscToCompaniDate');
+    });
+
+    afterEach(() => {
+      _formatMiscToCompaniDate.restore();
+    });
+
+    it('should return true if date is after other date', () => {
+      const dateBefore = new Date('2021-08-01T05:00:00.000Z');
+      const result = companiDate.isAfter(dateBefore);
+
+      expect(result).toBe(true);
+      sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, dateBefore);
+    });
+
+    it('should return false is date is not after other date', () => {
+      const dateAfter = new Date('2021-08-01T10:00:00.000Z');
+      const result = companiDate.isAfter(dateAfter);
+
+      expect(result).toBe(false);
+      sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, dateAfter);
+    });
+
+    it('should return error if invalid argument', () => {
+      try {
+        companiDate.isAfter(null, 'day');
+      } catch (e) {
+        expect(e).toEqual(new Error('Invalid DateTime: wrong arguments'));
+      } finally {
+        sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, null);
+      }
+    });
+  });
+
   describe('isSame', () => {
     let _formatMiscToCompaniDate;
     const companiDate = CompaniDatesHelper.CompaniDate('2021-11-24T07:00:00.000Z');
@@ -282,7 +360,7 @@ describe('_formatMiscToCompaniDate', () => {
   });
 
   it('should return dateTime if arg is object with dateTime', () => {
-    const payload = { _date: date };
+    const payload = { _getDate: date };
     const result = CompaniDatesHelper._formatMiscToCompaniDate(payload);
 
     expect(result instanceof luxon.DateTime).toBe(true);

--- a/tests/unit/helpers/dates/companiDates.test.js
+++ b/tests/unit/helpers/dates/companiDates.test.js
@@ -60,10 +60,10 @@ describe('GETTER', () => {
       expect(result).toEqual({ day: 24, second: 8 });
     });
 
-    it('should return empty if unit is plural', () => {
-      const result = companiDate.getUnits(['days']);
+    it('should return empty if unit is plural or invalid', () => {
+      const result = companiDate.getUnits(['days', 'second', 'mois']);
 
-      expect(result).toEqual({});
+      expect(result).toEqual({ second: 8 });
     });
   });
 });

--- a/tests/unit/helpers/dates/companiDates.test.js
+++ b/tests/unit/helpers/dates/companiDates.test.js
@@ -15,7 +15,7 @@ describe('CompaniDate', () => {
   });
 
   it('should return dateTime', () => {
-    const date = new Date('2021-11-24T07:00:00.000Z');
+    const date = '2021-11-24T07:00:00.000Z';
 
     const result = CompaniDatesHelper.CompaniDate(date);
 
@@ -23,8 +23,14 @@ describe('CompaniDate', () => {
       .toEqual(expect.objectContaining({
         _getDate: expect.any(luxon.DateTime),
         format: expect.any(Function),
+        toDate: expect.any(Function),
+        toISO: expect.any(Function),
+        isBefore: expect.any(Function),
+        isAfter: expect.any(Function),
         isSame: expect.any(Function),
         isSameOrBefore: expect.any(Function),
+        startOf: expect.any(Function),
+        endOf: expect.any(Function),
         diff: expect.any(Function),
       }));
     sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, date);
@@ -43,16 +49,7 @@ describe('CompaniDate', () => {
 
 describe('DISPLAY', () => {
   describe('format', () => {
-    let _formatMiscToCompaniDate;
     const companiDate = CompaniDatesHelper.CompaniDate('2021-11-24T07:12:08.000Z');
-
-    beforeEach(() => {
-      _formatMiscToCompaniDate = sinon.spy(CompaniDatesHelper, '_formatMiscToCompaniDate');
-    });
-
-    afterEach(() => {
-      _formatMiscToCompaniDate.restore();
-    });
 
     it('should return formated date in a string', () => {
       const result = companiDate.format('\'Le\' cccc dd LLLL y \'à\' HH\'h\'mm \'et\' s \'secondes\'');
@@ -60,12 +57,33 @@ describe('DISPLAY', () => {
       expect(result).toBe('Le mercredi 24 novembre 2021 à 08h12 et 8 secondes');
     });
   });
+
+  describe('toDate', () => {
+    const companiDate = CompaniDatesHelper.CompaniDate('2021-11-24T07:00:00.000+01:00');
+
+    it('should return a JSDate equivalent to companiDate (in utc)', () => {
+      const result = companiDate.toDate();
+
+      expect(result).toEqual(new Date('2021-11-24T06:00:00.000Z'));
+    });
+  });
+
+  describe('toISO', () => {
+    const companiDate = CompaniDatesHelper.CompaniDate('2021-12-24T12:00:00.000+03:00');
+
+    it('should return a string ISO 8601 equivalent to companiDate (in utc)', () => {
+      const result = companiDate.toISO();
+
+      expect(result).toEqual('2021-12-24T09:00:00.000Z');
+    });
+  });
 });
 
 describe('QUERY', () => {
   describe('isBefore', () => {
     let _formatMiscToCompaniDate;
-    const companiDate = CompaniDatesHelper.CompaniDate('2021-08-01T07:00:00.000Z');
+    let otherDate = '2021-11-01T10:00:00.000Z';
+    const companiDate = CompaniDatesHelper.CompaniDate('2021-11-01T07:00:00.000Z');
 
     beforeEach(() => {
       _formatMiscToCompaniDate = sinon.spy(CompaniDatesHelper, '_formatMiscToCompaniDate');
@@ -76,24 +94,23 @@ describe('QUERY', () => {
     });
 
     it('should return true if date is before other date', () => {
-      const dateBefore = new Date('2021-08-01T10:00:00.000Z');
-      const result = companiDate.isBefore(dateBefore);
+      const result = companiDate.isBefore(otherDate);
 
       expect(result).toBe(true);
-      sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, dateBefore);
+      sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, otherDate);
     });
 
     it('should return false is date is not before other date', () => {
-      const dateAfter = new Date('2021-08-01T05:00:00.000Z');
-      const result = companiDate.isBefore(dateAfter);
+      otherDate = '2021-11-01T05:00:00.000Z';
+      const result = companiDate.isBefore(otherDate);
 
       expect(result).toBe(false);
-      sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, dateAfter);
+      sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, otherDate);
     });
 
-    it('should return error if invalid argument', () => {
+    it('should return error if invalid other date', () => {
       try {
-        companiDate.isBefore(null, 'day');
+        companiDate.isBefore(null);
       } catch (e) {
         expect(e).toEqual(new Error('Invalid DateTime: wrong arguments'));
       } finally {
@@ -104,7 +121,8 @@ describe('QUERY', () => {
 
   describe('isAfter', () => {
     let _formatMiscToCompaniDate;
-    const companiDate = CompaniDatesHelper.CompaniDate('2021-08-01T07:00:00.000Z');
+    let otherDate = '2021-11-01T05:00:00.000Z';
+    const companiDate = CompaniDatesHelper.CompaniDate('2021-11-01T07:00:00.000Z');
 
     beforeEach(() => {
       _formatMiscToCompaniDate = sinon.spy(CompaniDatesHelper, '_formatMiscToCompaniDate');
@@ -115,24 +133,23 @@ describe('QUERY', () => {
     });
 
     it('should return true if date is after other date', () => {
-      const dateBefore = new Date('2021-08-01T05:00:00.000Z');
-      const result = companiDate.isAfter(dateBefore);
+      const result = companiDate.isAfter(otherDate);
 
       expect(result).toBe(true);
-      sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, dateBefore);
+      sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, otherDate);
     });
 
     it('should return false is date is not after other date', () => {
-      const dateAfter = new Date('2021-08-01T10:00:00.000Z');
-      const result = companiDate.isAfter(dateAfter);
+      otherDate = '2021-11-01T10:00:00.000Z';
+      const result = companiDate.isAfter(otherDate);
 
       expect(result).toBe(false);
-      sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, dateAfter);
+      sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, otherDate);
     });
 
-    it('should return error if invalid argument', () => {
+    it('should return error if invalid dateAfter', () => {
       try {
-        companiDate.isAfter(null, 'day');
+        companiDate.isAfter(null);
       } catch (e) {
         expect(e).toEqual(new Error('Invalid DateTime: wrong arguments'));
       } finally {
@@ -144,7 +161,7 @@ describe('QUERY', () => {
   describe('isSame', () => {
     let _formatMiscToCompaniDate;
     const companiDate = CompaniDatesHelper.CompaniDate('2021-11-24T07:00:00.000Z');
-    const otherDate = new Date('2021-11-24T10:00:00.000Z');
+    const otherDate = '2021-11-24T10:00:00.000Z';
 
     beforeEach(() => {
       _formatMiscToCompaniDate = sinon.spy(CompaniDatesHelper, '_formatMiscToCompaniDate');
@@ -168,7 +185,7 @@ describe('QUERY', () => {
       sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, otherDate);
     });
 
-    it('should return error if invalid argument', () => {
+    it('should return error if invalid other date', () => {
       try {
         companiDate.isSame(null, 'day');
       } catch (e) {
@@ -177,12 +194,22 @@ describe('QUERY', () => {
         sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, null);
       }
     });
+
+    it('should return error if unit is plural', () => {
+      try {
+        companiDate.isSame(otherDate, 'days');
+      } catch (e) {
+        expect(e).toEqual(new Error('Invalid unit days'));
+      } finally {
+        sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, otherDate);
+      }
+    });
   });
 
   describe('isSameOrBefore', () => {
     let _formatMiscToCompaniDate;
     const companiDate = CompaniDatesHelper.CompaniDate('2021-11-24T07:00:00.000Z');
-    let otherDate = new Date('2021-11-25T10:00:00.000Z');
+    let otherDate = '2021-11-25T10:00:00.000Z';
 
     beforeEach(() => {
       _formatMiscToCompaniDate = sinon.spy(CompaniDatesHelper, '_formatMiscToCompaniDate');
@@ -193,7 +220,7 @@ describe('QUERY', () => {
     });
 
     it('should return true if same moment', () => {
-      otherDate = new Date('2021-11-24T07:00:00.000Z');
+      otherDate = '2021-11-24T07:00:00.000Z';
 
       const result = companiDate.isSameOrBefore(otherDate);
 
@@ -209,7 +236,7 @@ describe('QUERY', () => {
     });
 
     it('should return true if after but same as specified unit', () => {
-      otherDate = new Date('2021-11-24T06:00:00.000Z');
+      otherDate = '2021-11-24T06:00:00.000Z';
 
       const result = companiDate.isSameOrBefore(otherDate, 'day');
 
@@ -218,7 +245,7 @@ describe('QUERY', () => {
     });
 
     it('should return false if after', () => {
-      otherDate = new Date('2021-11-23T10:00:00.000Z');
+      otherDate = '2021-11-23T10:00:00.000Z';
 
       const result = companiDate.isSameOrBefore(otherDate);
 
@@ -227,7 +254,7 @@ describe('QUERY', () => {
     });
 
     it('should return false if after specified unit', () => {
-      otherDate = new Date('2021-11-24T06:00:00.000Z');
+      otherDate = '2021-11-24T06:00:00.000Z';
 
       const result = companiDate.isSameOrBefore(otherDate, 'minute');
 
@@ -235,7 +262,7 @@ describe('QUERY', () => {
       sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, otherDate);
     });
 
-    it('should return error if invalid argument', () => {
+    it('should return error if invalid otherDate', () => {
       try {
         companiDate.isSameOrBefore(null);
       } catch (e) {
@@ -244,10 +271,78 @@ describe('QUERY', () => {
         sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, null);
       }
     });
+
+    it('should return error if unit is plural', () => {
+      try {
+        companiDate.isSame(otherDate, 'minutes');
+      } catch (e) {
+        expect(e).toEqual(new Error('Invalid unit minutes'));
+      } finally {
+        sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, otherDate);
+      }
+    });
   });
 });
 
-describe('MANIPULATE', () => {
+describe('MANIPULATE #tag', () => {
+  describe('startOf', () => {
+    const companiDate = CompaniDatesHelper.CompaniDate('2021-11-19T07:00:00.000Z');
+
+    it('should return newly constructed CompaniDate from date, setted to the beginning of the day', () => {
+      const result = companiDate.startOf('day');
+
+      expect(result).toEqual(expect.objectContaining({ _getDate: expect.any(luxon.DateTime) }));
+      expect(result._getDate.toUTC().toISO()).toEqual('2021-11-18T23:00:00.000Z');
+
+      const didNotMutate = companiDate._getDate.toUTC().toISO() === '2021-11-19T07:00:00.000Z';
+      expect(didNotMutate).toEqual(true);
+    });
+
+    it('should return start of day even if unit is plural. NB: it is not best practice', () => {
+      const result = companiDate.startOf('days');
+
+      expect(result).toEqual(expect.objectContaining({ _getDate: expect.any(luxon.DateTime) }));
+      expect(result._getDate.toUTC().toISO()).toEqual('2021-11-18T23:00:00.000Z');
+    });
+
+    it('should return error if invalid argument', () => {
+      try {
+        companiDate.startOf('jour');
+      } catch (e) {
+        expect(e).toEqual(new Error('Invalid unit jour'));
+      }
+    });
+  });
+
+  describe('endOf', () => {
+    const companiDate = CompaniDatesHelper.CompaniDate('2021-11-19T07:00:00.000Z');
+
+    it('should return newly constructed CompaniDate from date, setted to the end of the month', () => {
+      const result = companiDate.endOf('month');
+
+      expect(result).toEqual(expect.objectContaining({ _getDate: expect.any(luxon.DateTime) }));
+      expect(result._getDate.toUTC().toISO()).toEqual('2021-11-30T22:59:59.999Z');
+
+      const didNotMutate = companiDate._getDate.toUTC().toISO() === '2021-11-19T07:00:00.000Z';
+      expect(didNotMutate).toEqual(true);
+    });
+
+    it('should return end of month even if unit is plural. NB: it is not best practice', () => {
+      const result = companiDate.endOf('months');
+
+      expect(result).toEqual(expect.objectContaining({ _getDate: expect.any(luxon.DateTime) }));
+      expect(result._getDate.toUTC().toISO()).toEqual('2021-11-30T22:59:59.999Z');
+    });
+
+    it('should return error if invalid argument', () => {
+      try {
+        companiDate.endOf('mois');
+      } catch (e) {
+        expect(e).toEqual(new Error('Invalid unit mois'));
+      }
+    });
+  });
+
   describe('diff', () => {
     let _formatMiscToCompaniDate;
     const companiDate = CompaniDatesHelper.CompaniDate('2021-11-24T10:00:00.000Z');
@@ -261,7 +356,7 @@ describe('MANIPULATE', () => {
     });
 
     it('should return diff in milliseconds, if no unit specified', () => {
-      const otherDate = new Date('2021-11-24T08:29:48.000Z');
+      const otherDate = '2021-11-24T08:29:48.000Z';
       const result = companiDate.diff(otherDate);
       const expectedDiffInMillis = 1 * 60 * 60 * 1000 + 30 * 60 * 1000 + 12 * 1000;
 
@@ -270,7 +365,7 @@ describe('MANIPULATE', () => {
     });
 
     it('should return difference in positive days', () => {
-      const otherDate = new Date('2021-11-20T10:00:00.000Z');
+      const otherDate = '2021-11-20T10:00:00.000Z';
       const result = companiDate.diff(otherDate, 'days');
 
       expect(result).toBe(4);
@@ -278,7 +373,7 @@ describe('MANIPULATE', () => {
     });
 
     it('should return difference in days. Result should be 0 if difference is less then 24h', () => {
-      const otherDate = new Date('2021-11-23T21:00:00.000Z');
+      const otherDate = '2021-11-23T21:00:00.000Z';
       const result = companiDate.diff(otherDate, 'days');
 
       expect(result).toBe(0);
@@ -286,7 +381,7 @@ describe('MANIPULATE', () => {
     });
 
     it('should return difference in positive floated days', () => {
-      const otherDate = new Date('2021-11-22T21:00:00.000Z');
+      const otherDate = '2021-11-22T21:00:00.000Z';
       const result = companiDate.diff(otherDate, 'days', true);
 
       expect(result).toBeGreaterThan(0);
@@ -295,7 +390,7 @@ describe('MANIPULATE', () => {
     });
 
     it('should return difference in negative days', () => {
-      const otherDate = new Date('2021-11-30T10:00:00.000Z');
+      const otherDate = '2021-11-30T10:00:00.000Z';
       const result = companiDate.diff(otherDate, 'days');
 
       expect(result).toBe(-6);
@@ -303,7 +398,7 @@ describe('MANIPULATE', () => {
     });
 
     it('should return difference in negative floated days', () => {
-      const otherDate = new Date('2021-11-30T08:00:00.000Z');
+      const otherDate = '2021-11-30T08:00:00.000Z';
       const result = companiDate.diff(otherDate, 'days', true);
 
       expect(result).toBeLessThan(0);
@@ -364,7 +459,7 @@ describe('_formatMiscToCompaniDate', () => {
     const result = CompaniDatesHelper._formatMiscToCompaniDate(payload);
 
     expect(result instanceof luxon.DateTime).toBe(true);
-    expect(new luxon.DateTime(result).toJSDate()).toEqual(new Date('2021-11-24T07:00:00.000Z'));
+    expect(new luxon.DateTime(result).toUTC().toISO()).toEqual('2021-11-24T07:00:00.000Z');
     sinon.assert.notCalled(now);
     sinon.assert.notCalled(fromJSDate);
     sinon.assert.notCalled(fromISO);
@@ -377,7 +472,7 @@ describe('_formatMiscToCompaniDate', () => {
     const result = CompaniDatesHelper._formatMiscToCompaniDate(payload);
 
     expect(result instanceof luxon.DateTime).toBe(true);
-    expect(new luxon.DateTime(result).toJSDate()).toEqual(new Date('2021-11-24T07:00:00.000Z'));
+    expect(new luxon.DateTime(result).toUTC().toISO()).toEqual('2021-11-24T07:00:00.000Z');
     sinon.assert.calledOnceWithExactly(fromJSDate, payload);
     sinon.assert.notCalled(now);
     sinon.assert.notCalled(fromISO);
@@ -390,7 +485,7 @@ describe('_formatMiscToCompaniDate', () => {
     const result = CompaniDatesHelper._formatMiscToCompaniDate(payload);
 
     expect(result instanceof luxon.DateTime).toBe(true);
-    expect(new luxon.DateTime(result).toJSDate()).toEqual(new Date('2021-11-24T07:00:00.000Z'));
+    expect(new luxon.DateTime(result).toUTC().toISO()).toEqual('2021-11-24T07:00:00.000Z');
     sinon.assert.calledOnceWithExactly(fromISO, payload);
     sinon.assert.notCalled(now);
     sinon.assert.notCalled(fromJSDate);
@@ -419,7 +514,7 @@ describe('_formatMiscToCompaniDate', () => {
     );
 
     expect(result instanceof luxon.DateTime).toBe(true);
-    expect(new luxon.DateTime(result).toJSDate()).toEqual(new Date('2021-11-24T07:00:00.000+03:00'));
+    expect(new luxon.DateTime(result).toUTC().toISO()).toEqual('2021-11-24T04:00:00.000Z');
     sinon.assert.calledOnceWithExactly(
       fromFormat,
       '2021-11-24T07:00:00.000+03:00',
@@ -439,7 +534,7 @@ describe('_formatMiscToCompaniDate', () => {
     );
 
     expect(result instanceof luxon.DateTime).toBe(true);
-    expect(new luxon.DateTime(result).toJSDate()).toEqual(new Date('2021-11-24T07:00:00.000Z'));
+    expect(new luxon.DateTime(result).toUTC().toISO()).toEqual('2021-11-24T07:00:00.000Z');
     sinon.assert.calledOnceWithExactly(
       fromFormat,
       '2021-11-24T07:00:00.000Z',

--- a/tests/unit/helpers/dates/companiDates.test.js
+++ b/tests/unit/helpers/dates/companiDates.test.js
@@ -284,7 +284,7 @@ describe('QUERY', () => {
   });
 });
 
-describe('MANIPULATE #tag', () => {
+describe('MANIPULATE', () => {
   describe('startOf', () => {
     const companiDate = CompaniDatesHelper.CompaniDate('2021-11-19T07:00:00.000Z');
 
@@ -298,14 +298,14 @@ describe('MANIPULATE #tag', () => {
       expect(didNotMutate).toEqual(true);
     });
 
-    it('should return start of day even if unit is plural. NB: it is not best practice', () => {
+    it('should return start of day even if unit is plural. NB: not best practice, TS refuses plural', () => {
       const result = companiDate.startOf('days');
 
       expect(result).toEqual(expect.objectContaining({ _getDate: expect.any(luxon.DateTime) }));
       expect(result._getDate.toUTC().toISO()).toEqual('2021-11-18T23:00:00.000Z');
     });
 
-    it('should return error if invalid argument', () => {
+    it('should return error if invalid unit', () => {
       try {
         companiDate.startOf('jour');
       } catch (e) {
@@ -327,14 +327,14 @@ describe('MANIPULATE #tag', () => {
       expect(didNotMutate).toEqual(true);
     });
 
-    it('should return end of month even if unit is plural. NB: it is not best practice', () => {
+    it('should return end of month even if unit is plural. NB: not best practice, TS refuses plural', () => {
       const result = companiDate.endOf('months');
 
       expect(result).toEqual(expect.objectContaining({ _getDate: expect.any(luxon.DateTime) }));
       expect(result._getDate.toUTC().toISO()).toEqual('2021-11-30T22:59:59.999Z');
     });
 
-    it('should return error if invalid argument', () => {
+    it('should return error if invalid unit', () => {
       try {
         companiDate.endOf('mois');
       } catch (e) {
@@ -346,6 +346,7 @@ describe('MANIPULATE #tag', () => {
   describe('diff', () => {
     let _formatMiscToCompaniDate;
     const companiDate = CompaniDatesHelper.CompaniDate('2021-11-24T10:00:00.000Z');
+    let otherDate = '2021-11-20T10:00:00.000Z';
 
     beforeEach(() => {
       _formatMiscToCompaniDate = sinon.spy(CompaniDatesHelper, '_formatMiscToCompaniDate');
@@ -355,8 +356,15 @@ describe('MANIPULATE #tag', () => {
       _formatMiscToCompaniDate.restore();
     });
 
+    it('should return difference in positive days', () => {
+      const result = companiDate.diff(otherDate, 'days');
+
+      expect(result).toBe(4);
+      sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, otherDate);
+    });
+
     it('should return diff in milliseconds, if no unit specified', () => {
-      const otherDate = '2021-11-24T08:29:48.000Z';
+      otherDate = '2021-11-24T08:29:48.000Z';
       const result = companiDate.diff(otherDate);
       const expectedDiffInMillis = 1 * 60 * 60 * 1000 + 30 * 60 * 1000 + 12 * 1000;
 
@@ -364,16 +372,8 @@ describe('MANIPULATE #tag', () => {
       sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, otherDate);
     });
 
-    it('should return difference in positive days', () => {
-      const otherDate = '2021-11-20T10:00:00.000Z';
-      const result = companiDate.diff(otherDate, 'days');
-
-      expect(result).toBe(4);
-      sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, otherDate);
-    });
-
     it('should return difference in days. Result should be 0 if difference is less then 24h', () => {
-      const otherDate = '2021-11-23T21:00:00.000Z';
+      otherDate = '2021-11-23T21:00:00.000Z';
       const result = companiDate.diff(otherDate, 'days');
 
       expect(result).toBe(0);
@@ -381,7 +381,7 @@ describe('MANIPULATE #tag', () => {
     });
 
     it('should return difference in positive floated days', () => {
-      const otherDate = '2021-11-22T21:00:00.000Z';
+      otherDate = '2021-11-22T21:00:00.000Z';
       const result = companiDate.diff(otherDate, 'days', true);
 
       expect(result).toBeGreaterThan(0);
@@ -390,7 +390,7 @@ describe('MANIPULATE #tag', () => {
     });
 
     it('should return difference in negative days', () => {
-      const otherDate = '2021-11-30T10:00:00.000Z';
+      otherDate = '2021-11-30T10:00:00.000Z';
       const result = companiDate.diff(otherDate, 'days');
 
       expect(result).toBe(-6);
@@ -398,7 +398,7 @@ describe('MANIPULATE #tag', () => {
     });
 
     it('should return difference in negative floated days', () => {
-      const otherDate = '2021-11-30T08:00:00.000Z';
+      otherDate = '2021-11-30T08:00:00.000Z';
       const result = companiDate.diff(otherDate, 'days', true);
 
       expect(result).toBeLessThan(0);
@@ -406,13 +406,23 @@ describe('MANIPULATE #tag', () => {
       sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, otherDate);
     });
 
-    it('should return error if invalid argument', () => {
+    it('should return error if invalid otherDate', () => {
       try {
         companiDate.diff(null, 'days', true);
       } catch (e) {
         expect(e).toEqual(new Error('Invalid DateTime: wrong arguments'));
       } finally {
         sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, null);
+      }
+    });
+
+    it('should return error if invalid unit', () => {
+      try {
+        companiDate.diff(otherDate, 'jour', true);
+      } catch (e) {
+        expect(e).toEqual(new Error('Invalid unit jour'));
+      } finally {
+        sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, otherDate);
       }
     });
   });

--- a/tests/unit/helpers/dates/companiDates.test.js
+++ b/tests/unit/helpers/dates/companiDates.test.js
@@ -22,6 +22,7 @@ describe('CompaniDate', () => {
     expect(result)
       .toEqual(expect.objectContaining({
         _getDate: expect.any(luxon.DateTime),
+        getUnits: expect.any(Function),
         format: expect.any(Function),
         toDate: expect.any(Function),
         toISO: expect.any(Function),
@@ -33,6 +34,7 @@ describe('CompaniDate', () => {
         endOf: expect.any(Function),
         diff: expect.any(Function),
         add: expect.any(Function),
+        set: expect.any(Function),
       }));
     sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, date);
   });
@@ -45,6 +47,24 @@ describe('CompaniDate', () => {
     } finally {
       sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, null);
     }
+  });
+});
+
+describe('GETTER', () => {
+  describe('getUnits', () => {
+    const companiDate = CompaniDatesHelper.CompaniDate('2021-11-24T07:12:08.000Z');
+
+    it('should return units', () => {
+      const result = companiDate.getUnits(['day', 'second']);
+
+      expect(result).toEqual({ day: 24, second: 8 });
+    });
+
+    it('should return empty if unit is plural', () => {
+      const result = companiDate.getUnits(['days']);
+
+      expect(result).toEqual({});
+    });
   });
 });
 
@@ -451,6 +471,25 @@ describe('MANIPULATE', () => {
         companiDate.add(11111);
       } catch (e) {
         expect(e).toEqual(new Error('Invalid argument: expected to be an object, got number'));
+      }
+    });
+  });
+
+  describe('set', () => {
+    const companiDate = CompaniDatesHelper.CompaniDate('2021-12-20T07:00:00.000Z');
+
+    it('should return a newly constructed companiDate, updated by input', () => {
+      const result = companiDate.set({ month: 11, hour: 3, millisecond: 400 });
+
+      expect(result).toEqual(expect.objectContaining({ _getDate: expect.any(luxon.DateTime) }));
+      expect(result._getDate.toUTC().toISO()).toEqual('2021-11-20T02:00:00.400Z');
+    });
+
+    it('should return error if unit is plural', () => {
+      try {
+        companiDate.set({ day: 1, hours: 2 });
+      } catch (e) {
+        expect(e).toEqual(new Error('Invalid unit hours'));
       }
     });
   });

--- a/tests/unit/helpers/dates/companiDates.test.js
+++ b/tests/unit/helpers/dates/companiDates.test.js
@@ -121,7 +121,6 @@ describe('DISPLAY', () => {
 describe('QUERY', () => {
   describe('isBefore', () => {
     let _formatMiscToCompaniDate;
-    let otherDate = '2021-11-01T10:00:00.000Z';
     const companiDate = CompaniDatesHelper.CompaniDate('2021-11-01T07:00:00.000Z');
 
     beforeEach(() => {
@@ -133,6 +132,7 @@ describe('QUERY', () => {
     });
 
     it('should return true if date is before other date', () => {
+      const otherDate = '2021-11-01T10:00:00.000Z';
       const result = companiDate.isBefore(otherDate);
 
       expect(result).toBe(true);
@@ -140,7 +140,7 @@ describe('QUERY', () => {
     });
 
     it('should return false is date is not before other date', () => {
-      otherDate = '2021-11-01T05:00:00.000Z';
+      const otherDate = '2021-11-01T05:00:00.000Z';
       const result = companiDate.isBefore(otherDate);
 
       expect(result).toBe(false);
@@ -160,7 +160,6 @@ describe('QUERY', () => {
 
   describe('isAfter', () => {
     let _formatMiscToCompaniDate;
-    let otherDate = '2021-11-01T05:00:00.000Z';
     const companiDate = CompaniDatesHelper.CompaniDate('2021-11-01T07:00:00.000Z');
 
     beforeEach(() => {
@@ -172,6 +171,7 @@ describe('QUERY', () => {
     });
 
     it('should return true if date is after other date', () => {
+      const otherDate = '2021-11-01T05:00:00.000Z';
       const result = companiDate.isAfter(otherDate);
 
       expect(result).toBe(true);
@@ -179,7 +179,7 @@ describe('QUERY', () => {
     });
 
     it('should return false is date is not after other date', () => {
-      otherDate = '2021-11-01T10:00:00.000Z';
+      const otherDate = '2021-11-01T10:00:00.000Z';
       const result = companiDate.isAfter(otherDate);
 
       expect(result).toBe(false);
@@ -248,7 +248,6 @@ describe('QUERY', () => {
   describe('isSameOrBefore', () => {
     let _formatMiscToCompaniDate;
     const companiDate = CompaniDatesHelper.CompaniDate('2021-11-24T07:00:00.000Z');
-    let otherDate = '2021-11-25T10:00:00.000Z';
 
     beforeEach(() => {
       _formatMiscToCompaniDate = sinon.spy(CompaniDatesHelper, '_formatMiscToCompaniDate');
@@ -259,7 +258,7 @@ describe('QUERY', () => {
     });
 
     it('should return true if same moment', () => {
-      otherDate = '2021-11-24T07:00:00.000Z';
+      const otherDate = '2021-11-24T07:00:00.000Z';
 
       const result = companiDate.isSameOrBefore(otherDate);
 
@@ -268,6 +267,7 @@ describe('QUERY', () => {
     });
 
     it('should return true if before', () => {
+      const otherDate = '2021-11-25T10:00:00.000Z';
       const result = companiDate.isSameOrBefore(otherDate);
 
       expect(result).toBe(true);
@@ -275,7 +275,7 @@ describe('QUERY', () => {
     });
 
     it('should return true if after but same as specified unit', () => {
-      otherDate = '2021-11-24T06:00:00.000Z';
+      const otherDate = '2021-11-24T06:00:00.000Z';
 
       const result = companiDate.isSameOrBefore(otherDate, 'day');
 
@@ -284,7 +284,7 @@ describe('QUERY', () => {
     });
 
     it('should return false if after', () => {
-      otherDate = '2021-11-23T10:00:00.000Z';
+      const otherDate = '2021-11-23T10:00:00.000Z';
 
       const result = companiDate.isSameOrBefore(otherDate);
 
@@ -293,7 +293,7 @@ describe('QUERY', () => {
     });
 
     it('should return false if after specified unit', () => {
-      otherDate = '2021-11-24T06:00:00.000Z';
+      const otherDate = '2021-11-24T06:00:00.000Z';
 
       const result = companiDate.isSameOrBefore(otherDate, 'minute');
 
@@ -312,6 +312,7 @@ describe('QUERY', () => {
     });
 
     it('should return error if unit is plural', () => {
+      const otherDate = '2021-11-24T06:00:00.000Z';
       try {
         companiDate.isSame(otherDate, 'minutes');
       } catch (e) {
@@ -385,7 +386,6 @@ describe('MANIPULATE', () => {
   describe('diff', () => {
     let _formatMiscToCompaniDate;
     const companiDate = CompaniDatesHelper.CompaniDate('2021-11-24T10:00:00.000Z');
-    let otherDate = '2021-11-20T10:00:00.000Z';
 
     beforeEach(() => {
       _formatMiscToCompaniDate = sinon.spy(CompaniDatesHelper, '_formatMiscToCompaniDate');
@@ -396,6 +396,7 @@ describe('MANIPULATE', () => {
     });
 
     it('should return difference in positive days', () => {
+      const otherDate = '2021-11-20T10:00:00.000Z';
       const result = companiDate.diff(otherDate, 'days');
 
       expect(result).toBe(4);
@@ -403,7 +404,7 @@ describe('MANIPULATE', () => {
     });
 
     it('should return diff in milliseconds, if no unit specified', () => {
-      otherDate = '2021-11-24T08:29:48.000Z';
+      const otherDate = '2021-11-24T08:29:48.000Z';
       const result = companiDate.diff(otherDate);
       const expectedDiffInMillis = 1 * 60 * 60 * 1000 + 30 * 60 * 1000 + 12 * 1000;
 
@@ -412,7 +413,7 @@ describe('MANIPULATE', () => {
     });
 
     it('should return difference in days. Result should be 0 if difference is less then 24h', () => {
-      otherDate = '2021-11-23T21:00:00.000Z';
+      const otherDate = '2021-11-23T21:00:00.000Z';
       const result = companiDate.diff(otherDate, 'days');
 
       expect(result).toBe(0);
@@ -420,7 +421,7 @@ describe('MANIPULATE', () => {
     });
 
     it('should return difference in positive floated days', () => {
-      otherDate = '2021-11-22T21:00:00.000Z';
+      const otherDate = '2021-11-22T21:00:00.000Z';
       const result = companiDate.diff(otherDate, 'days', true);
 
       expect(result).toBeGreaterThan(0);
@@ -429,7 +430,7 @@ describe('MANIPULATE', () => {
     });
 
     it('should return difference in negative days', () => {
-      otherDate = '2021-11-30T10:00:00.000Z';
+      const otherDate = '2021-11-30T10:00:00.000Z';
       const result = companiDate.diff(otherDate, 'days');
 
       expect(result).toBe(-6);
@@ -437,7 +438,7 @@ describe('MANIPULATE', () => {
     });
 
     it('should return difference in negative floated days', () => {
-      otherDate = '2021-11-30T08:00:00.000Z';
+      const otherDate = '2021-11-30T08:00:00.000Z';
       const result = companiDate.diff(otherDate, 'days', true);
 
       expect(result).toBeLessThan(0);
@@ -456,6 +457,7 @@ describe('MANIPULATE', () => {
     });
 
     it('should return error if invalid unit', () => {
+      const otherDate = '2021-11-30T08:00:00.000Z';
       try {
         companiDate.diff(otherDate, 'jour', true);
       } catch (e) {


### PR DESCRIPTION
|  |  | TESTS  :computer: | |
|----------|----------|----------|----------|
| <ul><li>[x] oui </li></ul> | <ul><li>[ ] non</li></ul> | J'ai codé les tests unitaires
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | J'ai codé les tests d'intégration
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | C'est une ancienne route utilisée par les apps mobiles. | <ul><li>[ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens</li></ul>

---

|  |  | POINTS D'ATTENTION POUR CETTE PR  :warning:  | |
|----------|----------|----------|----------|
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | J'ai fait des modifications sur une route utilisée sur plusieurs plateformes | [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/n3bq2hr9Ia)
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | J'ai modifié un modèle utilisé en mobile | [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/rqTfwpUib)
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | J'ai ajouté un modèle spécifique à une structure | <ul><li>[ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés</li></ul>
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile |  <ul><li>[ ] Si oui, j'ai précisé sur le [slite de MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) qu'il faut forcer la mise à jour</li></ul>
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | J'ai ajouté une variable d'environnement | <ul><li>[ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites</li></ul>

---

|  |  |  FONCTIONNALITÉS APPS MOBILES  :iphone: | |
|----------|----------|----------|----------|
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | Mes changements impactent l'application formation | <ul><li>[ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours</li></ul>
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | Mes changements impactent l'application erp | <ul><li>[ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours</li></ul>

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : pas pertinant

### Les unités sur luxon  : 

Les unités de luxon apparaissent parfois au pluriel et parfois au singulier…

Il faut séparer les unités de date des unités de durée. Pourtant ce sont les même noms en français: 
  - prenons la date 02/01/2022 à 14:23
	- le jour de cette date est 02 (jour: 02)
	- l’heure est 14 (heure: 14)

  - prenons maintenant une durée de 1 jour, 2 heures et 6 minutes
	- on peut exprimer cette grandeur en jour : (jours: 1.0875)
	- on peut dire que c’est 1 jour et 126 minutes (jour: 1, minutes: 126) et pq pas (jours: 1, minutes: 126)

On voit bien qu’on utilise les même mots français pour designer deux choses bien différentes.

Maintenant venons en a luxon :
	- les unités de dates sont au singulier 
		- a noter que parfois (pour startOf par exemple) TS n’accepte pas le pluriel, mais luxon ne renvoie pas d’erreur
	 	alors que d’autre fois (pour hasSame) TS et  luxon renvoient une erreur si l’unité est pluriel (cf test unitaire de cette PR)
	- les unités de durées sont au singulier OU au pluriels.

Sur CompaniDate, je propose d'ecrire les unités de durées au pluriel pour bien distinguer les deux.


### Un point sur ma PR : 

  - j’ai viré les new Date pas utile
  - j’ai renommé le getter pour éviter la confusion avec la variable _date
  - j’ai enlevé la possibilité de créer une companiDate a partir d’une date luxons
  - j’ai ajouté des tests sur les unités entrées en argument 
  - pour les assertions sur la valeur d’une companiDate, je n’utilise pas les méthodes CompaniDate. Je recupere _date (avec _getDate) et je fais mes tests avec les méthodes de luxons
  - sur la fct add, j’envoie une erreur si on essaie de créer une durée a partir d’un Number. On s’est donné comme bonne pratique de prendre en entré un objet { unité: valeur }. Le message d’erreur est inspiré de celui de luxons quand on fait : console.log(luxon.Duration.fromObject(4)). Le risque c’est de recréer un genre de TS avec des if a n’en plus finir, mais ici j’ai trouvé que c’était adapté


Si tu as lu cette description, pense a réagir avec un :eye:
