### PR TITLE
COM-2579: sinonMongoose

### DIFF
--- a/tests/unit/helpers/123Paie/absences.test.js
+++ b/tests/unit/helpers/123Paie/absences.test.js
@@ -46,7 +46,7 @@ describe('getAbsences', () => {
     const result = await Absences123PayHelper.getAbsences(query, { company: { _id: companyId } });
 
     expect(result).toEqual(absences);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findPay,
       [
         { query: 'find', args: [{ date: { $gte: moment('2020-10-01T00:00:00').toDate() }, company: companyId }] },
@@ -55,7 +55,7 @@ describe('getAbsences', () => {
         { query: 'lean' },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findEvent,
       [
         {
@@ -94,7 +94,7 @@ describe('getAbsences', () => {
     const result = await Absences123PayHelper.getAbsences(query, { company: { _id: companyId } });
 
     expect(result).toEqual(absences);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findPay,
       [
         { query: 'find', args: [{ date: { $gte: moment('2020-10-01T00:00:00').toDate() }, company: companyId }] },
@@ -103,7 +103,7 @@ describe('getAbsences', () => {
         { query: 'lean' },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findEvent,
       [
         {

--- a/tests/unit/helpers/123Paie/contracts.test.js
+++ b/tests/unit/helpers/123Paie/contracts.test.js
@@ -61,7 +61,7 @@ describe('exportsContractVersions', () => {
         ['ap_soc', 'userNumber', 'Gallier', 'titotu', '02/11/2020', 26, 260],
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findContract,
       [
         { query: 'find', args: [{ $and: [{ endDate: null }, { endDate: { $exists: false } }] }] },
@@ -115,7 +115,7 @@ describe('exportContractEnds', () => {
         ['ap_soc', 'userNumber', 'Gallier', 'titotu', '07/11/2020', 16],
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findContract,
       [
         {

--- a/tests/unit/helpers/123Paie/identification.test.js
+++ b/tests/unit/helpers/123Paie/identification.test.js
@@ -197,7 +197,7 @@ describe('exportDpae', () => {
       exportToTxt,
       [['ap_matr', 'fs_bq_dom', 'ap_contrat'], ['serialNumber', 'BANK AUDI FRANCE', '1234567890']]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneUser,
       [
         {
@@ -248,7 +248,7 @@ describe('exportIdentification', () => {
     sinon.assert.calledWithExactly(formatBankingInfo.getCall(0), 'first user');
     sinon.assert.calledWithExactly(formatBankingInfo.getCall(1), 'second user');
     sinon.assert.calledOnceWithExactly(exportToTxt, [['identity', 'bank'], [1, 1], [2, 2]]);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findContract,
       [
         {

--- a/tests/unit/helpers/123Paie/pay.test.js
+++ b/tests/unit/helpers/123Paie/pay.test.js
@@ -107,7 +107,7 @@ describe('exportPay', () => {
         ['ap_soc', 'serialNumber', 'good_contract', 'T', '489', 'Frais kilométriques', '', 0, ''],
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findPay,
       [
         { query: 'find', args: [{ month: '03-2021', company: companyId }] },
@@ -210,7 +210,7 @@ describe('exportPay', () => {
         ['ap_soc', 'serialNumber', 'ended_good_contract', 'T', '489', 'Frais kilométriques', '', 0, ''],
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findPay,
       [
         { query: 'find', args: [{ month: '03-2021', company: companyId }] },

--- a/tests/unit/helpers/activities.test.js
+++ b/tests/unit/helpers/activities.test.js
@@ -40,7 +40,7 @@ describe('getActivity', () => {
       { query: 'lean', args: [{ virtuals: true }] },
     ];
 
-    SinonMongoose.calledWithExactly(findOne, chainedPayload);
+    SinonMongoose.calledOnceWithExactly(findOne, chainedPayload);
     expect(result).toMatchObject({ _id: 'skusku' });
   });
 });
@@ -198,7 +198,7 @@ describe('removeCard', () => {
 
     sinon.assert.calledOnceWithExactly(updateOne, { cards: cardId }, { $pull: { cards: cardId } });
     sinon.assert.notCalled(deleteMedia);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneAndRemoveCard,
       [
         { query: 'findOneAndRemove', args: [{ _id: cardId }, { 'media.publicId': 1 }] },
@@ -217,7 +217,7 @@ describe('removeCard', () => {
 
     sinon.assert.calledOnceWithExactly(updateOne, { cards: cardId }, { $pull: { cards: cardId } });
     sinon.assert.calledOnceWithExactly(deleteMedia, cardId, 'publicId');
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneAndRemoveCard,
       [
         { query: 'findOneAndRemove', args: [{ _id: cardId }, { 'media.publicId': 1 }] },

--- a/tests/unit/helpers/activities.test.js
+++ b/tests/unit/helpers/activities.test.js
@@ -18,7 +18,7 @@ describe('getActivity', () => {
     findOne.restore();
   });
 
-  it('should return the requested activity - with checkSinon and stubChainedQueries', async () => {
+  it('should return the requested activity', async () => {
     findOne.returns(SinonMongoose.stubChainedQueries([{ _id: 'skusku' }]));
 
     const activity = { _id: new ObjectId() };
@@ -26,7 +26,7 @@ describe('getActivity', () => {
     const result = await ActivityHelper.getActivity(activity._id);
 
     const chainedPayload = [
-      { query: '', args: [{ _id: activity._id }] },
+      { query: 'findOne', args: [{ _id: activity._id }] },
       { query: 'populate', args: [{ path: 'cards', select: '-__v -createdAt -updatedAt' }] },
       {
         query: 'populate',

--- a/tests/unit/helpers/activityHistories.test.js
+++ b/tests/unit/helpers/activityHistories.test.js
@@ -95,11 +95,11 @@ describe('list', () => {
     const result = await ActivityHistoryHelper.list(query, { company: { _id: companyId } });
 
     expect(result).toEqual([filteredActivityHistories]);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findUserCompanies,
       [{ query: 'find', args: [{ company: companyId }, { user: 1 }] }, { query: 'lean' }]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findHistories,
       [
         {

--- a/tests/unit/helpers/administrativeDocument.test.js
+++ b/tests/unit/helpers/administrativeDocument.test.js
@@ -52,7 +52,7 @@ describe('createAdministrativeDocument', () => {
       createAdministrativeDocument,
       { company: companyId, name: payload.name, driveFile: { driveId: '12345', link: 'www.12345.fr' } }
     );
-    SinonMongoose.calledWithExactly(findByIdCompany, [{ query: 'findById', args: [companyId] }, { query: 'lean' }]);
+    SinonMongoose.calledOnceWithExactly(findByIdCompany, [{ query: 'findById', args: [companyId] }, { query: 'lean' }]);
   });
 
   it('should return an error if uploaded file is not defined', async () => {
@@ -70,7 +70,10 @@ describe('createAdministrativeDocument', () => {
       );
       sinon.assert.notCalled(createPermissionStub);
       sinon.assert.notCalled(createAdministrativeDocument);
-      SinonMongoose.calledWithExactly(findByIdCompany, [{ query: 'findById', args: [companyId] }, { query: 'lean' }]);
+      SinonMongoose.calledOnceWithExactly(
+        findByIdCompany,
+        [{ query: 'findById', args: [companyId] }, { query: 'lean' }]
+      );
     }
   });
 });
@@ -96,7 +99,7 @@ describe('listAdministrativeDocuments', () => {
     const res = await AdministrativeDocumentHelper.listAdministrativeDocuments(credentials);
 
     expect(res).toEqual(administrativeDocuments);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findAdministrativeDocument,
       [{ query: 'find', args: [{ company: companyId }] }, { query: 'lean' }]
     );
@@ -125,7 +128,7 @@ describe('removeAdministrativeDocument', () => {
     await AdministrativeDocumentHelper.removeAdministrativeDocument(administrativeDocumentId);
 
     sinon.assert.calledWithExactly(deleteFileStub, '1234');
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneAndDelete,
       [{ query: 'findOneAndDelete', args: [{ _id: administrativeDocumentId }] }, { query: 'lean' }]
     );

--- a/tests/unit/helpers/attendanceSheets.test.js
+++ b/tests/unit/helpers/attendanceSheets.test.js
@@ -122,7 +122,7 @@ describe('create', () => {
     SinonMongoose.calledOnceWithExactly(
       findOne,
       [
-        { query: '', args: [{ _id: 'id de quelqun' }, { identity: 1 }] },
+        { query: 'findOne', args: [{ _id: 'id de quelqun' }, { identity: 1 }] },
         { query: 'lean' },
       ]
     );

--- a/tests/unit/helpers/attendanceSheets.test.js
+++ b/tests/unit/helpers/attendanceSheets.test.js
@@ -30,7 +30,7 @@ describe('list', () => {
     const result = await attendanceSheetHelper.list(courseId, null);
 
     expect(result).toMatchObject(attendanceSheets);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       find,
       [
         { query: 'find', args: [{ course: courseId }] },
@@ -62,7 +62,7 @@ describe('list', () => {
     const result = await attendanceSheetHelper.list(courseId, authCompanyId);
 
     expect(result).toMatchObject([attendanceSheets[0]]);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       find,
       [
         { query: 'find', args: [{ course: courseId }] },
@@ -119,7 +119,7 @@ describe('create', () => {
     formatIdentity.returns('monsieurPATATE');
 
     await attendanceSheetHelper.create(payload);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [
         { query: '', args: [{ _id: 'id de quelqun' }, { identity: 1 }] },

--- a/tests/unit/helpers/attendances.test.js
+++ b/tests/unit/helpers/attendances.test.js
@@ -43,7 +43,7 @@ describe('list', () => {
     const result = await AttendanceHelper.list([courseSlots], null);
 
     expect(result).toMatchObject(attendancesList);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       find,
       [
         { query: 'find', args: [{ courseSlot: { $in: [courseSlots] } }] },
@@ -67,7 +67,7 @@ describe('list', () => {
     const result = await AttendanceHelper.list([courseSlots], companyId);
 
     expect(result).toMatchObject([attendancesList[0]]);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       find,
       [
         { query: 'find', args: [{ courseSlot: { $in: [courseSlots] } }] },

--- a/tests/unit/helpers/authentication.test.js
+++ b/tests/unit/helpers/authentication.test.js
@@ -61,7 +61,7 @@ describe('authenticate', () => {
       refreshToken: 'refreshToken',
       user: { _id: user._id.toHexString() },
     });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [
         { query: 'findOne', args: [{ 'local.email': 'toto@email.com' }] },
@@ -95,7 +95,7 @@ describe('authenticate', () => {
       refreshToken: 'refreshToken',
       user: { _id: user._id.toHexString() },
     });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [
         { query: 'findOne', args: [{ 'local.email': payload.email.toLowerCase() }] },
@@ -131,7 +131,7 @@ describe('authenticate', () => {
       refreshToken: 'refreshToken',
       user: { _id: user._id.toHexString() },
     });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [
         { query: 'findOne', args: [{ 'local.email': payload.email.toLowerCase() }] },
@@ -156,7 +156,7 @@ describe('authenticate', () => {
     } catch (e) {
       expect(e.output.statusCode).toEqual(401);
     } finally {
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         findOne,
         [
           { query: 'findOne', args: [{ 'local.email': payload.email.toLowerCase() }] },
@@ -181,7 +181,7 @@ describe('authenticate', () => {
     } catch (e) {
       expect(e.output.statusCode).toEqual(401);
     } finally {
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         findOne,
         [
           { query: 'findOne', args: [{ 'local.email': payload.email.toLowerCase() }] },
@@ -211,7 +211,7 @@ describe('authenticate', () => {
     } catch (e) {
       expect(e.output.statusCode).toEqual(401);
     } finally {
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         findOne,
         [
           { query: 'findOne', args: [{ 'local.email': 'toto@email.com' }] },
@@ -251,7 +251,7 @@ describe('refreshToken', () => {
     } catch (e) {
       expect(e).toEqual(Boom.unauthorized());
     } finally {
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         findOne,
         [{ query: 'findOne', args: [{ refreshToken: 'refreshToken' }] }, { query: 'lean' }]
       );
@@ -274,7 +274,7 @@ describe('refreshToken', () => {
       refreshToken: 'refreshToken',
       user: { _id: user._id.toHexString() },
     });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [{ query: 'findOne', args: [{ refreshToken: 'refreshToken' }] }, { query: 'lean' }]
     );
@@ -304,7 +304,7 @@ describe('updatePassword', () => {
     const result = await AuthenticationHelper.updatePassword(userId, payload);
 
     expect(result).toEqual({ _id: userId, local: { password: '123456!eR' } });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneAndUpdate,
       [
         {
@@ -373,7 +373,7 @@ describe('checkPasswordToken', () => {
     } catch (e) {
       expect(e).toEqual(Boom.notFound(translate[language].userNotFound));
     } finally {
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         userFindOne,
         [
           { query: 'findOne', args: [flat(filter, { maxDepth: 2 })] },
@@ -400,11 +400,11 @@ describe('checkPasswordToken', () => {
 
     const result = await AuthenticationHelper.checkPasswordToken(token, email);
     expect(result).toEqual({ token: '1234567890', user: userPayload });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       identityVerificationFindOne,
       [{ query: 'findOne', args: [{ email, code: token }] }, { query: 'lean' }]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       userFindOne,
       [
         { query: 'findOne', args: [{ 'local.email': email }] },
@@ -427,7 +427,7 @@ describe('checkPasswordToken', () => {
     } catch (e) {
       expect(e).toEqual(Boom.notFound());
     } finally {
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         identityVerificationFindOne,
         [{ query: 'findOne', args: [{ email, code: token }] }, { query: 'lean' }]
       );
@@ -448,7 +448,7 @@ describe('checkPasswordToken', () => {
     } catch (e) {
       expect(e).toEqual(Boom.unauthorized());
     } finally {
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         identityVerificationFindOne,
         [{ query: 'findOne', args: [{ email, code: token }] }, { query: 'lean' }]
       );
@@ -469,7 +469,7 @@ describe('checkPasswordToken', () => {
     const result = await AuthenticationHelper.checkPasswordToken('1234567890');
 
     expect(result).toEqual({ token: '1234567890', user: userPayload });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       userFindOne,
       [
         { query: 'findOne', args: [flat(filter, { maxDepth: 2 })] },
@@ -566,7 +566,7 @@ describe('forgotPassword', () => {
     sinon.assert.notCalled(generatePasswordTokenStub);
     sinon.assert.notCalled(sendVerificationCodeSms);
     sinon.assert.calledOnceWithExactly(identityVerificationCreate, { email, code: '1999' });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       identityVerificationFindOneAndUpdate,
       [{ query: 'findOneAndUpdate', args: [{ email }, { $set: { code: '1999' } }, { new: true }] }]
     );
@@ -588,7 +588,7 @@ describe('forgotPassword', () => {
     sinon.assert.notCalled(identityVerificationCreate);
     sinon.assert.notCalled(userFindOne);
     sinon.assert.notCalled(sendVerificationCodeSms);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       identityVerificationFindOneAndUpdate,
       [{ query: 'findOneAndUpdate', args: [{ email }, { $set: { code: '1999' } }, { new: true }] }]
     );
@@ -611,11 +611,11 @@ describe('forgotPassword', () => {
     sinon.assert.notCalled(generatePasswordTokenStub);
     sinon.assert.notCalled(identityVerificationCreate);
     sinon.assert.calledOnceWithExactly(sendVerificationCodeSms, '0687654321', '1999');
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       identityVerificationFindOneAndUpdate,
       [{ query: 'findOneAndUpdate', args: [{ email }, { $set: { code: '1999' } }, { new: true }] }]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       userFindOne,
       [{ query: 'findOne', args: [{ 'local.email': 'toto@toto.com' }, { 'contact.phone': 1 }] }, { query: 'lean' }]
     );
@@ -635,7 +635,7 @@ describe('forgotPassword', () => {
     } catch (e) {
       expect(e.output.statusCode).toEqual(409);
     } finally {
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         userFindOne,
         [{ query: 'findOne', args: [{ 'local.email': 'toto@toto.com' }, { 'contact.phone': 1 }] }, { query: 'lean' }]
       );
@@ -665,7 +665,7 @@ describe('generatePasswordToken', () => {
     } catch (e) {
       expect(e).toEqual(Boom.notFound(translate[language].userNotFound));
     } finally {
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         findOneAndUpdate,
         [
           {
@@ -694,7 +694,7 @@ describe('generatePasswordToken', () => {
     const result = await AuthenticationHelper.generatePasswordToken('toto@toto.com', 3600000);
 
     expect(result).toEqual({ token: expect.any(String), expiresIn: date.getTime() + 3600000 });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneAndUpdate,
       [
         {

--- a/tests/unit/helpers/authorization.test.js
+++ b/tests/unit/helpers/authorization.test.js
@@ -40,7 +40,7 @@ describe('validate', () => {
         company: null,
       },
     });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findById,
       [
         { query: 'findById', args: [userId, '_id identity role local'] },
@@ -109,7 +109,7 @@ describe('validate', () => {
         role: { client: { name: 'client_admin' }, vendor: { name: 'vendor_admin' } },
       },
     });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findById,
       [
         { query: 'findById', args: [userId, '_id identity role local'] },
@@ -191,7 +191,7 @@ describe('validate', () => {
         role: { client: { name: 'client_admin' } },
       },
     });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findById,
       [
         { query: 'findById', args: [userId, '_id identity role local'] },
@@ -233,7 +233,7 @@ describe('validate', () => {
         role: { client: { name: 'helper' } },
       },
     });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findById,
       [
         { query: 'findById', args: [userId, '_id identity role local'] },
@@ -273,7 +273,7 @@ describe('validate', () => {
         role: { client: { name: AUXILIARY_WITHOUT_COMPANY } },
       },
     });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findById,
       [
         { query: 'findById', args: [userId, '_id identity role local'] },
@@ -352,7 +352,7 @@ describe('validate', () => {
         role: { client: { name: 'coach' }, vendor: { name: 'trainer' } },
       },
     });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findById,
       [
         { query: 'findById', args: [userId, '_id identity role local'] },

--- a/tests/unit/helpers/balances.test.js
+++ b/tests/unit/helpers/balances.test.js
@@ -732,7 +732,7 @@ describe('getBalances', () => {
       nonArchivedCustomers,
       maxDate
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findThirdPartyPayer,
       [{ query: 'find', args: [{ company: credentials.company._id }] }, { query: 'lean' }]
     );

--- a/tests/unit/helpers/billSlips.test.js
+++ b/tests/unit/helpers/billSlips.test.js
@@ -107,7 +107,7 @@ describe('getBillSlipNumber', () => {
 
     expect(result).toEqual('1234567890');
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneAndUpdate,
       [
         {
@@ -159,7 +159,7 @@ describe('createBillSlips', () => {
     sinon.assert.notCalled(formatBillSlipNumber);
     sinon.assert.notCalled(updateOneBillSlipNumber);
     sinon.assert.notCalled(insertManyBillSlip);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findBillSlip,
       [
         {
@@ -204,7 +204,7 @@ describe('createBillSlips', () => {
         { company: company._id, month: '09-2019', thirdPartyPayer: thirdPartyPayer2, number: 'BORD-129ASD00013' },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findBillSlip,
       [
         {
@@ -247,7 +247,7 @@ describe('createBillSlips', () => {
         { company: company._id, month: '09-2019', thirdPartyPayer: thirdPartyPayer2, number: 'BORD-129ASD00013' },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findBillSlip,
       [
         {
@@ -576,7 +576,7 @@ describe('generateFile', () => {
       path.join(process.cwd(), 'src/data/billSlip.docx'),
       billSlipData
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findByIdBillSlip,
       [
         { query: 'findById', args: [billSlip._id] },

--- a/tests/unit/helpers/bills.test.js
+++ b/tests/unit/helpers/bills.test.js
@@ -1261,7 +1261,7 @@ describe('getBillNumber', () => {
 
     const result = await BillHelper.getBillNumber(new Date('2019-11-15'), companyId);
     expect(result).toEqual(billNumber);
-    SinonMongoose.calledWithExactly(findOneAndUpdateBillNumber, [
+    SinonMongoose.calledOnceWithExactly(findOneAndUpdateBillNumber, [
       {
         query: 'findOneAndUpdate',
         args: [{ prefix, company: companyId }, {}, { new: true, upsert: true, setDefaultsOnInsert: true }],
@@ -1852,7 +1852,7 @@ describe('list', () => {
 
     await BillHelper.list(query, credentials);
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findBill,
       [
         { query: 'find', args: [{ type: 'manual', company: authCompanyId }] },
@@ -1938,7 +1938,7 @@ describe('formatAndCreateBill', () => {
 
     sinon.assert.calledOnceWithExactly(getBillNumber, '2021-09-01', companyId);
     sinon.assert.calledOnceWithExactly(formatBillNumber, '101', 'FACT-101', 1);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findBillingItem,
       [
         { query: 'find', args: [{ _id: { $in: [billingItemId1, billingItemId2] } }, { vat: 1, name: 1 }] },
@@ -1998,7 +1998,7 @@ describe('getBills', () => {
 
     expect(result).toEqual(bills);
     sinon.assert.notCalled(getDateQueryStub);
-    SinonMongoose.calledWithExactly(findBill, [
+    SinonMongoose.calledOnceWithExactly(findBill, [
       { query: 'find', args: [{ company: credentials.company._id }] },
       { query: 'populate', args: [{ path: 'thirdPartyPayer', select: '_id name' }] },
       { query: 'lean' },
@@ -2015,7 +2015,7 @@ describe('getBills', () => {
     const result = await BillHelper.getBills(query, credentials);
 
     expect(result).toEqual(bills);
-    SinonMongoose.calledWithExactly(findBill, [
+    SinonMongoose.calledOnceWithExactly(findBill, [
       { query: 'find', args: [{ company: credentials.company._id, date: dateQuery }] },
       { query: 'populate', args: [{ path: 'thirdPartyPayer', select: '_id name' }] },
       { query: 'lean' },
@@ -2033,7 +2033,7 @@ describe('getBills', () => {
     const result = await BillHelper.getBills(query, credentials);
 
     expect(result).toEqual(bills);
-    SinonMongoose.calledWithExactly(findBill, [
+    SinonMongoose.calledOnceWithExactly(findBill, [
       { query: 'find', args: [{ company: credentials.company._id, date: dateQuery }] },
       { query: 'populate', args: [{ path: 'thirdPartyPayer', select: '_id name' }] },
       { query: 'lean' },
@@ -2553,14 +2553,14 @@ describe('generateBillPdf', async () => {
     sinon.assert.calledWithExactly(formatPdf, bill, credentials.company);
     sinon.assert.calledWithExactly(generatePdf, { content: [{ text: 'data' }] });
     sinon.assert.calledOnceWithExactly(getPdfContent, { data: 'data' });
-    SinonMongoose.calledWithExactly(findOneBill, [
+    SinonMongoose.calledOnceWithExactly(findOneBill, [
       { query: 'findOne', args: [{ _id: bill._id, origin: 'compani' }] },
       { query: 'populate', args: [{ path: 'thirdPartyPayer', select: '_id name address' }] },
       { query: 'populate', args: [{ path: 'customer', select: '_id identity contact fundings' }] },
       { query: 'populate', args: [{ path: 'subscriptions.events.auxiliary', select: 'identity' }] },
       { query: 'lean' },
     ]);
-    SinonMongoose.calledWithExactly(findOneCompany, [
+    SinonMongoose.calledOnceWithExactly(findOneCompany, [
       { query: 'findOne', args: [{ _id: companyId }] },
       { query: 'lean' },
     ]);

--- a/tests/unit/helpers/categories.test.js
+++ b/tests/unit/helpers/categories.test.js
@@ -39,7 +39,7 @@ describe('list', () => {
     const result = await CategoryHelper.list();
 
     expect(result).toMatchObject(categoriesList);
-    SinonMongoose.calledWithExactly(list, [
+    SinonMongoose.calledOnceWithExactly(list, [
       { query: 'find' },
       { query: 'populate', args: [{ path: 'programsCount' }] },
       { query: 'lean' },

--- a/tests/unit/helpers/companies.test.js
+++ b/tests/unit/helpers/companies.test.js
@@ -53,7 +53,7 @@ describe('createCompany', () => {
     sinon.assert.calledWithExactly(createFolderStub.getCall(1), 'customers', '1234567890');
     sinon.assert.calledWithExactly(createFolderStub.getCall(2), 'auxiliaries', '1234567890');
     sinon.assert.calledOnceWithExactly(createCompany, { ...createdCompany, prefixNumber: 346 });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       find,
       [
         { query: 'find' },
@@ -81,7 +81,7 @@ describe('list', () => {
     const result = await CompanyHelper.list();
 
     expect(result).toEqual(companyList);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       find,
       [{ query: 'find', args: [{}, { _id: 1, name: 1 }] }, { query: 'lean', args: [] }]
     );
@@ -104,7 +104,7 @@ describe('getCompany', () => {
     const result = await CompanyHelper.getCompany(company._id);
 
     expect(result).toEqual(company);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [{ query: 'findOne', args: [{ _id: company._id }] }, { query: 'lean', args: [] }]
     );
@@ -151,7 +151,7 @@ describe('uploadFile', () => {
       type: undefined,
     });
     sinon.assert.calledWithExactly(getFileByIdStub, { fileId: uploadedFile.id });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneAndUpdate,
       [
         { query: 'findOneAndUpdate', args: [{ _id: params._id }, { $set: flat(companyPayload) }, { new: true }] },
@@ -178,7 +178,7 @@ describe('getFirstIntervention', () => {
 
     expect(result).toBeDefined();
     expect(result).toEqual([{ startDate: '2019-11-12' }]);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       find,
       [
         { query: 'find', args: [{ company: credentials.company._id, type: INTERVENTION }] },

--- a/tests/unit/helpers/companyLinkRequests.test.js
+++ b/tests/unit/helpers/companyLinkRequests.test.js
@@ -47,7 +47,7 @@ describe('list', () => {
 
     expect(result).toEqual(companyLinkRequestList);
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       find,
       [
         { query: 'find', args: [{ company: companyId }] },

--- a/tests/unit/helpers/contracts.test.js
+++ b/tests/unit/helpers/contracts.test.js
@@ -41,7 +41,7 @@ describe('getContractList', () => {
     const result = await ContractHelper.getContractList(query, credentials);
 
     expect(result).toEqual(contracts);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findContract,
       [
         { query: 'find', args: [{ $and: [{ company: '1234567890' }, { user: '1234567890' }] }] },
@@ -67,7 +67,7 @@ describe('getContractList', () => {
     const result = await ContractHelper.getContractList(query, credentials);
 
     expect(result).toEqual(contracts);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findContract,
       [
         {
@@ -266,14 +266,14 @@ describe('createContract', () => {
       { _id: payload.user },
       { $push: { contracts: payload._id }, $unset: { inactivityDate: '' }, $set: { 'role.client': role._id } }
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneRole,
       [
         { query: 'findOne', args: [{ name: AUXILIARY }, { _id: 1, interface: 1 }] },
         { query: 'lean' },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneUser,
       [
         { query: 'findOne', args: [{ _id: payload.user }] },
@@ -327,14 +327,14 @@ describe('createContract', () => {
       { _id: payload.user },
       { $push: { contracts: payload._id }, $unset: { inactivityDate: '' }, $set: { 'role.client': role._id } }
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneRole,
       [
         { query: 'findOne', args: [{ name: AUXILIARY }, { _id: 1, interface: 1 }] },
         { query: 'lean' },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneUser,
       [
         { query: 'findOne', args: [{ _id: payload.user }] },
@@ -381,14 +381,14 @@ describe('createContract', () => {
       { _id: payload.user },
       { $push: { contracts: payload._id }, $unset: { inactivityDate: '' }, $set: { 'role.client': role._id } }
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneRole,
       [
         { query: 'findOne', args: [{ name: AUXILIARY }, { _id: 1, interface: 1 }] },
         { query: 'lean' },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneUser,
       [
         { query: 'findOne', args: [{ _id: payload.user }] },
@@ -424,7 +424,7 @@ describe('createContract', () => {
       sinon.assert.notCalled(updateOneUser);
       sinon.assert.notCalled(findOneRole);
       sinon.assert.notCalled(createContract);
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         findOneUser,
         [
           { query: 'findOne', args: [{ _id: payload.user }] },
@@ -520,14 +520,14 @@ describe('endContract', () => {
       credentials
     );
     sinon.assert.calledWithExactly(updateEndDateStub, updatedContract.user._id, updatedContract.endDate);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneContract,
       [
         { query: 'findOne', args: [{ _id: contract._id.toHexString() }] },
         { query: 'lean' },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneAndUpdateContract,
       [
         {
@@ -548,7 +548,7 @@ describe('endContract', () => {
         { query: 'lean', args: [{ autopopulate: true, virtuals: true }] },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       countDocumentHistories,
       [
         {
@@ -567,7 +567,7 @@ describe('endContract', () => {
         },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       eventCountDocuments,
       [
         {
@@ -624,14 +624,14 @@ describe('endContract', () => {
       sinon.assert.notCalled(updateAbsencesOnContractEnd);
       sinon.assert.notCalled(updateEndDateStub);
       sinon.assert.notCalled(findOneAndUpdateContract);
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         findOneContract,
         [
           { query: 'findOne', args: [{ _id: contract._id.toHexString() }] },
           { query: 'lean' },
         ]
       );
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         countDocumentHistories,
         [
           {
@@ -650,7 +650,7 @@ describe('endContract', () => {
           },
         ]
       );
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         eventCountDocuments,
         [
           {
@@ -710,14 +710,14 @@ describe('endContract', () => {
       sinon.assert.notCalled(findOneAndUpdateContract);
       sinon.assert.notCalled(countDocumentHistories);
 
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         findOneContract,
         [
           { query: 'findOne', args: [{ _id: contract._id.toHexString() }] },
           { query: 'lean' },
         ]
       );
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         eventCountDocuments,
         [
           {
@@ -761,7 +761,7 @@ describe('endContract', () => {
       sinon.assert.notCalled(updateAbsencesOnContractEnd);
       sinon.assert.notCalled(updateEndDateStub);
       sinon.assert.notCalled(findOneAndUpdateContract);
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         findOneContract,
         [
           { query: 'findOne', args: [{ _id: contractId.toHexString() }] },
@@ -809,7 +809,7 @@ describe('createVersion', () => {
 
     await ContractHelper.createVersion(contract._id.toHexString(), newVersion, credentials);
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneContract,
       [{ query: 'findOne', args: [{ _id: contract._id.toHexString() }] }]
     );
@@ -818,7 +818,7 @@ describe('createVersion', () => {
       { _id: contract._id.toHexString() },
       { $set: { [`versions.${1}.endDate`]: moment('2019-09-13T00:00:00').subtract(1, 'd').endOf('d').toISOString() } }
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneAndUpdateContract,
       [{ query: 'findOneAndUpdate', args: [{ _id: contract._id.toHexString() }, { $push: { versions: newVersion } }] }]
     );
@@ -839,11 +839,11 @@ describe('createVersion', () => {
 
     await ContractHelper.createVersion(contract._id.toHexString(), newVersion, credentials);
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneContract,
       [{ query: 'findOne', args: [{ _id: contract._id.toHexString() }] }]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneAndUpdateContract,
       [{
         query: 'findOneAndUpdate',
@@ -873,7 +873,7 @@ describe('createVersion', () => {
     } catch (e) {
       expect(e.output.statusCode).toEqual(400);
     } finally {
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         findOneContract,
         [{ query: 'findOne', args: [{ _id: contract._id.toHexString() }] }]
       );
@@ -991,7 +991,7 @@ describe('canUpdateVersion', () => {
       countAuxiliaryEventsBetweenDates,
       { auxiliary: contract.user, endDate: versionToUpdate.startDate, company: '1234567890' }
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findContract,
       [
         { query: 'find', args: [{ company: '1234567890', user: contract.user }] },
@@ -1028,7 +1028,7 @@ describe('canUpdateVersion', () => {
         startDate: '2018-10-02T23:59:59',
       }
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findContract,
       [
         { query: 'find', args: [{ company: '1234567890', user: contract.user }] },
@@ -1052,7 +1052,7 @@ describe('canUpdateVersion', () => {
       countAuxiliaryEventsBetweenDates,
       { auxiliary: contract.user, endDate: versionToUpdate.startDate, company: '1234567890' }
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findContract,
       [
         { query: 'find', args: [{ company: '1234567890', user: contract.user }] },
@@ -1203,14 +1203,14 @@ describe('updateVersion', () => {
       companyId
     );
     sinon.assert.notCalled(updateOneContract);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneContract,
       [
         { query: 'findOne', args: [{ _id: contractId.toHexString() }] },
         { query: 'lean' },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneAndUpdateContract,
       [
         { query: 'findOneAndUpdate', args: [{ _id: contractId.toHexString() }, { $set: {}, $push: {} }] },
@@ -1253,14 +1253,14 @@ describe('updateVersion', () => {
       { _id: contractId.toHexString() },
       { $unset: { auxiliaryDoc: '' } }
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneContract,
       [
         { query: 'findOne', args: [{ _id: contractId.toHexString() }] },
         { query: 'lean' },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneAndUpdateContract,
       [
         { query: 'findOneAndUpdate', args: [{ _id: contractId.toHexString() }, { $set: {}, $push: {} }] },
@@ -1299,7 +1299,7 @@ describe('updateVersion', () => {
       sinon.assert.notCalled(formatVersionEditionPayload);
       sinon.assert.notCalled(updateOneContract);
       sinon.assert.notCalled(findOneAndUpdateContract);
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         findOneContract,
         [
           { query: 'findOne', args: [{ _id: contractId.toHexString() }] },

--- a/tests/unit/helpers/courseHistories.test.js
+++ b/tests/unit/helpers/courseHistories.test.js
@@ -334,7 +334,7 @@ describe('list', () => {
     const result = await CourseHistoriesHelper.list(query);
 
     expect(result).toMatchObject(returnedList);
-    SinonMongoose.calledWithExactly(find, [
+    SinonMongoose.calledOnceWithExactly(find, [
       { query: '', args: [query] },
       { query: 'populate', args: [{ path: 'createdBy', select: '_id identity picture' }] },
       { query: 'populate', args: [{ path: 'trainee', select: '_id identity' }] },
@@ -365,7 +365,7 @@ describe('list', () => {
     const result = await CourseHistoriesHelper.list(query);
 
     expect(result).toMatchObject(returnedList);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       find,
       [
         { query: '', args: [{ course: query.course, createdAt: { $lt: query.createdAt } }] },

--- a/tests/unit/helpers/courseHistories.test.js
+++ b/tests/unit/helpers/courseHistories.test.js
@@ -335,7 +335,7 @@ describe('list', () => {
 
     expect(result).toMatchObject(returnedList);
     SinonMongoose.calledOnceWithExactly(find, [
-      { query: '', args: [query] },
+      { query: 'find', args: [query] },
       { query: 'populate', args: [{ path: 'createdBy', select: '_id identity picture' }] },
       { query: 'populate', args: [{ path: 'trainee', select: '_id identity' }] },
       { query: 'sort', args: [{ createdAt: -1 }] },
@@ -368,7 +368,7 @@ describe('list', () => {
     SinonMongoose.calledOnceWithExactly(
       find,
       [
-        { query: '', args: [{ course: query.course, createdAt: { $lt: query.createdAt } }] },
+        { query: 'find', args: [{ course: query.course, createdAt: { $lt: query.createdAt } }] },
         { query: 'populate', args: [{ path: 'createdBy', select: '_id identity picture' }] },
         { query: 'populate', args: [{ path: 'trainee', select: '_id identity' }] },
         { query: 'sort', args: [{ createdAt: -1 }] },

--- a/tests/unit/helpers/courseSlots.test.js
+++ b/tests/unit/helpers/courseSlots.test.js
@@ -144,7 +144,7 @@ describe('updateCourseSlot', () => {
     findByIdStep.returns(SinonMongoose.stubChainedQueries([{ _id: payload.step, type: REMOTE }], ['lean']));
 
     await CourseSlotsHelper.updateCourseSlot(slot, payload, user);
-    SinonMongoose.calledWithExactly(findByIdStep, [{ query: 'findById', args: [payload.step] }, { query: 'lean' }]);
+    SinonMongoose.calledOnceWithExactly(findByIdStep, [{ query: 'findById', args: [payload.step] }, { query: 'lean' }]);
     sinon.assert.calledOnceWithExactly(hasConflicts, { ...slot, ...payload });
     sinon.assert.calledOnceWithExactly(createHistoryOnSlotEdition, slot, payload, user._id);
     sinon.assert.calledOnceWithExactly(
@@ -162,7 +162,7 @@ describe('updateCourseSlot', () => {
     findByIdStep.returns(SinonMongoose.stubChainedQueries([{ _id: payload.step, type: REMOTE }], ['lean']));
 
     await CourseSlotsHelper.updateCourseSlot(slot, payload, user);
-    SinonMongoose.calledWithExactly(findByIdStep, [{ query: 'findById', args: [payload.step] }, { query: 'lean' }]);
+    SinonMongoose.calledOnceWithExactly(findByIdStep, [{ query: 'findById', args: [payload.step] }, { query: 'lean' }]);
     sinon.assert.calledOnceWithExactly(hasConflicts, { ...slot, ...payload });
     sinon.assert.calledOnceWithExactly(createHistoryOnSlotEdition, slot, payload, user._id);
     sinon.assert.calledOnceWithExactly(
@@ -184,7 +184,7 @@ describe('updateCourseSlot', () => {
     findByIdStep.returns(SinonMongoose.stubChainedQueries([{ _id: payload.step, type: ON_SITE }], ['lean']));
 
     await CourseSlotsHelper.updateCourseSlot(slot, payload, user);
-    SinonMongoose.calledWithExactly(findByIdStep, [{ query: 'findById', args: [payload.step] }, { query: 'lean' }]);
+    SinonMongoose.calledOnceWithExactly(findByIdStep, [{ query: 'findById', args: [payload.step] }, { query: 'lean' }]);
     sinon.assert.calledOnceWithExactly(hasConflicts, { ...slot, ...payload });
     sinon.assert.calledOnceWithExactly(createHistoryOnSlotEdition, slot, payload, user._id);
     sinon.assert.calledOnceWithExactly(
@@ -202,7 +202,7 @@ describe('updateCourseSlot', () => {
     findByIdStep.returns(SinonMongoose.stubChainedQueries([{ _id: payload.step, type: ON_SITE }], ['lean']));
 
     await CourseSlotsHelper.updateCourseSlot(slot, payload, user);
-    SinonMongoose.calledWithExactly(findByIdStep, [{ query: 'findById', args: [payload.step] }, { query: 'lean' }]);
+    SinonMongoose.calledOnceWithExactly(findByIdStep, [{ query: 'findById', args: [payload.step] }, { query: 'lean' }]);
     sinon.assert.calledOnceWithExactly(hasConflicts, { ...slot, ...payload });
     sinon.assert.calledOnceWithExactly(createHistoryOnSlotEdition, slot, payload, user._id);
     sinon.assert.calledOnceWithExactly(

--- a/tests/unit/helpers/courses.test.js
+++ b/tests/unit/helpers/courses.test.js
@@ -348,7 +348,7 @@ describe('listUserCourses', () => {
       )
     ));
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       courseFind,
       [
         {
@@ -417,7 +417,7 @@ describe('getCourse', () => {
     );
     expect(result).toMatchObject(course);
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [
         { query: 'findOne', args: [{ _id: course._id }] },
@@ -480,7 +480,7 @@ describe('getCourse', () => {
     const result = await CourseHelper.getCourse({ _id: course._id }, loggedUser);
 
     expect(result).toMatchObject(courseWithFilteredTrainees);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [
         { query: 'findOne', args: [{ _id: course._id }] },
@@ -817,7 +817,7 @@ describe('getQuestionnaireAnswers', () => {
     const result = await CourseHelper.getQuestionnaireAnswers(courseId);
 
     expect(result).toMatchObject(followUps);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneCourse,
       [
         { query: 'findOne', args: [{ _id: courseId }] },
@@ -870,7 +870,7 @@ describe('getQuestionnaireAnswers', () => {
     const result = await CourseHelper.getQuestionnaireAnswers(courseId);
 
     expect(result).toMatchObject([]);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneCourse,
       [
         { query: 'findOne', args: [{ _id: courseId }] },
@@ -915,7 +915,7 @@ describe('getQuestionnaireAnswers', () => {
     const result = await CourseHelper.getQuestionnaireAnswers(courseId);
 
     expect(result).toMatchObject([]);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneCourse,
       [
         { query: 'findOne', args: [{ _id: courseId }] },
@@ -1063,7 +1063,7 @@ describe('getTraineeCourse', () => {
       progress: 1,
     });
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       courseFindOne,
       [
         { query: 'findOne', args: [{ _id: course._id }] },
@@ -1140,7 +1140,7 @@ describe('updateCourse', () => {
     const result = await CourseHelper.updateCourse(courseId, payload);
     expect(result.misc).toEqual(payload.misc);
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       courseFindOneAndUpdate,
       [
         { query: 'findOneAndUpdate', args: [{ _id: courseId }, { $set: payload }] },
@@ -1160,7 +1160,7 @@ describe('updateCourse', () => {
     expect(result._id).toBe(courseId);
     expect(result.contact).toBeUndefined();
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       courseFindOneAndUpdate,
       [
         { query: 'findOneAndUpdate', args: [{ _id: courseId }, { $unset: payload }] },
@@ -1222,7 +1222,7 @@ describe('sendSMS', () => {
 
     await CourseHelper.sendSMS(courseId, payload, credentials);
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       courseFindById,
       [
         { query: 'findById', args: [courseId] },
@@ -1307,7 +1307,7 @@ describe('getSMSHistory', () => {
     const result = await CourseHelper.getSMSHistory(courseId);
 
     expect(result).toEqual(sms);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       courseSmsHistoryFind,
       [
         { query: 'find', args: [{ course: courseId }] },
@@ -1352,7 +1352,7 @@ describe('addCourseTrainee', () => {
     await CourseHelper.addCourseTrainee(course._id, payload, credentials);
 
     sinon.assert.calledOnceWithExactly(courseUpdateOne, { _id: course._id }, { $addToSet: { trainees: user._id } });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       userFindOne,
       [
         { query: 'findOne', args: [{ _id: user._id }, { formationExpoTokenList: 1 }] },
@@ -1700,7 +1700,7 @@ describe('generateAttendanceSheets', () => {
 
     await CourseHelper.generateAttendanceSheets(courseId);
 
-    SinonMongoose.calledWithExactly(courseFindOne, [
+    SinonMongoose.calledOnceWithExactly(courseFindOne, [
       { query: 'findOne', args: [{ _id: courseId }] },
       { query: 'populate', args: ['company'] },
       { query: 'populate', args: [{ path: 'slots', populate: { path: 'step', select: 'type' } }] },
@@ -1734,7 +1734,7 @@ describe('generateAttendanceSheets', () => {
 
     await CourseHelper.generateAttendanceSheets(courseId);
 
-    SinonMongoose.calledWithExactly(courseFindOne, [
+    SinonMongoose.calledOnceWithExactly(courseFindOne, [
       { query: 'findOne', args: [{ _id: courseId }] },
       { query: 'populate', args: ['company'] },
       { query: 'populate', args: [{ path: 'slots', populate: { path: 'step', select: 'type' } }] },
@@ -1912,7 +1912,7 @@ describe('generateCompletionCertificate', () => {
       fileId: process.env.GOOGLE_DRIVE_TRAINING_CERTIFICATE_TEMPLATE_ID,
       tmpFilePath: '/path/certificate_template.docx',
     });
-    SinonMongoose.calledWithExactly(courseFindOne, [
+    SinonMongoose.calledOnceWithExactly(courseFindOne, [
       { query: 'findOne', args: [{ _id: courseId }] },
       { query: 'populate', args: ['slots'] },
       { query: 'populate', args: ['trainees'] },
@@ -2128,7 +2128,7 @@ describe('generateConvocationPdf', () => {
     const result = await CourseHelper.generateConvocationPdf(courseId);
 
     expect(result).toEqual({ pdf: 'pdf', courseName: 'Comment-attraper-des-Pokemons' });
-    SinonMongoose.calledWithExactly(courseFindOne, [
+    SinonMongoose.calledOnceWithExactly(courseFindOne, [
       { query: 'findOne', args: [{ _id: courseId }] },
       {
         query: 'populate',
@@ -2200,7 +2200,7 @@ describe('getQuestionnaires', () => {
     const result = await CourseHelper.getQuestionnaires(courseId);
 
     expect(result).toMatchObject([questionnaires[0]]);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findQuestionnaire,
       [
         { query: 'find', args: [{ status: { $ne: DRAFT } }] },

--- a/tests/unit/helpers/creditNotes.test.js
+++ b/tests/unit/helpers/creditNotes.test.js
@@ -58,7 +58,7 @@ describe('getCreditNotes', () => {
 
     expect(result).toEqual([{ customer: { _id: customerId, firstname: 'toto' } }]);
     sinon.assert.calledOnceWithExactly(getDateQueryStub, { startDate: payload.startDate, endDate: payload.endDate });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       find,
       [
         { query: 'find', args: [{ date: dateQuery, customer: customerId, company: companyId }] },
@@ -89,7 +89,7 @@ describe('getCreditNotes', () => {
 
     expect(result).toEqual([{ customer: { _id: customerId, firstname: 'toto' } }]);
     sinon.assert.notCalled(getDateQueryStub);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       find,
       [
         { query: 'find', args: [{ customer: customerId, company: companyId }] },
@@ -126,7 +126,7 @@ describe('getCreditNotes', () => {
 
     expect(result).toEqual([]);
     sinon.assert.calledOnceWithExactly(getDateQueryStub, { startDate: payload.startDate, endDate: payload.endDate });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       find,
       [
         { query: 'find', args: [{ date: dateQuery, customer: customerId, company: companyId }] },
@@ -183,7 +183,7 @@ describe('updateEventAndFundingHistory', () => {
     sinon.assert.calledOnceWithExactly(findOneAndUpdate, { fundingId, month: '01/2019' }, { $inc: { careHours: -3 } });
     sinon.assert.calledOnceWithExactly(updateOneEvent, { _id: events[0]._id }, { isBilled: false });
     sinon.assert.calledOnceWithExactly(updateOneFundingHistory, { fundingId }, { $inc: { careHours: -3 } });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       find,
       [{ query: 'find', args: [{ _id: { $in: [] }, company: credentials.company._id }] }, { query: 'lean' }]
     );
@@ -207,7 +207,7 @@ describe('updateEventAndFundingHistory', () => {
     sinon.assert.calledOnceWithExactly(findOneAndUpdate, { fundingId, month: '01/2019' }, { $inc: { careHours: -3 } });
     sinon.assert.calledOnceWithExactly(updateOneEvent, { _id: events[0]._id }, { isBilled: false });
     sinon.assert.notCalled(updateOneFundingHistory);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       find,
       [{ query: 'find', args: [{ _id: { $in: [] }, company: credentials.company._id }] }, { query: 'lean' }]
     );
@@ -231,7 +231,7 @@ describe('updateEventAndFundingHistory', () => {
     sinon.assert.calledOnceWithExactly(findOneAndUpdate, { fundingId, month: '01/2019' }, { $inc: { careHours: 3 } });
     sinon.assert.calledOnceWithExactly(updateOneEvent, { _id: events[0]._id }, { isBilled: true });
     sinon.assert.calledOnceWithExactly(updateOneFundingHistory, { fundingId }, { $inc: { careHours: 3 } });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       find,
       [{ query: 'find', args: [{ _id: { $in: [] }, company: credentials.company._id }] }, { query: 'lean' }]
     );
@@ -255,7 +255,7 @@ describe('updateEventAndFundingHistory', () => {
 
     sinon.assert.calledOnceWithExactly(updateOneFundingHistory, { fundingId }, { $inc: { amountTTC: -666 } });
     sinon.assert.calledOnceWithExactly(updateOneEvent, { _id: events[0]._id }, { isBilled: false });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       find,
       [{ query: 'find', args: [{ _id: { $in: [eventId] }, company: credentials.company._id }] }, { query: 'lean' }]
     );
@@ -339,7 +339,7 @@ describe('getCreditNoteNumber', () => {
 
     await CreditNoteHelper.getCreditNoteNumber(payload, company._id);
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneAndUpdate,
       [
         {
@@ -979,7 +979,7 @@ describe('generateCreditNotePdf', () => {
     const result = await CreditNoteHelper.generateCreditNotePdf(params, credentials);
 
     expect(result).toEqual({ pdf: { title: 'creditNote' }, creditNoteNumber: '12345' });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       creditNoteFindOne,
       [
         { query: 'find', args: [{ _id: params._id }] },
@@ -996,7 +996,7 @@ describe('generateCreditNotePdf', () => {
         { query: 'lean' },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       companyNoteFindOne,
       [{ query: 'find', args: [{ _id: credentials.company._id }] }, { query: 'lean' }]
     );
@@ -1020,7 +1020,7 @@ describe('generateCreditNotePdf', () => {
       sinon.assert.notCalled(formatPdf);
       sinon.assert.notCalled(getPdfContent);
       sinon.assert.notCalled(generatePdf);
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         creditNoteFindOne,
         [
           { query: 'find', args: [{ _id: params._id }] },
@@ -1051,7 +1051,7 @@ describe('generateCreditNotePdf', () => {
       sinon.assert.notCalled(formatPdf);
       sinon.assert.notCalled(getPdfContent);
       sinon.assert.notCalled(generatePdf);
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         creditNoteFindOne,
         [
           { query: 'find', args: [{ _id: params._id }] },

--- a/tests/unit/helpers/creditNotes.test.js
+++ b/tests/unit/helpers/creditNotes.test.js
@@ -343,7 +343,7 @@ describe('getCreditNoteNumber', () => {
       findOneAndUpdate,
       [
         {
-          query: 'find',
+          query: 'findOneAndUpdate',
           args: [
             { prefix: '0919', company: company._id },
             {},
@@ -982,7 +982,7 @@ describe('generateCreditNotePdf', () => {
     SinonMongoose.calledOnceWithExactly(
       creditNoteFindOne,
       [
-        { query: 'find', args: [{ _id: params._id }] },
+        { query: 'findOne', args: [{ _id: params._id }] },
         {
           query: 'populate',
           args: [{
@@ -998,7 +998,7 @@ describe('generateCreditNotePdf', () => {
     );
     SinonMongoose.calledOnceWithExactly(
       companyNoteFindOne,
-      [{ query: 'find', args: [{ _id: credentials.company._id }] }, { query: 'lean' }]
+      [{ query: 'findOne', args: [{ _id: credentials.company._id }] }, { query: 'lean' }]
     );
     sinon.assert.calledOnceWithExactly(
       formatPdf,
@@ -1023,7 +1023,7 @@ describe('generateCreditNotePdf', () => {
       SinonMongoose.calledOnceWithExactly(
         creditNoteFindOne,
         [
-          { query: 'find', args: [{ _id: params._id }] },
+          { query: 'findOne', args: [{ _id: params._id }] },
           {
             query: 'populate',
             args: [{
@@ -1054,7 +1054,7 @@ describe('generateCreditNotePdf', () => {
       SinonMongoose.calledOnceWithExactly(
         creditNoteFindOne,
         [
-          { query: 'find', args: [{ _id: params._id }] },
+          { query: 'findOne', args: [{ _id: params._id }] },
           {
             query: 'populate',
             args: [{

--- a/tests/unit/helpers/customerAbsences.test.js
+++ b/tests/unit/helpers/customerAbsences.test.js
@@ -71,7 +71,7 @@ describe('list', () => {
     await CustomerAbsencesHelper.list(query, credentials);
 
     sinon.assert.calledOnceWithExactly(formatIdsArray, customerId);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findCustomerAbsence,
       [
         {
@@ -117,7 +117,7 @@ describe('list', () => {
     await CustomerAbsencesHelper.list(query, credentials);
 
     sinon.assert.calledOnceWithExactly(formatIdsArray, customers);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findCustomerAbsence,
       [
         {
@@ -201,7 +201,7 @@ describe('updateCustomerAbsence', () => {
 
     await CustomerAbsencesHelper.updateCustomerAbsence(customerAbsenceId, payload, credentials);
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [
         { query: 'findOne', args: [{ _id: customerAbsenceId, company: companyId }, { customer: 1 }] },

--- a/tests/unit/helpers/customerNotes.test.js
+++ b/tests/unit/helpers/customerNotes.test.js
@@ -65,7 +65,7 @@ describe('list', () => {
     const result = await CustomerNotesHelper.list(customer, credentials);
 
     expect(result).toMatchObject(customerNotes);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       find,
       [
         { query: 'find', args: [{ customer, company: credentials.company._id }] },
@@ -111,7 +111,7 @@ describe('update', () => {
 
     await CustomerNotesHelper.update(customerNote._id, payload, credentials);
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [
         { query: 'findOne', args: [{ _id: customerNote._id, company: credentials.company._id }] },
@@ -160,7 +160,7 @@ describe('update', () => {
 
     await CustomerNotesHelper.update(customerNote._id, payload, credentials);
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [
         { query: 'findOne', args: [{ _id: customerNote._id, company: credentials.company._id }] },

--- a/tests/unit/helpers/customerPartners.test.js
+++ b/tests/unit/helpers/customerPartners.test.js
@@ -45,7 +45,7 @@ describe('list', () => {
     const result = await CustomerPartnersHelper.list(customer, credentials);
 
     expect(result).toMatchObject(customerPartners);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       find,
       [
         { query: 'find', args: [{ customer, company: credentials.company._id }] },
@@ -83,7 +83,7 @@ describe('update', () => {
 
     await CustomerPartnersHelper.update(customerPartnerId, { prescriber: true });
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneAndUpdate,
       [
         {
@@ -108,7 +108,7 @@ describe('update', () => {
     await CustomerPartnersHelper.update(customerPartnerId, { prescriber: false });
 
     sinon.assert.notCalled(updateOne);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneAndUpdate,
       [
         {

--- a/tests/unit/helpers/customers.test.js
+++ b/tests/unit/helpers/customers.test.js
@@ -73,7 +73,7 @@ describe('getCustomersBySector', () => {
 
     sinon.assert.calledWithExactly(populateSubscriptionsServices.getCall(0), { _id: customerIds[0] });
     sinon.assert.calledWithExactly(populateSubscriptionsServices.getCall(1), { _id: customerIds[1] });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findSectorHistories,
       [
         {
@@ -91,7 +91,7 @@ describe('getCustomersBySector', () => {
         { query: 'lean' },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findEvents,
       [
         {
@@ -172,7 +172,7 @@ describe('getCustomers', () => {
     expect(result).toEqual([]);
     sinon.assert.notCalled(subscriptionsAccepted);
     sinon.assert.notCalled(populateSubscriptionsServices);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findCustomer,
       [
         { query: 'find', args: [{ company: companyId }] },
@@ -226,7 +226,7 @@ describe('getCustomers', () => {
       { identity: { firstname: 'Emmanuel' }, company: companyId }
     );
     sinon.assert.calledWithExactly(populateSubscriptionsServices.getCall(1), { company: companyId });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findCustomer,
       [
         { query: 'find', args: [{ company: companyId }] },
@@ -280,7 +280,7 @@ describe('getCustomers', () => {
       populateSubscriptionsServices,
       { identity: { firstname: 'Emmanuel' }, company: companyId, archivedAt: '2021-09-10T00:00:00' }
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findCustomer,
       [
         { query: 'find', args: [{ company: companyId, archivedAt: { $ne: null } }] },
@@ -332,7 +332,7 @@ describe('getCustomers', () => {
       populateSubscriptionsServices,
       { identity: { firstname: 'Jean-Paul', lastname: 'Belmondot' }, company: companyId }
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findCustomer,
       [
         { query: 'find', args: [{ company: companyId, archivedAt: { $eq: null } }] },
@@ -370,7 +370,7 @@ describe('getCustomersFirstIntervention', () => {
       123456: { _id: '123456', firstIntervention: { _id: 'poiuy', startDate: '2019-09-10T00:00:00' } },
       '0987': { _id: '0987', firstIntervention: { _id: 'sdfg', startDate: '2019-09-10T00:00:00' } },
     });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findCustomer,
       [
         { query: 'find', args: [query, { _id: 1 }] },
@@ -444,7 +444,7 @@ describe('getCustomersWithSubscriptions', () => {
     const rep = await CustomerHelper.getCustomersWithSubscriptions({ company: { _id: companyId } });
 
     expect(rep).toEqual(customersWithSubscriptions);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findCustomer,
       [
         { query: 'find', args: [{ subscriptions: { $exists: true, $not: { $size: 0 } }, company: companyId }] },
@@ -497,7 +497,7 @@ describe('getCustomer', () => {
     const result = await CustomerHelper.getCustomer(customerId, credentials);
 
     expect(result).toBeNull();
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneCustomer,
       [
         { query: 'findOne', args: [{ _id: customerId }] },
@@ -527,7 +527,7 @@ describe('getCustomer', () => {
     expect(result).toEqual({ identity: { firstname: 'Emmanuel' }, subscriptions: 2, subscriptionsAccepted: true });
     sinon.assert.calledOnce(populateSubscriptionsServices);
     sinon.assert.calledOnce(subscriptionsAccepted);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneCustomer,
       [
         { query: 'findOne', args: [{ _id: customerId }] },
@@ -569,7 +569,7 @@ describe('getCustomer', () => {
       populateFundingsList,
       { ...customer, subscriptions: 2, subscriptionsAccepted: true }
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneCustomer,
       [
         { query: 'findOne', args: [{ _id: customerId }] },
@@ -601,7 +601,7 @@ describe('getRumNumber', () => {
 
     await CustomerHelper.getRumNumber(companyId);
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneAndUpdateRum,
       [
         {
@@ -685,7 +685,10 @@ describe('formatPaymentPayload', () => {
     sinon.assert.calledWithExactly(getRumNumber, company._id);
     sinon.assert.calledWithExactly(formatRumNumber, company.prefixNumber, rumNumber.prefix, 1);
     sinon.assert.calledWithExactly(updateOne, { prefix: rumNumber.prefix, company: company._id }, { $inc: { seq: 1 } });
-    SinonMongoose.calledWithExactly(findByIdCustomer, [{ query: 'finById', args: [customerId] }, { query: 'lean' }]);
+    SinonMongoose.calledOnceWithExactly(
+      findByIdCustomer,
+      [{ query: 'finById', args: [customerId] }, { query: 'lean' }]
+    );
   });
 
   it('shouldn\'t generate a new mandate (create iban)', async () => {
@@ -702,7 +705,10 @@ describe('formatPaymentPayload', () => {
     sinon.assert.notCalled(getRumNumber);
     sinon.assert.notCalled(formatRumNumber);
     sinon.assert.notCalled(updateOne);
-    SinonMongoose.calledWithExactly(findByIdCustomer, [{ query: 'findById', args: [customerId] }, { query: 'lean' }]);
+    SinonMongoose.calledOnceWithExactly(
+      findByIdCustomer,
+      [{ query: 'findById', args: [customerId] }, { query: 'lean' }]
+    );
   });
 });
 
@@ -738,7 +744,10 @@ describe('updateCustomerEvents', () => {
       },
       { $set: { address: payload.contact.primaryAddress } }
     );
-    SinonMongoose.calledWithExactly(findByIdCustomer, [{ query: 'findById', args: [customerId] }, { query: 'lean' }]);
+    SinonMongoose.calledOnceWithExactly(
+      findByIdCustomer,
+      [{ query: 'findById', args: [customerId] }, { query: 'lean' }]
+    );
   });
 
   it('should update events if secondaryAddress is changed', async () => {
@@ -760,7 +769,10 @@ describe('updateCustomerEvents', () => {
       },
       { $set: { address: payload.contact.secondaryAddress } }
     );
-    SinonMongoose.calledWithExactly(findByIdCustomer, [{ query: 'findById', args: [customerId] }, { query: 'lean' }]);
+    SinonMongoose.calledOnceWithExactly(
+      findByIdCustomer,
+      [{ query: 'findById', args: [customerId] }, { query: 'lean' }]
+    );
   });
 
   it('shouldn\'t update events if secondaryAddress is created', async () => {
@@ -774,7 +786,10 @@ describe('updateCustomerEvents', () => {
     await CustomerHelper.updateCustomerEvents(customerId, payload);
 
     sinon.assert.notCalled(updateMany);
-    SinonMongoose.calledWithExactly(findByIdCustomer, [{ query: 'findById', args: [customerId] }, { query: 'lean' }]);
+    SinonMongoose.calledOnceWithExactly(
+      findByIdCustomer,
+      [{ query: 'findById', args: [customerId] }, { query: 'lean' }]
+    );
   });
 
   it('should update events with primaryAddress if secondaryAddress is deleted', async () => {
@@ -799,7 +814,10 @@ describe('updateCustomerEvents', () => {
       },
       { $set: { address: customer.contact.primaryAddress } }
     );
-    SinonMongoose.calledWithExactly(findByIdCustomer, [{ query: 'findById', args: [customerId] }, { query: 'lean' }]);
+    SinonMongoose.calledOnceWithExactly(
+      findByIdCustomer,
+      [{ query: 'findById', args: [customerId] }, { query: 'lean' }]
+    );
   });
 });
 
@@ -843,7 +861,7 @@ describe('updateCustomer', () => {
     sinon.assert.notCalled(updateCustomerEvents);
     sinon.assert.notCalled(deleteCustomerEvents);
     sinon.assert.calledOnceWithExactly(updateCustomerReferent, customer._id, payload.referent, credentials.company);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneAndUpdateCustomer,
       [
         { query: 'findOneAndUpdate', args: [{ _id: customer._id }, { $set: flat({}, { safe: true }) }, { new: true }] },
@@ -875,7 +893,7 @@ describe('updateCustomer', () => {
     sinon.assert.notCalled(updateCustomerReferent);
     sinon.assert.notCalled(deleteCustomerEvents);
     sinon.assert.calledOnceWithExactly(formatPaymentPayload, customerId, payload, credentials.company);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneAndUpdateCustomer,
       [
         {
@@ -913,7 +931,7 @@ describe('updateCustomer', () => {
     sinon.assert.notCalled(updateCustomerReferent);
     sinon.assert.notCalled(deleteCustomerEvents);
     sinon.assert.calledOnceWithExactly(formatPaymentPayload, customerId, payload, credentials.company);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneAndUpdateCustomer,
       [{ query: 'findOneAndUpdate', args: [{ _id: customerId }, payload, { new: true }] }, { query: 'lean' }]
     );
@@ -933,7 +951,7 @@ describe('updateCustomer', () => {
     sinon.assert.notCalled(formatPaymentPayload);
     sinon.assert.notCalled(updateCustomerReferent);
     sinon.assert.notCalled(deleteCustomerEvents);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneAndUpdateCustomer,
       [
         {
@@ -959,7 +977,7 @@ describe('updateCustomer', () => {
     sinon.assert.notCalled(formatPaymentPayload);
     sinon.assert.notCalled(updateCustomerReferent);
     sinon.assert.notCalled(deleteCustomerEvents);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneAndUpdateCustomer,
       [
         {
@@ -985,7 +1003,7 @@ describe('updateCustomer', () => {
     sinon.assert.notCalled(formatPaymentPayload);
     sinon.assert.notCalled(updateCustomerReferent);
     sinon.assert.notCalled(deleteCustomerEvents);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneAndUpdateCustomer,
       [
         {
@@ -1016,7 +1034,7 @@ describe('updateCustomer', () => {
     sinon.assert.notCalled(formatPaymentPayload);
     sinon.assert.notCalled(updateCustomerReferent);
     sinon.assert.notCalled(deleteCustomerEvents);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneAndUpdateCustomer,
       [
         {
@@ -1047,7 +1065,7 @@ describe('updateCustomer', () => {
       credentials
     );
     sinon.assert.calledOnceWithExactly(updateCustomerAbsencesOnCustomerStop, customerId, '2019-06-25T16:34:04.144Z');
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneAndUpdateCustomer,
       [
         {
@@ -1076,7 +1094,7 @@ describe('updateCustomer', () => {
     sinon.assert.notCalled(updateCustomerEvents);
     sinon.assert.notCalled(updateCustomerReferent);
     sinon.assert.notCalled(deleteCustomerEvents);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneAndUpdateCustomer,
       [
         {
@@ -1193,11 +1211,11 @@ describe('removeCustomer', () => {
 
     await CustomerHelper.removeCustomer(customerId);
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [{ query: 'findOne', args: [{ _id: customerId }, { driveFolder: 1, company: 1 }] }, { query: 'lean' }]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findHelper,
       [{ query: 'find', args: [{ customer: customerId, company: companyId }, { user: 1 }] }, { query: 'lean' }]
     );
@@ -1227,11 +1245,11 @@ describe('removeCustomer', () => {
 
     await CustomerHelper.removeCustomer(customerId);
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [{ query: 'findOne', args: [{ _id: customerId }, { driveFolder: 1, company: 1 }] }, { query: 'lean' }]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findHelper,
       [{ query: 'find', args: [{ customer: customerId, company: companyId }, { user: 1 }] }, { query: 'lean' }]
     );
@@ -1256,11 +1274,11 @@ describe('removeCustomer', () => {
 
     await CustomerHelper.removeCustomer(customerId);
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [{ query: 'findOne', args: [{ _id: customerId }, { driveFolder: 1, company: 1 }] }, { query: 'lean' }]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findHelper,
       [{ query: 'find', args: [{ customer: customerId, company: companyId }, { user: 1 }] }, { query: 'lean' }]
     );
@@ -1329,7 +1347,7 @@ describe('generateQRCode', () => {
 
     expect(result).toEqual({ fileName: 'qrcode.pdf', pdf: 'pdf' });
     sinon.assert.calledOnceWithExactly(toDataURL, `${customerId}`, { margin: 0 });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneCustomer,
       [{ query: 'findOne', args: [{ _id: customerId }, { identity: 1 }] }, { query: 'lean' }]
     );

--- a/tests/unit/helpers/customers.test.js
+++ b/tests/unit/helpers/customers.test.js
@@ -687,7 +687,7 @@ describe('formatPaymentPayload', () => {
     sinon.assert.calledWithExactly(updateOne, { prefix: rumNumber.prefix, company: company._id }, { $inc: { seq: 1 } });
     SinonMongoose.calledOnceWithExactly(
       findByIdCustomer,
-      [{ query: 'finById', args: [customerId] }, { query: 'lean' }]
+      [{ query: 'findById', args: [customerId] }, { query: 'lean' }]
     );
   });
 

--- a/tests/unit/helpers/dataExport.test.js
+++ b/tests/unit/helpers/dataExport.test.js
@@ -64,7 +64,7 @@ describe('exportCustomers', () => {
       'Date de création',
       'Statut',
     ]);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findCustomer,
       [
         { query: 'find', args: [{ company: companyId }] },
@@ -144,7 +144,7 @@ describe('exportCustomers', () => {
       '12/12/2012',
       'Actif',
     ]);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findCustomer,
       [
         { query: 'find', args: [{ company: companyId }] },
@@ -173,7 +173,7 @@ describe('exportCustomers', () => {
     expect(result[1]).toMatchObject([
       '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', 0, '', 0, '', '',
     ]);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findCustomer,
       [
         { query: 'find', args: [{ company: companyId }] },
@@ -221,7 +221,7 @@ describe('exportAuxiliaries', () => {
       'Date de début de contrat prestataire', 'Date de fin de contrat prestataire', 'Date d\'inactivité',
       'Date de création']);
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findUserCompany,
       [{ query: 'find', args: [{ company: credentials.company._id }, { user: 1 }] }, { query: 'lean' }]
     );
@@ -287,18 +287,18 @@ describe('exportAuxiliaries', () => {
       '01/02/2019',
     ]);
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findUserCompany,
       [{ query: 'find', args: [{ company: credentials.company._id }, { user: 1 }] }, { query: 'lean' }]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findRole,
       [
         { query: 'find', args: [{ name: { $in: ['auxiliary', 'planning_referent', 'auxiliary_without_company'] } }] },
         { query: 'lean' },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findUser,
       [
         {
@@ -350,18 +350,18 @@ describe('exportAuxiliaries', () => {
       '', '', auxiliaries[0]._id, '', '', '', '', '', '', '', '', '', '', '', 2, '', '02/12/2019', '', '', '',
     ]);
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findUserCompany,
       [{ query: 'find', args: [{ company: credentials.company._id }, { user: 1 }] }, { query: 'lean' }]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findRole,
       [
         { query: 'find', args: [{ name: { $in: ['auxiliary', 'planning_referent', 'auxiliary_without_company'] } }] },
         { query: 'lean' },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findUser,
       [
         {
@@ -429,7 +429,7 @@ describe('exportHelpers', () => {
       'Bénéficiaire - Ville',
       'Date de création',
     ]);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findUserCompany,
       [{ query: 'find', args: [{ company: credentials.company._id }, { user: 1 }] }, { query: 'lean' }]
     );
@@ -489,12 +489,15 @@ describe('exportHelpers', () => {
         '01/02/2019',
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findUserCompany,
       [{ query: 'find', args: [{ company: credentials.company._id }, { user: 1 }] }, { query: 'lean' }]
     );
-    SinonMongoose.calledWithExactly(findOneRole, [{ query: 'findOne', args: [{ name: 'helper' }] }, { query: 'lean' }]);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
+      findOneRole,
+      [{ query: 'findOne', args: [{ name: 'helper' }] }, { query: 'lean' }]
+    );
+    SinonMongoose.calledOnceWithExactly(
       findUser,
       [
         {
@@ -541,7 +544,7 @@ describe('exportSectors', () => {
       'Date d\'arrivée dans l\'équipe',
       'Date de départ de l\'équipe',
     ]);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findSectorHistory,
       [
         { query: 'find', args: [{ company: credentials.company._id, startDate: { $exists: true } }] },
@@ -587,7 +590,7 @@ describe('exportSectors', () => {
       '10/11/2019',
       '10/12/2019',
     ]);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findSectorHistory,
       [
         { query: 'find', args: [{ company: credentials.company._id, startDate: { $exists: true } }] },
@@ -629,7 +632,7 @@ describe('exportReferents', () => {
       'Date de début',
       'Date de fin',
     ]);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findReferentHistory,
       [
         { query: 'find', args: [{ company: credentials.company._id }] },
@@ -686,7 +689,7 @@ describe('exportReferents', () => {
       '10/11/2020',
       '',
     ]);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findReferentHistory,
       [
         { query: 'find', args: [{ company: credentials.company._id }] },
@@ -828,7 +831,7 @@ describe('exportServices', () => {
       'Date de création',
       'Date de mise a jour',
     ]);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findService,
       [
         { query: 'find', args: [{ company: credentials.company._id }] },
@@ -881,7 +884,7 @@ describe('exportServices', () => {
     expect(result[2]).toMatchObject([
       'Forfaitaire', 'Compani', 'kické', 'F-13', 'F-5.5', 'smatch', '01/02/2019', '21/01/2019', '14/02/2019',
     ]);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findService,
       [
         { query: 'find', args: [{ company: credentials.company._id }] },
@@ -931,7 +934,7 @@ describe('exportSubscriptions', () => {
       'Dont soirées',
       'Dont dimanches',
     ]);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findCustomer,
       [
         { query: 'find', args: [{ subscriptions: { $exists: true, $not: { $size: 0 } }, company: companyId }] },
@@ -964,7 +967,7 @@ describe('exportSubscriptions', () => {
     expect(result).toBeDefined();
     expect(result[1]).toBeDefined();
     expect(result[1]).toMatchObject([expect.any(ObjectId), 'M.', 'AUTONOMIE', '', 'Service', 'F-12', 'F-4', 9, 2]);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findCustomer,
       [
         { query: 'find', args: [{ subscriptions: { $exists: true, $not: { $size: 0 } }, company: companyId }] },

--- a/tests/unit/helpers/delivery.test.js
+++ b/tests/unit/helpers/delivery.test.js
@@ -70,7 +70,7 @@ describe('formatEvents', () => {
         _id: event3,
       },
     ]);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findUsers,
       [
         {
@@ -82,7 +82,7 @@ describe('formatEvents', () => {
         { query: 'lean' },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findCustomers,
       [
         {
@@ -97,7 +97,7 @@ describe('formatEvents', () => {
         { query: 'lean' },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findEventHistories,
       [
         {
@@ -267,7 +267,7 @@ describe('getEvents', () => {
       { isBilled: false, _id: 'not_billed', auxiliary: 'auxiliary' },
       { isBilled: true, _id: 'billed', auxiliary: 'aux' },
     ]);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findCustomers,
       [
         {
@@ -277,7 +277,7 @@ describe('getEvents', () => {
         { query: 'lean' },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findEvents,
       [
         {
@@ -327,7 +327,7 @@ describe('getFileName', () => {
     const result = await DeliveryHelper.getFileName(query);
 
     expect(result).toEqual(`440-202109-APA-${moment().format('YYMMDDHHmm')}.xml`);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [{ query: 'findOne', args: [{ _id: tppId }, { teletransmissionType: 1, companyCode: 1 }] }, { query: 'lean' }]
     );

--- a/tests/unit/helpers/delivery.test.js
+++ b/tests/unit/helpers/delivery.test.js
@@ -271,7 +271,7 @@ describe('getEvents', () => {
       findCustomers,
       [
         {
-          query: '',
+          query: 'find',
           args: [{ 'fundings.thirdPartyPayer': { $in: [tpp1, tpp2] }, company: companyId }, { fundings: 1 }],
         },
         { query: 'lean' },
@@ -281,7 +281,7 @@ describe('getEvents', () => {
       findEvents,
       [
         {
-          query: '',
+          query: 'find',
           args: [{
             subscription: { $in: ['234', '111', '987'] },
             company: companyId,

--- a/tests/unit/helpers/distanceMatrix.test.js
+++ b/tests/unit/helpers/distanceMatrix.test.js
@@ -31,7 +31,7 @@ describe('getDistanceMatrices', () => {
     const result = await DistanceMatrixHelper.getDistanceMatrices(credentials);
 
     expect(result).toEqual(distanceMatrix);
-    SinonMongoose.calledWithExactly(find, [{ query: 'find', args: [{ company: companyId }] }, { query: 'lean' }]);
+    SinonMongoose.calledOnceWithExactly(find, [{ query: 'find', args: [{ company: companyId }] }, { query: 'lean' }]);
   });
 });
 

--- a/tests/unit/helpers/draftFinalPay.test.js
+++ b/tests/unit/helpers/draftFinalPay.test.js
@@ -258,15 +258,15 @@ describe('computeDraftFinalPay', () => {
 
     expect(result).toBeDefined();
     expect(result).toEqual([{ hoursBalance: 120 }]);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       surchargeFind,
       [{ query: 'find', args: [{ company: companyId }] }, { query: 'lean' }]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       companyFindOne,
       [{ query: 'findOne', args: [{ _id: companyId }] }, { query: 'lean' }]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       surchargeFind,
       [{ query: 'find', args: [{ company: credentials.company._id }] }, { query: 'lean' }]
     );

--- a/tests/unit/helpers/draftPay.test.js
+++ b/tests/unit/helpers/draftPay.test.js
@@ -1991,15 +1991,15 @@ describe('computeDraftPay', () => {
     expect(result).toEqual([]);
     sinon.assert.calledOnceWithExactly(getPreviousMonthPay, [], query, [{ _id: 'sur' }], [{ _id: 'dm' }], companyId);
     sinon.assert.notCalled(computeAuxiliaryDraftPay);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       companyFindOne,
       [{ query: 'findOne', args: [{ _id: companyId }] }, { query: 'lean' }]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       surchargeFind,
       [{ query: 'find', args: [{ company: companyId }] }, { query: 'lean' }]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       distanceMatrixFind,
       [{ query: 'find', args: [{ company: companyId }] }, { query: 'lean' }]
     );

--- a/tests/unit/helpers/draftbills.test.js
+++ b/tests/unit/helpers/draftbills.test.js
@@ -119,7 +119,7 @@ describe('populateFundings', () => {
 
     expect(result[0].thirdPartyPayer._id).toEqual(tppId);
     sinon.assert.called(mergeLastVersionWithBaseObjectStub);
-    SinonMongoose.calledWithExactly(findOneFundingHistory, [
+    SinonMongoose.calledOnceWithExactly(findOneFundingHistory, [
       { query: 'findOne', args: [{ fundingId: fundings[0]._id }] },
       { query: 'lean' },
     ]);
@@ -145,7 +145,7 @@ describe('populateFundings', () => {
 
     expect(result[0].history).toMatchObject([{ careHours: 4, fundingId }]);
     sinon.assert.called(mergeLastVersionWithBaseObjectStub);
-    SinonMongoose.calledWithExactly(findOneFundingHistory, [
+    SinonMongoose.calledOnceWithExactly(findOneFundingHistory, [
       { query: 'findOne', args: [{ fundingId: fundings[0]._id }] },
       { query: 'lean' },
     ]);
@@ -170,7 +170,7 @@ describe('populateFundings', () => {
 
     expect(result[0].history).toMatchObject([{ careHours: 0, amountTTC: 0, fundingId }]);
     sinon.assert.called(mergeLastVersionWithBaseObjectStub);
-    SinonMongoose.calledWithExactly(findOneFundingHistory, [
+    SinonMongoose.calledOnceWithExactly(findOneFundingHistory, [
       { query: 'findOne', args: [{ fundingId: fundings[0]._id }] },
       { query: 'lean' },
     ]);
@@ -201,7 +201,7 @@ describe('populateFundings', () => {
     const addedHistory = result[0].history.find(hist => hist.month === '03/2019');
     expect(addedHistory).toMatchObject({ careHours: 0, amountTTC: 0, fundingId, month: '03/2019' });
     sinon.assert.called(mergeLastVersionWithBaseObjectStub);
-    SinonMongoose.calledWithExactly(findFundingHistory, [
+    SinonMongoose.calledOnceWithExactly(findFundingHistory, [
       { query: 'find', args: [{ fundingId: fundings[0]._id, company: companyId }] },
       { query: 'lean' },
     ]);
@@ -1306,15 +1306,15 @@ describe('getDraftBillsList', () => {
     const result = await DraftBillsHelper.getDraftBillsList(query, credentials);
 
     expect(result).toEqual([]);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findThirdPartyPayer,
       [{ query: 'find', args: [{ company: companyId }] }, { query: 'lean' }]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findSurcharge,
       [{ query: 'find', args: [{ company: companyId }] }, { query: 'lean' }]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findBillingItem,
       [{ query: 'find', args: [{ company: companyId }] }, { query: 'lean' }]
     );
@@ -1445,15 +1445,15 @@ describe('getDraftBillsList', () => {
       query,
       { _id: 'ghjk', identity: { firstname: 'Toto' } }
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findThirdPartyPayer,
       [{ query: 'find', args: [{ company: companyId }] }, { query: 'lean' }]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findSurcharge,
       [{ query: 'find', args: [{ company: companyId }] }, { query: 'lean' }]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findBillingItem,
       [{ query: 'find', args: [{ company: companyId }] }, { query: 'lean' }]
     );
@@ -1622,15 +1622,15 @@ describe('getDraftBillsList', () => {
       query,
       { _id: 'asdf', identity: { firstname: 'Tata' } }
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findThirdPartyPayer,
       [{ query: 'find', args: [{ company: companyId }] }, { query: 'lean' }]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findSurcharge,
       [{ query: 'find', args: [{ company: companyId }] }, { query: 'lean' }]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findBillingItem,
       [{ query: 'find', args: [{ company: companyId }] }, { query: 'lean' }]
     );

--- a/tests/unit/helpers/establishments.test.js
+++ b/tests/unit/helpers/establishments.test.js
@@ -41,7 +41,10 @@ describe('create', () => {
     const result = await EstablishmentsHelper.create(payload, credentials);
 
     expect(result).toMatchObject(payloadWithCompany);
-    SinonMongoose.calledWithExactly(create, [{ query: 'create', args: [payloadWithCompany] }, { query: 'toObject' }]);
+    SinonMongoose.calledOnceWithExactly(
+      create,
+      [{ query: 'create', args: [payloadWithCompany] }, { query: 'toObject' }]
+    );
   });
 });
 
@@ -63,7 +66,7 @@ describe('update', () => {
     const result = await EstablishmentsHelper.update(establishmentId, payload);
 
     expect(result).toMatchObject({ _id: establishmentId });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneAndUpdate,
       [
         { query: 'findOneAndUpdate', args: [{ _id: establishmentId }, { $set: payload }, { new: true }] },
@@ -90,7 +93,7 @@ describe('list', () => {
 
     await EstablishmentsHelper.list(credentials);
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       find,
       [
         { query: 'find', args: [{ company: credentials.company._id }] },

--- a/tests/unit/helpers/eventHistories.test.js
+++ b/tests/unit/helpers/eventHistories.test.js
@@ -170,7 +170,7 @@ describe('createEventHistory', () => {
         event: { eventId: payload._id, auxiliary: auxiliaryId.toHexString() },
       }
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [
         { query: 'findOne', args: [{ _id: payload.auxiliary }] },
@@ -662,7 +662,7 @@ describe('formatHistoryForAuxiliaryUpdate', () => {
       sectors: [sectorId],
       auxiliaries: [auxiliaryId, 'qwertyuiop'],
     });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       find,
       [
         { query: 'find', args: [{ _id: { $in: [auxiliaryId, 'qwertyuiop'] } }] },
@@ -692,7 +692,7 @@ describe('formatHistoryForAuxiliaryUpdate', () => {
       sectors: [sectorId],
       auxiliaries: [auxiliaryId],
     });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [
         { query: 'findOne', args: [{ _id: auxiliaryId }] },
@@ -723,7 +723,7 @@ describe('formatHistoryForAuxiliaryUpdate', () => {
       sectors: [sectorId, eventSectorId],
       auxiliaries: [auxiliaryId],
     });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [
         { query: 'findOne', args: [{ _id: auxiliaryId }] },
@@ -775,7 +775,7 @@ describe('formatHistoryForCancelUpdate', () => {
         cancel: { reason: 'toto', condition: 'tata' },
       },
     });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [
         { query: 'findOne', args: [{ _id: auxiliaryId.toHexString() }] },
@@ -852,7 +852,7 @@ describe('formatHistoryForDatesUpdate', () => {
         startDate: { from: '2019-01-21T09:38:18', to: '2019-01-20T09:38:18' },
       },
     });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [
         { query: 'findOne', args: [{ _id: auxiliaryId.toHexString() }] },
@@ -943,7 +943,7 @@ describe('formatHistoryForHoursUpdate', () => {
         endHour: { from: '2019-01-21T10:38:18', to: '2019-01-21T11:38:18' },
       },
     });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [
         { query: 'findOne', args: [{ _id: auxiliaryId.toHexString() }] },
@@ -1119,12 +1119,15 @@ describe('createTimeStampCancellationHistory', () => {
         sectors: [sectorId],
       }
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [{ query: 'findOne', args: [{ _id: eventHistoryId }] }, { query: 'lean' }]
     );
-    SinonMongoose.calledWithExactly(findOneEvent, [{ query: 'findOne', args: [{ _id: eventId }] }, { query: 'lean' }]);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
+      findOneEvent,
+      [{ query: 'findOne', args: [{ _id: eventId }] }, { query: 'lean' }]
+    );
+    SinonMongoose.calledOnceWithExactly(
       findOneUser,
       [
         { query: 'findOne', args: [{ _id: auxiliaryId }] },
@@ -1162,11 +1165,14 @@ describe('createTimeStampCancellationHistory', () => {
         sectors: [sectorId],
       }
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [{ query: 'findOne', args: [{ _id: eventHistoryId }] }, { query: 'lean' }]
     );
-    SinonMongoose.calledWithExactly(findOneEvent, [{ query: 'findOne', args: [{ _id: eventId }] }, { query: 'lean' }]);
+    SinonMongoose.calledOnceWithExactly(
+      findOneEvent,
+      [{ query: 'findOne', args: [{ _id: eventId }] }, { query: 'lean' }]
+    );
     sinon.assert.notCalled(findOneUser);
   });
 });

--- a/tests/unit/helpers/events.test.js
+++ b/tests/unit/helpers/events.test.js
@@ -345,7 +345,7 @@ describe('updateEvent', () => {
     sinon.assert.calledOnceWithExactly(isUpdateAllowed, event, payload, credentials);
     sinon.assert.calledOnceWithExactly(createEventHistoryOnUpdate, payload, event, credentials);
     sinon.assert.calledOnceWithExactly(updateRepetition, event, payload, credentials);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [
         { query: 'findOne', args: [{ _id: event._id }] },
@@ -437,7 +437,7 @@ describe('updateEvent', () => {
     sinon.assert.calledOnceWithExactly(formatEditionPayload, event, payload, true);
     sinon.assert.calledOnceWithExactly(createEventHistoryOnUpdate, { _id: event._id }, event, credentials);
     sinon.assert.calledOnceWithExactly(updateOne, { _id: event._id }, { $set: { _id: eventId }, $unset: {} });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [
         { query: 'findOne', args: [{ _id: event._id }] },
@@ -492,7 +492,7 @@ describe('updateEvent', () => {
     sinon.assert.calledOnceWithExactly(formatEditionPayload, event, payload, false);
     sinon.assert.calledOnceWithExactly(createEventHistoryOnUpdate, { _id: event._id }, event, credentials);
     sinon.assert.calledOnceWithExactly(updateOne, { _id: event._id }, { $set: { _id: eventId }, $unset: {} });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [
         { query: 'findOne', args: [{ _id: event._id }] },
@@ -556,7 +556,7 @@ describe('listForCreditNotes', () => {
     expect(result).toBeDefined();
     expect(result).toBe(events);
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findEvent,
       [
         { query: 'find', args: [query] },
@@ -587,7 +587,7 @@ describe('listForCreditNotes', () => {
     expect(result).toBeDefined();
     expect(result).toEqual([{ type: 'intervention' }]);
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findEvent,
       [
         { query: 'find', args: [query] },
@@ -621,7 +621,7 @@ describe('listForCreditNotes', () => {
     expect(result).toBeDefined();
     expect(result).toBe(events);
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findEvent,
       [
         { query: 'find', args: [query] },
@@ -1170,7 +1170,7 @@ describe('detachAuxiliaryFromEvent', () => {
     const result = await EventHelper.detachAuxiliaryFromEvent(event, companyId);
 
     expect(result).toEqual({ sector: 'sector', repetition: { frequency: 'never' } });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneUser,
       [
         { query: 'findOne', args: [{ _id: event.auxiliary }] },
@@ -1255,7 +1255,7 @@ describe('createEvent', () => {
     sinon.assert.calledOnceWithExactly(createEventHistoryOnCreate, event, credentials);
     sinon.assert.calledOnceWithExactly(getEvent, event._id, credentials);
     sinon.assert.calledOnceWithExactly(populateEventSubscription, event);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       createEvent,
       [{ query: 'createEvent', args: [{ ...payload, company: companyId }] }, { query: 'toObject' }]
     );
@@ -1288,7 +1288,7 @@ describe('createEvent', () => {
     sinon.assert.calledOnceWithExactly(createEventHistoryOnCreate, { ...newEvent, repetition }, credentials);
     sinon.assert.calledOnceWithExactly(getEvent, detachedEvent._id, credentials);
     sinon.assert.calledOnceWithExactly(populateEventSubscription, detachedEvent);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       createEvent,
       [{ query: 'createEvent', args: [detachedEvent] }, { query: 'toObject' }]
     );
@@ -1325,7 +1325,7 @@ describe('createEvent', () => {
       credentials
     );
     sinon.assert.calledOnceWithExactly(populateEventSubscription, event);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       createEvent,
       [{ query: 'createEvent', args: [{ ...payload, company: companyId }] }, { query: 'toObject' }]
     );
@@ -1368,7 +1368,7 @@ describe('createEvent', () => {
       auxiliary,
       credentials
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneUser,
       [
         { query: 'findOne', args: [{ _id: event.auxiliary }] },
@@ -1376,7 +1376,7 @@ describe('createEvent', () => {
         { query: 'lean', args: [{ autopopulate: true, virtuals: true }] },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       createEvent,
       [{ query: 'createEvent', args: [{ ...payload, company: companyId }] }, { query: 'toObject' }]
     );
@@ -1463,7 +1463,7 @@ describe('unassignConflictInterventions', () => {
 
     sinon.assert.calledOnceWithExactly(formatEventsInConflictQuery, dates, auxiliaryId, [INTERVENTION], companyId);
     sinon.assert.callCount(updateEvent, events.length);
-    SinonMongoose.calledWithExactly(findEvent, [{ query: 'find', args: [query] }, { query: 'lean' }]);
+    SinonMongoose.calledOnceWithExactly(findEvent, [{ query: 'find', args: [query] }, { query: 'lean' }]);
   });
 });
 
@@ -1571,7 +1571,7 @@ describe('deleteEventsAndRepetition', () => {
     sinon.assert.notCalled(createEventHistoryOnDelete);
     sinon.assert.notCalled(repetitionDeleteOne);
     sinon.assert.calledOnceWithExactly(checkDeletionIsAllowed, events);
-    SinonMongoose.calledWithExactly(find, [{ query: 'find', args: [query] }]);
+    SinonMongoose.calledOnceWithExactly(find, [{ query: 'find', args: [query] }]);
   });
 
   it('should delete events with repetitions', async () => {
@@ -1634,7 +1634,7 @@ describe('deleteEventsAndRepetition', () => {
     sinon.assert.calledOnceWithExactly(repetitionDeleteOne, { parentId });
     sinon.assert.calledOnceWithExactly(deleteMany, { _id: { $in: events.map(ev => ev._id) } });
     sinon.assert.calledOnceWithExactly(checkDeletionIsAllowed, events);
-    SinonMongoose.calledWithExactly(find, [{ query: 'find', args: [query] }]);
+    SinonMongoose.calledOnceWithExactly(find, [{ query: 'find', args: [query] }]);
   });
 
   it('should not delete event if at least one is billed', async () => {
@@ -1662,7 +1662,7 @@ describe('deleteEventsAndRepetition', () => {
       sinon.assert.notCalled(createEventHistoryOnDeleteList);
       sinon.assert.notCalled(deleteMany);
       sinon.assert.calledOnceWithExactly(checkDeletionIsAllowed, events);
-      SinonMongoose.calledWithExactly(find, [{ query: 'find', args: [query] }]);
+      SinonMongoose.calledOnceWithExactly(find, [{ query: 'find', args: [query] }]);
     }
   });
 
@@ -1691,7 +1691,7 @@ describe('deleteEventsAndRepetition', () => {
       sinon.assert.notCalled(createEventHistoryOnDeleteList);
       sinon.assert.notCalled(deleteMany);
       sinon.assert.calledOnceWithExactly(checkDeletionIsAllowed, events);
-      SinonMongoose.calledWithExactly(find, [{ query: 'find', args: [query] }]);
+      SinonMongoose.calledOnceWithExactly(find, [{ query: 'find', args: [query] }]);
     }
   });
 });
@@ -1914,7 +1914,7 @@ describe('workingStats', () => {
     sinon.assert.calledOnceWithExactly(getContractWeekInfoStub, contract, query);
     sinon.assert.calledOnceWithExactly(getPayFromEventsStub, [], auxiliaries[0], distanceMatrix, [], query);
     sinon.assert.calledOnceWithExactly(getPayFromAbsencesStub, [], contract, query);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findUser,
       [
         { query: 'find', args: [{ _id: { $in: query.auxiliary } }] },
@@ -1922,7 +1922,7 @@ describe('workingStats', () => {
         { query: 'lean' },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findDistanceMatrix,
       [{ query: 'find', args: [{ company: companyId }] }, { query: 'lean' }]
     );
@@ -1968,13 +1968,13 @@ describe('workingStats', () => {
       queryWithoutAuxiliary
     );
     sinon.assert.calledOnceWithExactly(getPayFromAbsencesStub, [], contract, queryWithoutAuxiliary);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findUserCompany,
       [
         { query: 'find', args: [{ company: companyId }, { user: 1 }] },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findUser,
       [
         { query: 'find', args: [{ _id: { $in: [users[0].user] } }] },
@@ -1982,7 +1982,7 @@ describe('workingStats', () => {
         { query: 'lean' },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findDistanceMatrix,
       [{ query: 'find', args: [{ company: companyId }] }, { query: 'lean' }]
     );
@@ -1998,7 +1998,7 @@ describe('workingStats', () => {
 
     sinon.assert.notCalled(findUserCompany);
     sinon.assert.calledOnceWithExactly(getEventsToPayStub, query.startDate, query.endDate, [auxiliaryId], companyId);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findUser,
       [
         { query: 'find', args: [{ _id: { $in: query.auxiliary } }] },
@@ -2006,7 +2006,7 @@ describe('workingStats', () => {
         { query: 'lean' },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findDistanceMatrix,
       [{ query: 'find', args: [{ company: companyId }] }, { query: 'lean' }]
     );
@@ -2030,7 +2030,7 @@ describe('workingStats', () => {
     sinon.assert.notCalled(findUserCompany);
     sinon.assert.calledOnceWithExactly(getEventsToPayStub, query.startDate, query.endDate, [auxiliaryId], companyId);
     sinon.assert.calledOnceWithExactly(getContractStub, contracts, query.startDate, query.endDate);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findUser,
       [
         { query: 'find', args: [{ _id: { $in: query.auxiliary } }] },
@@ -2038,7 +2038,7 @@ describe('workingStats', () => {
         { query: 'lean' },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findDistanceMatrix,
       [{ query: 'find', args: [{ company: companyId }] }, { query: 'lean' }]
     );

--- a/tests/unit/helpers/events.test.js
+++ b/tests/unit/helpers/events.test.js
@@ -1257,7 +1257,7 @@ describe('createEvent', () => {
     sinon.assert.calledOnceWithExactly(populateEventSubscription, event);
     SinonMongoose.calledOnceWithExactly(
       createEvent,
-      [{ query: 'createEvent', args: [{ ...payload, company: companyId }] }, { query: 'toObject' }]
+      [{ query: 'create', args: [{ ...payload, company: companyId }] }, { query: 'toObject' }]
     );
     sinon.assert.calledOnceWithExactly(isRepetition, { ...payload, company: companyId });
     sinon.assert.notCalled(findOneUser);
@@ -1290,7 +1290,7 @@ describe('createEvent', () => {
     sinon.assert.calledOnceWithExactly(populateEventSubscription, detachedEvent);
     SinonMongoose.calledOnceWithExactly(
       createEvent,
-      [{ query: 'createEvent', args: [detachedEvent] }, { query: 'toObject' }]
+      [{ query: 'create', args: [detachedEvent] }, { query: 'toObject' }]
     );
     sinon.assert.calledOnceWithExactly(isRepetition, { ...newEvent, company: companyId });
     sinon.assert.calledOnceWithExactly(detachAuxiliaryFromEvent, { ...newEvent, company: companyId }, companyId);
@@ -1327,7 +1327,7 @@ describe('createEvent', () => {
     sinon.assert.calledOnceWithExactly(populateEventSubscription, event);
     SinonMongoose.calledOnceWithExactly(
       createEvent,
-      [{ query: 'createEvent', args: [{ ...payload, company: companyId }] }, { query: 'toObject' }]
+      [{ query: 'create', args: [{ ...payload, company: companyId }] }, { query: 'toObject' }]
     );
     sinon.assert.calledOnceWithExactly(isRepetition, { ...payload, company: companyId });
     sinon.assert.notCalled(findOneUser);
@@ -1378,7 +1378,7 @@ describe('createEvent', () => {
     );
     SinonMongoose.calledOnceWithExactly(
       createEvent,
-      [{ query: 'createEvent', args: [{ ...payload, company: companyId }] }, { query: 'toObject' }]
+      [{ query: 'create', args: [{ ...payload, company: companyId }] }, { query: 'toObject' }]
     );
     sinon.assert.notCalled(detachAuxiliaryFromEvent);
   });

--- a/tests/unit/helpers/eventsRepetition.test.js
+++ b/tests/unit/helpers/eventsRepetition.test.js
@@ -286,7 +286,7 @@ describe('createRepeatedEvents', () => {
     sinon.assert.calledWithExactly(formatRepeatedPayload.getCall(1), event, sector, '2019-01-12T09:00:00.000Z');
     sinon.assert.calledWithExactly(formatRepeatedPayload.getCall(2), event, sector, '2019-01-13T09:00:00.000Z');
     sinon.assert.calledOnceWithExactly(insertMany, repeatedEvents);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       customerFindOne,
       [
         { query: 'findOne', args: [{ _id: event.customer, stoppedAt: { $exists: true } }, { stoppedAt: 1 }] },
@@ -321,7 +321,7 @@ describe('createRepeatedEvents', () => {
     sinon.assert.calledWithExactly(formatRepeatedPayload.getCall(0), event, sector, '2019-01-11T09:00:00.000Z');
     sinon.assert.calledWithExactly(formatRepeatedPayload.getCall(1), event, sector, '2019-01-14T09:00:00.000Z');
     sinon.assert.calledOnceWithExactly(insertMany, [fridayEvent, mondayEvent]);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       customerFindOne,
       [
         { query: 'findOne', args: [{ _id: event.customer, stoppedAt: { $exists: true } }, { stoppedAt: 1 }] },
@@ -357,7 +357,7 @@ describe('createRepeatedEvents', () => {
     sinon.assert.calledWithExactly(formatRepeatedPayload.getCall(1), event, sector, '2019-01-12T09:00:00.000Z');
     sinon.assert.calledWithExactly(formatRepeatedPayload.getCall(2), event, sector, '2019-01-13T09:00:00.000Z');
     sinon.assert.calledOnceWithExactly(insertMany, repeatedEvents.slice(0, 2));
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       customerFindOne,
       [
         { query: 'findOne', args: [{ _id: event.customer, stoppedAt: { $exists: true } }, { stoppedAt: 1 }] },
@@ -626,7 +626,7 @@ describe('createRepetitions', () => {
 
     await EventsRepetitionHelper.createRepetitions(event, payload, credentials);
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [
         { query: 'findOne', args: [{ _id: auxiliaryId }] },
@@ -650,7 +650,7 @@ describe('createRepetitions', () => {
 
     await EventsRepetitionHelper.createRepetitions(event, payload, credentials);
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [
         { query: 'findOne', args: [{ _id: auxiliaryId }] },
@@ -787,7 +787,7 @@ describe('updateRepetition', () => {
     await EventsRepetitionHelper.updateRepetition(event, payload, credentials);
 
     sinon.assert.notCalled(findOneUser);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       find,
       [
         {
@@ -864,7 +864,7 @@ describe('updateRepetition', () => {
 
     await EventsRepetitionHelper.updateRepetition(event, payload, credentials);
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneUser,
       [
         { query: 'findOne', args: [{ _id: auxiliaryId }] },
@@ -875,7 +875,7 @@ describe('updateRepetition', () => {
         { query: 'lean' },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       find,
       [
         {
@@ -970,7 +970,7 @@ describe('updateRepetition', () => {
 
     await EventsRepetitionHelper.updateRepetition(event, payload, credentials);
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneUser,
       [
         { query: 'findOne', args: [{ _id: auxiliaryId }] },
@@ -981,7 +981,7 @@ describe('updateRepetition', () => {
         { query: 'lean' },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       find,
       [
         {
@@ -1065,7 +1065,7 @@ describe('updateRepetition', () => {
 
     await EventsRepetitionHelper.updateRepetition(event, payload, credentials);
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneUser,
       [
         { query: 'findOne', args: [{ _id: auxiliaryId }] },
@@ -1076,7 +1076,7 @@ describe('updateRepetition', () => {
         { query: 'lean' },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       find,
       [
         {
@@ -1163,7 +1163,7 @@ describe('updateRepetition', () => {
     await EventsRepetitionHelper.updateRepetition(event, payload, credentials);
 
     sinon.assert.notCalled(findOneUser);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       find,
       [
         {

--- a/tests/unit/helpers/eventsValidation.test.js
+++ b/tests/unit/helpers/eventsValidation.test.js
@@ -90,7 +90,7 @@ describe('isUserContractValidOnEventDates', () => {
     const result = await EventsValidationHelper.isUserContractValidOnEventDates(event);
 
     expect(result).toBe(false);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [
         { query: 'findOne', args: [{ _id: event.auxiliary }] },
@@ -109,7 +109,7 @@ describe('isUserContractValidOnEventDates', () => {
     const result = await EventsValidationHelper.isUserContractValidOnEventDates(event);
 
     expect(result).toBe(false);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [
         { query: 'findOne', args: [{ _id: event.auxiliary }] },
@@ -129,7 +129,7 @@ describe('isUserContractValidOnEventDates', () => {
     const result = await EventsValidationHelper.isUserContractValidOnEventDates(event);
 
     expect(result).toBe(false);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [
         { query: 'findOne', args: [{ _id: event.auxiliary }] },
@@ -149,7 +149,7 @@ describe('isUserContractValidOnEventDates', () => {
     const result = await EventsValidationHelper.isUserContractValidOnEventDates(event);
 
     expect(result).toBe(true);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [
         { query: 'findOne', args: [{ _id: event.auxiliary }] },
@@ -174,7 +174,7 @@ describe('isUserContractValidOnEventDates', () => {
     const result = await EventsValidationHelper.isUserContractValidOnEventDates(event);
 
     expect(result).toBe(false);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [
         { query: 'findOne', args: [{ _id: event.auxiliary }] },
@@ -199,7 +199,7 @@ describe('isUserContractValidOnEventDates', () => {
     const result = await EventsValidationHelper.isUserContractValidOnEventDates(event);
 
     expect(result).toBe(true);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [
         { query: 'findOne', args: [{ _id: event.auxiliary }] },

--- a/tests/unit/helpers/fundings.test.js
+++ b/tests/unit/helpers/fundings.test.js
@@ -34,7 +34,7 @@ describe('checkSubscriptionFunding', () => {
     } catch (e) {
       expect(e).toEqual(Boom.notFound('Error while checking subscription funding: customer not found.'));
     } finally {
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         findOneCustomer,
         [{ query: 'findOne', args: [{ _id: customerId }] }, { query: 'lean' }]
       );
@@ -49,7 +49,7 @@ describe('checkSubscriptionFunding', () => {
     const res = await FundingsHelper.checkSubscriptionFunding(customerId, checkedFunding);
 
     expect(res).toBe(true);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneCustomer,
       [{ query: 'findOne', args: [{ _id: customerId }] }, { query: 'lean' }]
     );
@@ -63,7 +63,7 @@ describe('checkSubscriptionFunding', () => {
     const res = await FundingsHelper.checkSubscriptionFunding(customerId, checkedFunding);
 
     expect(res).toBe(true);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneCustomer,
       [{ query: 'findOne', args: [{ _id: customerId }] }, { query: 'lean' }]
     );
@@ -86,7 +86,7 @@ describe('checkSubscriptionFunding', () => {
     const res = await FundingsHelper.checkSubscriptionFunding(customerId, checkedFunding);
 
     expect(res).toBe(true);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneCustomer,
       [{ query: 'findOne', args: [{ _id: customerId }] }, { query: 'lean' }]
     );
@@ -107,7 +107,7 @@ describe('checkSubscriptionFunding', () => {
     const res = await FundingsHelper.checkSubscriptionFunding(customerId, checkedFunding);
 
     expect(res).toBe(true);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneCustomer,
       [{ query: 'findOne', args: [{ _id: customerId }] }, { query: 'lean' }]
     );
@@ -128,7 +128,7 @@ describe('checkSubscriptionFunding', () => {
     const res = await FundingsHelper.checkSubscriptionFunding(customerId, checkedFunding);
 
     expect(res).toBe(true);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneCustomer,
       [{ query: 'findOne', args: [{ _id: customerId }] }, { query: 'lean' }]
     );
@@ -149,7 +149,7 @@ describe('checkSubscriptionFunding', () => {
     const res = await FundingsHelper.checkSubscriptionFunding(customerId, checkedFunding);
 
     expect(res).toBe(true);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneCustomer,
       [{ query: 'findOne', args: [{ _id: customerId }] }, { query: 'lean' }]
     );
@@ -170,7 +170,7 @@ describe('checkSubscriptionFunding', () => {
     const res = await FundingsHelper.checkSubscriptionFunding(customerId, checkedFunding);
 
     expect(res).toBe(true);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneCustomer,
       [{ query: 'findOne', args: [{ _id: customerId }] }, { query: 'lean' }]
     );
@@ -191,7 +191,7 @@ describe('checkSubscriptionFunding', () => {
     const res = await FundingsHelper.checkSubscriptionFunding(customerId, checkedFunding);
 
     expect(res).toBe(false);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneCustomer,
       [{ query: 'findOne', args: [{ _id: customerId }] }, { query: 'lean' }]
     );
@@ -217,7 +217,7 @@ describe('checkSubscriptionFunding', () => {
     const res = await FundingsHelper.checkSubscriptionFunding(customerId, checkedFunding);
 
     expect(res).toBe(false);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneCustomer,
       [{ query: 'findOne', args: [{ _id: customerId }] }, { query: 'lean' }]
     );
@@ -304,7 +304,7 @@ describe('createFunding', () => {
 
     sinon.assert.calledOnceWithExactly(checkSubscriptionFunding, customerId, payload);
     sinon.assert.calledOnceWithExactly(populateFundingsList, customer);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneAndUpdateCustomer,
       [
         {
@@ -372,7 +372,7 @@ describe('updateFunding', () => {
 
     sinon.assert.calledWithExactly(checkSubscriptionFunding, customerId, checkPayload);
     sinon.assert.calledWithExactly(populateFundingsList, customer);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneAndUpdateCustomer,
       [
         {

--- a/tests/unit/helpers/helpers.test.js
+++ b/tests/unit/helpers/helpers.test.js
@@ -41,7 +41,7 @@ describe('list', () => {
         customer: query.customer,
       },
     ]);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       find,
       [
         { query: 'find', args: [{ customer: query.customer, company: companyId }] },
@@ -73,7 +73,7 @@ describe('update', () => {
 
     await HelpersHelper.update(helperId, { referent: true });
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneAndUpdate,
       [{ query: 'findOneAndUpdate', args: [{ _id: helperId }, { $set: { referent: true } }] }, { query: 'lean' }]
     );

--- a/tests/unit/helpers/historyExport.test.js
+++ b/tests/unit/helpers/historyExport.test.js
@@ -153,7 +153,7 @@ describe('getWorkingEventsForExport', () => {
 
     const result = await ExportHelper.getWorkingEventsForExport(startDate, endDate, companyId);
     expect(result).toStrictEqual(eventsWithSubscription);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       find,
       [
         { query: 'find', args: [payload] },
@@ -788,7 +788,7 @@ describe('exportBillsAndCreditNotesHistory', () => {
     const exportArray = await ExportHelper.exportBillsAndCreditNotesHistory(null, null, credentials);
 
     expect(exportArray).toEqual([header]);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findBill,
       [
         { query: 'find', args: [findQuery] },
@@ -798,7 +798,7 @@ describe('exportBillsAndCreditNotesHistory', () => {
         { query: 'lean' },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findCreditNote,
       [
         { query: 'find', args: [findQuery] },
@@ -825,7 +825,7 @@ describe('exportBillsAndCreditNotesHistory', () => {
       ['Facture', '', '', '', '', '', '', '', '', '', '', '', '', ''],
       ['Avoir', '', '', '', '', '', '', '', '', '', '', '', '', ''],
     ]);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findBill,
       [
         { query: 'find', args: [findQuery] },
@@ -835,7 +835,7 @@ describe('exportBillsAndCreditNotesHistory', () => {
         { query: 'lean' },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findCreditNote,
       [
         { query: 'find', args: [findQuery] },
@@ -930,7 +930,7 @@ describe('exportBillsAndCreditNotesHistory', () => {
         '16/10/2019',
       ],
     ]);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findBill,
       [
         { query: 'find', args: [findQuery] },
@@ -940,7 +940,7 @@ describe('exportBillsAndCreditNotesHistory', () => {
         { query: 'lean' },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findCreditNote,
       [
         { query: 'find', args: [findQuery] },
@@ -982,7 +982,7 @@ describe('exportContractHistory', () => {
       'Taux horaire',
       'Volume horaire hebdomadaire',
     ]]);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       find,
       [
         { query: 'find', args: [{ company: credentials.company._id, 'versions.startDate': { $lte: endDate, $gte: startDate } }] },
@@ -1004,7 +1004,7 @@ describe('exportContractHistory', () => {
       ['Type', 'Id Auxiliaire', 'Titre', 'Prénom', 'Nom', 'Date de début', 'Date de fin', 'Taux horaire', 'Volume horaire hebdomadaire'],
       ['Contrat', contracts[0].user._id, '', '', '', '10/10/2019', '', '', ''],
     ]);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       find,
       [
         { query: 'find', args: [{ company: credentials.company._id, 'versions.startDate': { $lte: endDate, $gte: startDate } }] },
@@ -1039,7 +1039,7 @@ describe('exportContractHistory', () => {
       ['Contrat', contracts[0].user._id, 'M.', '', 'Patate', '10/10/2019', '', '10,45', 12],
       ['Avenant', contracts[1].user._id, 'Mme', 'Patate', '', '08/10/2019', '07/11/2019', '2,00', 14],
     ]);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       find,
       [
         { query: 'find', args: [{ company: credentials.company._id, 'versions.startDate': { $lte: endDate, $gte: startDate } }] },
@@ -1404,7 +1404,7 @@ describe('exportPayAndFinalPayHistory', () => {
     const exportArray = await ExportHelper.exportPayAndFinalPayHistory(startDate, endDate, credentials);
 
     expect(exportArray).toEqual([header]);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findPay,
       [
         { query: 'find', args: [query] },
@@ -1423,7 +1423,7 @@ describe('exportPayAndFinalPayHistory', () => {
         { query: 'lean', args: [{ autopopulate: true, virtuals: true }] },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findFinalPay,
       [
         { query: 'find', args: [query] },
@@ -1481,7 +1481,7 @@ describe('exportPayAndFinalPayHistory', () => {
         '15,10', '20,00', '100,00', '0,00'],
     ]);
     sinon.assert.callCount(formatFloatForExportStub, 77);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findPay,
       [
         { query: 'find', args: [query] },
@@ -1500,7 +1500,7 @@ describe('exportPayAndFinalPayHistory', () => {
         { query: 'lean', args: [{ autopopulate: true, virtuals: true }] },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findFinalPay,
       [
         { query: 'find', args: [query] },
@@ -1590,7 +1590,7 @@ describe('exportPaymentsHistory', () => {
     const exportArray = await ExportHelper.exportPaymentsHistory(null, null, credentials);
 
     expect(exportArray).toEqual([header]);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       find,
       [
         { query: 'find', args: [{ date: { $lte: null, $gte: null }, company: credentials.company._id }] },
@@ -1637,7 +1637,7 @@ describe('exportPaymentsHistory', () => {
         '1002,40',
       ],
     ]);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       find,
       [
         { query: 'find', args: [{ date: { $lte: null, $gte: null }, company: credentials.company._id }] },

--- a/tests/unit/helpers/internalHours.test.js
+++ b/tests/unit/helpers/internalHours.test.js
@@ -43,7 +43,7 @@ describe('list', () => {
     const result = await InternalHoursHelper.list(credentials);
 
     expect(result).toEqual(internalHours);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       find,
       [{ query: 'find', args: [{ company: credentials.company._id }] }, { query: 'lean' }]
     );

--- a/tests/unit/helpers/mandates.test.js
+++ b/tests/unit/helpers/mandates.test.js
@@ -30,7 +30,7 @@ describe('getMandates', () => {
     const result = await MandatesHelper.getMandates(customerId);
 
     expect(result).toMatchObject(mandate);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneCustomer,
       [
         {
@@ -66,7 +66,7 @@ describe('updateMandate', () => {
     const result = await MandatesHelper.updateMandate(customerId, mandateId, payload);
 
     expect(result).toMatchObject({ ...payload, _id: mandateId });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneAndUpdateCustomer,
       [
         {
@@ -126,7 +126,7 @@ describe('getSignatureRequest', () => {
       { _id: customerId, 'payment.mandates._id': mandateId.toHexString() },
       { $set: flat({ 'payment.mandates.$.everSignId': 'document_hash' }) }
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneCustomer,
       [
         {
@@ -163,7 +163,7 @@ describe('getSignatureRequest', () => {
       expect(e.output.statusCode).toEqual(400);
     } finally {
       sinon.assert.notCalled(updateOneCustomer);
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         findOneCustomer,
         [
           {
@@ -236,11 +236,11 @@ describe('saveSignedMandate', () => {
       { driveFolderId: 'driveFolder', name: 'rum', type: 'application/pdf', body: 'file' }
     );
     sinon.assert.calledWithExactly(getFileById, { fileId: 'fileId' });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneCustomer,
       [{ query: 'findOne', args: [{ _id: customerId }] }, { query: 'lean' }]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneAndUpdateCustomer,
       [
         {
@@ -278,7 +278,7 @@ describe('saveSignedMandate', () => {
       sinon.assert.notCalled(addFile);
       sinon.assert.notCalled(getFileById);
       sinon.assert.notCalled(findOneAndUpdateCustomer);
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         findOneCustomer,
         [{ query: 'findOne', args: [{ _id: customerId }] }, { query: 'lean' }]
       );
@@ -308,7 +308,7 @@ describe('saveSignedMandate', () => {
       sinon.assert.notCalled(addFile);
       sinon.assert.notCalled(getFileById);
       sinon.assert.notCalled(findOneAndUpdateCustomer);
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         findOneCustomer,
         [{ query: 'findOne', args: [{ _id: customerId }] }, { query: 'lean' }]
       );

--- a/tests/unit/helpers/notifications.test.js
+++ b/tests/unit/helpers/notifications.test.js
@@ -101,7 +101,7 @@ describe('sendBlendedCourseRegistrationNotification', () => {
 
     await NotificationHelper.sendBlendedCourseRegistrationNotification(trainee, courseId);
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [
         { query: 'findOne', args: [{ _id: courseId }] },
@@ -179,7 +179,7 @@ describe('sendNewElearningCourseNotification', () => {
 
     await NotificationHelper.sendNewElearningCourseNotification(courseId);
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       courseFindOne,
       [
         { query: 'findOne', args: [{ _id: courseId }] },
@@ -190,7 +190,7 @@ describe('sendNewElearningCourseNotification', () => {
         { query: 'lean', args: [] },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       userFind,
       [
         {
@@ -237,7 +237,7 @@ describe('sendNewElearningCourseNotification', () => {
 
     await NotificationHelper.sendNewElearningCourseNotification(courseId);
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       courseFindOne,
       [
         { query: 'findOne', args: [{ _id: courseId }] },
@@ -248,7 +248,7 @@ describe('sendNewElearningCourseNotification', () => {
         { query: 'lean', args: [] },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       userFind,
       [
         {

--- a/tests/unit/helpers/partnerOrganizations.test.js
+++ b/tests/unit/helpers/partnerOrganizations.test.js
@@ -69,7 +69,7 @@ describe('list', () => {
     const result = await PartnerOrganizationsHelper.list(credentials);
 
     expect(result).toEqual([{ _id: partnerOrganizationId, name: 'skusku', partners: [], prescribedCustomersCount: 0 }]);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       find,
       [
         { query: 'find', args: [{ company: credentials.company._id }] },
@@ -116,7 +116,7 @@ describe('list', () => {
         },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       find,
       [
         { query: 'find', args: [{ company: credentials.company._id }] },
@@ -153,7 +153,7 @@ describe('getPartnerOrganization', () => {
 
     await PartnerOrganizationsHelper.getPartnerOrganization(partnerOrganizationId, credentials);
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [
         { query: 'findOne', args: [{ _id: partnerOrganizationId, company: credentials.company._id }] },

--- a/tests/unit/helpers/partners.test.js
+++ b/tests/unit/helpers/partners.test.js
@@ -20,7 +20,7 @@ describe('list', () => {
 
     await PartnersHelper.list(credentials);
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       find,
       [{ query: 'find', args: [{ company: credentials.company._id }] }, { query: 'lean' }]
     );

--- a/tests/unit/helpers/pay.test.js
+++ b/tests/unit/helpers/pay.test.js
@@ -258,9 +258,10 @@ describe('hoursBalanceDetailByAuxiliary', () => {
     sinon.assert.calledWithExactly(computeDraftPay, [{ ...auxiliary, prevPay }], query, credentials);
     SinonMongoose.calledWithExactly(
       payFindOne,
-      [{ query: 'findOne', args: [{ auxiliary: auxiliaryId, month }] }, { query: 'lean' }]
+      [{ query: 'findOne', args: [{ auxiliary: auxiliaryId, month }] }, { query: 'lean' }],
+      0
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       finalPayFindOne,
       [{ query: 'findOne', args: [{ auxiliary: auxiliaryId, month }] }, { query: 'lean' }]
     );
@@ -269,7 +270,7 @@ describe('hoursBalanceDetailByAuxiliary', () => {
       [{ query: 'findOne', args: [{ auxiliary: auxiliaryId, month: prevMonth }] }, { query: 'lean' }],
       1
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       userFindOne,
       [
         { query: 'findOne', args: [{ _id: auxiliaryId }] },
@@ -300,9 +301,10 @@ describe('hoursBalanceDetailByAuxiliary', () => {
     sinon.assert.calledWithExactly(computeDraftFinalPay, [{ ...auxiliary, prevPay }], query, credentials);
     SinonMongoose.calledWithExactly(
       payFindOne,
-      [{ query: 'findOne', args: [{ auxiliary: auxiliaryId, month }] }, { query: 'lean' }]
+      [{ query: 'findOne', args: [{ auxiliary: auxiliaryId, month }] }, { query: 'lean' }],
+      0
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       finalPayFindOne,
       [{ query: 'findOne', args: [{ auxiliary: auxiliaryId, month }] }, { query: 'lean' }]
     );
@@ -311,7 +313,7 @@ describe('hoursBalanceDetailByAuxiliary', () => {
       [{ query: 'findOne', args: [{ auxiliary: auxiliaryId, month: prevMonth }] }, { query: 'lean' }],
       1
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       userFindOne,
       [
         { query: 'findOne', args: [{ _id: auxiliaryId }] },
@@ -369,7 +371,7 @@ describe('hoursBalanceDetailByAuxiliary', () => {
     expect(result).toEqual({ ...pay, sectors: [sectorId.toHexString()], counterAndDiffRelevant: true });
     sinon.assert.notCalled(getContractStub);
     sinon.assert.notCalled(computeDraftPay);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       payFindOne,
       [{ query: 'findOne', args: [{ auxiliary: auxiliaryId, month }] }, { query: 'lean' }]
     );
@@ -390,11 +392,11 @@ describe('hoursBalanceDetailByAuxiliary', () => {
     expect(result).toEqual({ ...pay, sectors: [sectorId.toHexString()], counterAndDiffRelevant: true });
     sinon.assert.notCalled(getContractStub);
     sinon.assert.notCalled(computeDraftPay);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       payFindOne,
       [{ query: 'findOne', args: [{ auxiliary: auxiliaryId, month }] }, { query: 'lean' }]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       finalPayFindOne,
       [{ query: 'findOne', args: [{ auxiliary: auxiliaryId, month }] }, { query: 'lean' }]
     );
@@ -477,7 +479,7 @@ describe('hoursBalanceDetailBySector', () => {
       [query.sector],
       credentials.company._id
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       userFind,
       [
         { query: 'find', args: [{ _id: { $in: [] } }, { identity: 1, picture: 1 }] },
@@ -512,7 +514,7 @@ describe('hoursBalanceDetailBySector', () => {
     );
     sinon.assert.calledWithExactly(getContractStub, [contract], startDate, endDate);
     sinon.assert.calledWithExactly(hoursBalanceDetailByAuxiliary, auxiliaryId, startDate, endDate, credentials);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       userFind,
       [
         { query: 'find', args: [{ _id: { $in: [auxiliaryId] } }, { identity: 1, picture: 1 }] },
@@ -567,7 +569,7 @@ describe('hoursBalanceDetailBySector', () => {
       endDate,
       credentials
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       userFind,
       [
         { query: 'find', args: [{ _id: { $in: auxiliaryIds } }, { identity: 1, picture: 1 }] },
@@ -596,7 +598,7 @@ describe('hoursBalanceDetailBySector', () => {
     );
     sinon.assert.notCalled(getContractStub);
     sinon.assert.notCalled(hoursBalanceDetailByAuxiliary);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       userFind,
       [
         { query: 'find', args: [{ _id: { $in: [auxiliaryId] } }, { identity: 1, picture: 1 }] },
@@ -628,7 +630,7 @@ describe('hoursBalanceDetailBySector', () => {
     );
     sinon.assert.calledWithExactly(getContractStub, [contract], startDate, endDate);
     sinon.assert.notCalled(hoursBalanceDetailByAuxiliary);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       userFind,
       [
         { query: 'find', args: [{ _id: { $in: [auxiliaryId] } }, { identity: 1, picture: 1 }] },

--- a/tests/unit/helpers/payDocuments.test.js
+++ b/tests/unit/helpers/payDocuments.test.js
@@ -46,7 +46,7 @@ describe('create', () => {
     } catch (e) {
       expect(e).toEqual(Boom.failedDependency('Google drive: File not uploaded'));
     } finally {
-      SinonMongoose.calledWithExactly(findOne, [
+      SinonMongoose.calledOnceWithExactly(findOne, [
         { query: '', args: [{ _id: userId }, { identity: 1, 'administrative.driveFolder': 1 }] },
         { query: 'lean' },
       ]);
@@ -80,7 +80,7 @@ describe('create', () => {
       addFile,
       { driveFolderId: 'driveId', name: 'bulletin_de_paie_31_12_2020_0000_bonjour', type: 'pdf', body: 'stream' }
     );
-    SinonMongoose.calledWithExactly(findOne, [
+    SinonMongoose.calledOnceWithExactly(findOne, [
       { query: '', args: [{ _id: userId }, { identity: 1, 'administrative.driveFolder': 1 }] },
       { query: 'lean' },
     ]);

--- a/tests/unit/helpers/payDocuments.test.js
+++ b/tests/unit/helpers/payDocuments.test.js
@@ -47,7 +47,7 @@ describe('create', () => {
       expect(e).toEqual(Boom.failedDependency('Google drive: File not uploaded'));
     } finally {
       SinonMongoose.calledOnceWithExactly(findOne, [
-        { query: '', args: [{ _id: userId }, { identity: 1, 'administrative.driveFolder': 1 }] },
+        { query: 'findOne', args: [{ _id: userId }, { identity: 1, 'administrative.driveFolder': 1 }] },
         { query: 'lean' },
       ]);
       sinon.assert.calledWithExactly(formatIdentity, { lastname: 'lastname' }, 'FL');
@@ -81,7 +81,7 @@ describe('create', () => {
       { driveFolderId: 'driveId', name: 'bulletin_de_paie_31_12_2020_0000_bonjour', type: 'pdf', body: 'stream' }
     );
     SinonMongoose.calledOnceWithExactly(findOne, [
-      { query: '', args: [{ _id: userId }, { identity: 1, 'administrative.driveFolder': 1 }] },
+      { query: 'findOne', args: [{ _id: userId }, { identity: 1, 'administrative.driveFolder': 1 }] },
       { query: 'lean' },
     ]);
     sinon.assert.calledOnceWithExactly(

--- a/tests/unit/helpers/payDocuments.test.js
+++ b/tests/unit/helpers/payDocuments.test.js
@@ -46,10 +46,13 @@ describe('create', () => {
     } catch (e) {
       expect(e).toEqual(Boom.failedDependency('Google drive: File not uploaded'));
     } finally {
-      SinonMongoose.calledOnceWithExactly(findOne, [
-        { query: 'findOne', args: [{ _id: userId }, { identity: 1, 'administrative.driveFolder': 1 }] },
-        { query: 'lean' },
-      ]);
+      SinonMongoose.calledOnceWithExactly(
+        findOne,
+        [
+          { query: 'findOne', args: [{ _id: userId }, { identity: 1, 'administrative.driveFolder': 1 }] },
+          { query: 'lean' },
+        ]
+      );
       sinon.assert.calledWithExactly(formatIdentity, { lastname: 'lastname' }, 'FL');
       sinon.assert.calledWithExactly(addFile, {
         driveFolderId: 'driveId',
@@ -80,10 +83,13 @@ describe('create', () => {
       addFile,
       { driveFolderId: 'driveId', name: 'bulletin_de_paie_31_12_2020_0000_bonjour', type: 'pdf', body: 'stream' }
     );
-    SinonMongoose.calledOnceWithExactly(findOne, [
-      { query: 'findOne', args: [{ _id: userId }, { identity: 1, 'administrative.driveFolder': 1 }] },
-      { query: 'lean' },
-    ]);
+    SinonMongoose.calledOnceWithExactly(
+      findOne,
+      [
+        { query: 'findOne', args: [{ _id: userId }, { identity: 1, 'administrative.driveFolder': 1 }] },
+        { query: 'lean' },
+      ]
+    );
     sinon.assert.calledOnceWithExactly(
       create,
       {

--- a/tests/unit/helpers/payments.test.js
+++ b/tests/unit/helpers/payments.test.js
@@ -34,7 +34,7 @@ describe('getPayments', () => {
 
     expect(result).toEqual([payment]);
     sinon.assert.notCalled(getDateQueryStub);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       find,
       [
         { query: 'find', args: [{ company: credentials.company._id }] },
@@ -57,7 +57,7 @@ describe('getPayments', () => {
 
     expect(result).toEqual([payment]);
     sinon.assert.calledOnceWithExactly(getDateQueryStub, { startDate: query.startDate, endDate: query.endDate });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       find,
       [
         { query: 'find', args: [{ company: credentials.company._id, date: { $lte: '2019-11-01' } }] },
@@ -80,7 +80,7 @@ describe('getPayments', () => {
 
     expect(result).toEqual([payment]);
     sinon.assert.calledOnceWithExactly(getDateQueryStub, { startDate: query.startDate, endDate: query.endDate });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       find,
       [
         { query: 'find', args: [{ company: credentials.company._id, date: { $gte: '2019-11-01' } }] },
@@ -378,7 +378,7 @@ describe('getPaymentNumber', () => {
 
     await PaymentsHelper.getPaymentNumber(payment, companyId);
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneAndUpdate,
       [
         {

--- a/tests/unit/helpers/payments.test.js
+++ b/tests/unit/helpers/payments.test.js
@@ -382,7 +382,7 @@ describe('getPaymentNumber', () => {
       findOneAndUpdate,
       [
         {
-          query: 'find',
+          query: 'findOneAndUpdate',
           args: [
             { nature: payment.nature, company: companyId, prefix: '1219' },
             {},

--- a/tests/unit/helpers/programs.test.js
+++ b/tests/unit/helpers/programs.test.js
@@ -43,7 +43,7 @@ describe('list', () => {
 
     const result = await ProgramHelper.list();
     expect(result).toMatchObject(programsList);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       find,
       [
         { query: 'find', args: [{}] },
@@ -78,7 +78,7 @@ describe('listELearning', () => {
     const result = await ProgramHelper.listELearning(credentials);
     expect(result).toMatchObject([{ name: 'name' }, { name: 'program' }]);
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       courseFind,
       [
         {
@@ -91,7 +91,7 @@ describe('listELearning', () => {
         { query: 'lean' },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       programFind,
       [
         { query: 'find', args: [{ subPrograms: { $in: subPrograms } }] },
@@ -134,7 +134,7 @@ describe('listELearning', () => {
     const result = await ProgramHelper.listELearning(credentials, { _id: programId });
     expect(result).toMatchObject([{ _id: programId, name: 'name' }]);
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       courseFind,
       [
         {
@@ -147,7 +147,7 @@ describe('listELearning', () => {
         { query: 'lean' },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       programFind,
       [
         { query: 'find', args: [{ _id: programId, subPrograms: { $in: subPrograms } }] },
@@ -235,7 +235,7 @@ describe('getProgram', () => {
         }],
       }],
     });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       programFindOne,
       [
         { query: 'findOne', args: [{ _id: program._id }] },
@@ -418,11 +418,11 @@ describe('addTester', () => {
 
     await ProgramHelper.addTester(programId, user);
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [{ query: 'findOne', args: [{ 'local.email': 'test@test.fr' }] }, { query: 'lean' }]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneAndUpdate,
       [
         { query: 'findOne', args: [{ _id: programId }, { $addToSet: { testers: user._id } }, { new: true }] },
@@ -443,11 +443,11 @@ describe('addTester', () => {
 
     await ProgramHelper.addTester(programId, payload);
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [{ query: 'findOne', args: [{ 'local.email': 'test@test.fr' }] }, { query: 'lean' }]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneAndUpdate,
       [
         { query: 'findOne', args: [{ _id: programId }, { $addToSet: { testers: userId } }, { new: true }] },

--- a/tests/unit/helpers/programs.test.js
+++ b/tests/unit/helpers/programs.test.js
@@ -425,7 +425,7 @@ describe('addTester', () => {
     SinonMongoose.calledOnceWithExactly(
       findOneAndUpdate,
       [
-        { query: 'findOne', args: [{ _id: programId }, { $addToSet: { testers: user._id } }, { new: true }] },
+        { query: 'findOneAndUpdate', args: [{ _id: programId }, { $addToSet: { testers: user._id } }, { new: true }] },
         { query: 'lean' },
       ]
     );
@@ -450,7 +450,7 @@ describe('addTester', () => {
     SinonMongoose.calledOnceWithExactly(
       findOneAndUpdate,
       [
-        { query: 'findOne', args: [{ _id: programId }, { $addToSet: { testers: userId } }, { new: true }] },
+        { query: 'findOneAndUpdate', args: [{ _id: programId }, { $addToSet: { testers: userId } }, { new: true }] },
         { query: 'lean' },
       ]
     );

--- a/tests/unit/helpers/questionnaires.test.js
+++ b/tests/unit/helpers/questionnaires.test.js
@@ -43,7 +43,7 @@ describe('list', () => {
     const result = await QuestionnaireHelper.list();
 
     expect(result).toMatchObject(questionnairesList);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       find,
       [{ query: 'find' }, { query: 'populate', args: [{ path: 'historiesCount' }] }, { query: 'lean' }]
     );
@@ -68,7 +68,7 @@ describe('getQuestionnaire', () => {
     const result = await QuestionnaireHelper.getQuestionnaire(questionnaireId);
 
     expect(result).toMatchObject(questionnaire);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [
         { query: 'findOne', args: [{ _id: questionnaireId }] },
@@ -98,7 +98,7 @@ describe('editQuestionnaire', () => {
     const result = await QuestionnaireHelper.update(questionnaireId, { name: 'test2', cards });
 
     expect(result).toMatchObject(questionnaire);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneAndUpdate,
       [
         { query: 'findOneAndUpdate', args: [{ _id: questionnaireId }, { $set: { name: 'test2', cards } }] },
@@ -158,7 +158,7 @@ describe('removeCard', () => {
 
     sinon.assert.calledOnceWithExactly(updateOne, { cards: cardId }, { $pull: { cards: cardId } });
     sinon.assert.notCalled(deleteMedia);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneAndRemoveCard,
       [
         { query: 'findOne', args: [{ _id: cardId }, { 'media.publicId': 1 }] },
@@ -177,7 +177,7 @@ describe('removeCard', () => {
 
     sinon.assert.calledOnceWithExactly(updateOne, { cards: cardId }, { $pull: { cards: cardId } });
     sinon.assert.calledOnceWithExactly(deleteMedia, cardId, 'publicId');
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneAndRemoveCard,
       [
         { query: 'findOne', args: [{ _id: cardId }, { 'media.publicId': 1 }] },
@@ -214,7 +214,7 @@ describe('getUserQuestionnaires', () => {
 
     expect(result).toMatchObject([]);
     sinon.assert.notCalled(findOneQuestionnaire);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneCourse,
       [
         { query: 'findOne', args: [{ _id: courseId }] },
@@ -240,7 +240,7 @@ describe('getUserQuestionnaires', () => {
     const result = await QuestionnaireHelper.getUserQuestionnaires(courseId, credentials);
 
     expect(result).toMatchObject([]);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneCourse,
       [
         { query: 'findOne', args: [{ _id: courseId }] },
@@ -249,7 +249,7 @@ describe('getUserQuestionnaires', () => {
         { query: 'lean', args: [{ virtuals: true }] },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneQuestionnaire,
       [
         { query: 'findOne', args: [{ type: EXPECTATIONS, status: PUBLISHED }, { type: 1, name: 1 }] },
@@ -279,7 +279,7 @@ describe('getUserQuestionnaires', () => {
     const result = await QuestionnaireHelper.getUserQuestionnaires(courseId, credentials);
 
     expect(result).toMatchObject([]);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneCourse,
       [
         { query: 'findOne', args: [{ _id: courseId }] },
@@ -288,7 +288,7 @@ describe('getUserQuestionnaires', () => {
         { query: 'lean', args: [{ virtuals: true }] },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneQuestionnaire,
       [
         { query: 'findOne', args: [{ type: EXPECTATIONS, status: PUBLISHED }, { type: 1, name: 1 }] },
@@ -314,7 +314,7 @@ describe('getUserQuestionnaires', () => {
     const result = await QuestionnaireHelper.getUserQuestionnaires(courseId, credentials);
 
     expect(result).toMatchObject([questionnaire]);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneCourse,
       [
         { query: 'findOne', args: [{ _id: courseId }] },
@@ -323,7 +323,7 @@ describe('getUserQuestionnaires', () => {
         { query: 'lean', args: [{ virtuals: true }] },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneQuestionnaire,
       [
         { query: 'findOne', args: [{ type: EXPECTATIONS, status: PUBLISHED }, { type: 1, name: 1 }] },
@@ -346,7 +346,7 @@ describe('getUserQuestionnaires', () => {
     const result = await QuestionnaireHelper.getUserQuestionnaires(courseId, credentials);
 
     expect(result).toMatchObject([questionnaire]);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneCourse,
       [
         { query: 'findOne', args: [{ _id: courseId }] },
@@ -355,7 +355,7 @@ describe('getUserQuestionnaires', () => {
         { query: 'lean', args: [{ virtuals: true }] },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneQuestionnaire,
       [
         { query: 'findOne', args: [{ type: EXPECTATIONS, status: PUBLISHED }, { type: 1, name: 1 }] },
@@ -381,7 +381,7 @@ describe('getUserQuestionnaires', () => {
 
     expect(result).toMatchObject([]);
     sinon.assert.notCalled(findOneQuestionnaire);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneCourse,
       [
         { query: 'findOne', args: [{ _id: courseId }] },
@@ -407,7 +407,7 @@ describe('getUserQuestionnaires', () => {
     const result = await QuestionnaireHelper.getUserQuestionnaires(courseId, credentials);
 
     expect(result).toMatchObject([]);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneCourse,
       [
         { query: 'findOne', args: [{ _id: courseId }] },
@@ -416,7 +416,7 @@ describe('getUserQuestionnaires', () => {
         { query: 'lean', args: [{ virtuals: true }] },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneQuestionnaire,
       [
         { query: 'findOne', args: [{ type: END_OF_COURSE, status: PUBLISHED }, { type: 1, name: 1 }] },
@@ -446,7 +446,7 @@ describe('getUserQuestionnaires', () => {
     const result = await QuestionnaireHelper.getUserQuestionnaires(courseId, credentials);
 
     expect(result).toMatchObject([]);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneCourse,
       [
         { query: 'findOne', args: [{ _id: courseId }] },
@@ -455,7 +455,7 @@ describe('getUserQuestionnaires', () => {
         { query: 'lean', args: [{ virtuals: true }] },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneQuestionnaire,
       [
         { query: 'findOne', args: [{ type: END_OF_COURSE, status: PUBLISHED }, { type: 1, name: 1 }] },
@@ -481,7 +481,7 @@ describe('getUserQuestionnaires', () => {
     const result = await QuestionnaireHelper.getUserQuestionnaires(courseId, credentials);
 
     expect(result).toMatchObject([questionnaire]);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneCourse,
       [
         { query: 'findOne', args: [{ _id: courseId }] },
@@ -490,7 +490,7 @@ describe('getUserQuestionnaires', () => {
         { query: 'lean', args: [{ virtuals: true }] },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneQuestionnaire,
       [
         { query: 'findOne', args: [{ type: END_OF_COURSE, status: PUBLISHED }, { type: 1, name: 1 }] },
@@ -519,7 +519,7 @@ describe('getUserQuestionnaires', () => {
 
     expect(result).toMatchObject([]);
     sinon.assert.notCalled(findOneQuestionnaire);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneCourse,
       [
         { query: 'findOne', args: [{ _id: courseId }] },
@@ -648,7 +648,7 @@ describe('getFollowUp', () => {
         },
       ],
     });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       courseFindOne,
       [
         { query: 'findOne', args: [{ _id: courseId }] },
@@ -661,7 +661,7 @@ describe('getFollowUp', () => {
         { query: 'lean' },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       questionnaireFindOne,
       [
         { query: 'findOne', args: [{ _id: questionnaireId }] },
@@ -795,7 +795,7 @@ describe('getFollowUp', () => {
         },
       ],
     });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       courseFindOne,
       [
         { query: 'findOne', args: [{ _id: courseId }] },
@@ -808,7 +808,7 @@ describe('getFollowUp', () => {
         { query: 'lean' },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       questionnaireFindOne,
       [
         { query: 'findOne', args: [{ _id: questionnaireId }] },
@@ -929,7 +929,7 @@ describe('getFollowUp', () => {
         },
       ],
     });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       questionnaireFindOne,
       [
         { query: 'findOne', args: [{ _id: questionnaireId }] },
@@ -997,7 +997,7 @@ describe('getFollowUp', () => {
       questionnaire: { type: EXPECTATIONS, name: 'questionnaire' },
       followUp: [],
     });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       courseFindOne,
       [
         { query: 'findOne', args: [{ _id: courseId }] },
@@ -1010,7 +1010,7 @@ describe('getFollowUp', () => {
         { query: 'lean' },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       questionnaireFindOne,
       [
         { query: 'findOne', args: [{ _id: questionnaireId }] },
@@ -1069,7 +1069,7 @@ describe('getFollowUp', () => {
       questionnaire: { type: EXPECTATIONS, name: 'questionnaire' },
       followUp: [],
     });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       courseFindOne,
       [
         { query: 'findOne', args: [{ _id: courseId }] },
@@ -1082,7 +1082,7 @@ describe('getFollowUp', () => {
         { query: 'lean' },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       questionnaireFindOne,
       [
         { query: 'findOne', args: [{ _id: questionnaireId }] },
@@ -1147,7 +1147,7 @@ describe('getFollowUp', () => {
       questionnaire: { type: EXPECTATIONS, name: 'questionnaire' },
       followUp: [],
     });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       courseFindOne,
       [
         { query: 'findOne', args: [{ _id: courseId }] },
@@ -1160,7 +1160,7 @@ describe('getFollowUp', () => {
         { query: 'lean' },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       questionnaireFindOne,
       [
         { query: 'findOne', args: [{ _id: questionnaireId }] },

--- a/tests/unit/helpers/questionnaires.test.js
+++ b/tests/unit/helpers/questionnaires.test.js
@@ -161,7 +161,7 @@ describe('removeCard', () => {
     SinonMongoose.calledOnceWithExactly(
       findOneAndRemoveCard,
       [
-        { query: 'findOne', args: [{ _id: cardId }, { 'media.publicId': 1 }] },
+        { query: 'findOneAndRemove', args: [{ _id: cardId }, { 'media.publicId': 1 }] },
         { query: 'lean' },
       ]
     );
@@ -180,7 +180,7 @@ describe('removeCard', () => {
     SinonMongoose.calledOnceWithExactly(
       findOneAndRemoveCard,
       [
-        { query: 'findOne', args: [{ _id: cardId }, { 'media.publicId': 1 }] },
+        { query: 'findOneAndRemove', args: [{ _id: cardId }, { 'media.publicId': 1 }] },
         { query: 'lean' },
       ]
     );

--- a/tests/unit/helpers/quotes.test.js
+++ b/tests/unit/helpers/quotes.test.js
@@ -24,7 +24,7 @@ describe('getQuotes', () => {
 
     await QuoteHelper.getQuotes(customerId);
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [
         {
@@ -55,7 +55,7 @@ describe('getQuoteNumber', () => {
 
     await QuoteHelper.getQuoteNumber(company._id);
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneAndUpdate,
       [
         {
@@ -116,7 +116,7 @@ describe('createQuote', () => {
 
     sinon.assert.calledOnceWithExactly(getQuoteNumberStub, credentials.company._id);
     sinon.assert.calledOnceWithExactly(formatQuoteNumberStub, credentials.company.prefixNumber, 'pre', 2);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneAndUpdate,
       [
         {

--- a/tests/unit/helpers/referentHistories.test.js
+++ b/tests/unit/helpers/referentHistories.test.js
@@ -38,7 +38,7 @@ describe('updateCustomerReferent', () => {
       sinon.assert.notCalled(createReferentHistory);
       sinon.assert.notCalled(findOneCustomer);
       sinon.assert.notCalled(deleteOneReferentHistory);
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         findReferentHistory,
         [
           { query: 'find', args: [{ customer: customerId, company: company._id }] },
@@ -58,7 +58,7 @@ describe('updateCustomerReferent', () => {
       sinon.assert.calledOnceWithExactly(createReferentHistory, customerId, referent.toHexString(), company);
       sinon.assert.notCalled(findOneCustomer);
       sinon.assert.notCalled(deleteOneReferentHistory);
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         findReferentHistory,
         [
           { query: 'find', args: [{ customer: customerId, company: company._id }] },
@@ -80,7 +80,7 @@ describe('updateCustomerReferent', () => {
       sinon.assert.notCalled(createReferentHistory);
       sinon.assert.notCalled(findOneCustomer);
       sinon.assert.notCalled(deleteOneReferentHistory);
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         findReferentHistory,
         [
           { query: 'find', args: [{ customer: customerId, company: company._id }] },
@@ -101,7 +101,7 @@ describe('updateCustomerReferent', () => {
       sinon.assert.calledOnceWithExactly(createReferentHistory, customerId, referent.toHexString(), company);
       sinon.assert.notCalled(findOneCustomer);
       sinon.assert.notCalled(deleteOneReferentHistory);
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         findReferentHistory,
         [
           { query: 'find', args: [{ customer: customerId, company: company._id }] },
@@ -123,7 +123,7 @@ describe('updateCustomerReferent', () => {
       sinon.assert.notCalled(createReferentHistory);
       sinon.assert.notCalled(findOneCustomer);
       sinon.assert.notCalled(deleteOneReferentHistory);
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         findReferentHistory,
         [
           { query: 'find', args: [{ customer: customerId, company: company._id }] },
@@ -144,7 +144,7 @@ describe('updateCustomerReferent', () => {
       sinon.assert.notCalled(createReferentHistory);
       sinon.assert.notCalled(findOneCustomer);
       sinon.assert.notCalled(deleteOneReferentHistory);
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         findReferentHistory,
         [
           { query: 'find', args: [{ customer: customerId, company: company._id }] },
@@ -168,7 +168,7 @@ describe('updateCustomerReferent', () => {
       sinon.assert.calledOnceWithExactly(createReferentHistory, customerId, referent.toHexString(), company);
       sinon.assert.notCalled(findOneCustomer);
       sinon.assert.notCalled(deleteOneReferentHistory);
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         findReferentHistory,
         [
           { query: 'find', args: [{ customer: customerId, company: company._id }] },
@@ -192,7 +192,7 @@ describe('updateCustomerReferent', () => {
       sinon.assert.notCalled(updateLastHistory);
       sinon.assert.notCalled(createReferentHistory);
       sinon.assert.calledOnceWithExactly(deleteOneReferentHistory, { _id: lastHistory._id });
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         findReferentHistory,
         [
           { query: 'find', args: [{ customer: customerId, company: company._id }] },
@@ -201,7 +201,7 @@ describe('updateCustomerReferent', () => {
           { query: 'lean' },
         ]
       );
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         findOneCustomer,
         [
           { query: 'find', args: [{ _id: customerId }] },
@@ -223,7 +223,7 @@ describe('updateCustomerReferent', () => {
       sinon.assert.notCalled(updateLastHistory);
       sinon.assert.notCalled(createReferentHistory);
       sinon.assert.calledOnceWithExactly(deleteOneReferentHistory, { _id: lastHistory._id });
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         findReferentHistory,
         [
           { query: 'find', args: [{ customer: customerId, company: company._id }] },
@@ -232,7 +232,7 @@ describe('updateCustomerReferent', () => {
           { query: 'lean' },
         ]
       );
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         findOneCustomer,
         [
           { query: 'find', args: [{ _id: customerId }] },
@@ -260,7 +260,7 @@ describe('updateCustomerReferent', () => {
       );
       sinon.assert.notCalled(createReferentHistory);
       sinon.assert.notCalled(deleteOneReferentHistory);
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         findReferentHistory,
         [
           { query: 'find', args: [{ customer: customerId, company: company._id }] },
@@ -269,7 +269,7 @@ describe('updateCustomerReferent', () => {
           { query: 'lean' },
         ]
       );
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         findOneCustomer,
         [
           { query: 'find', args: [{ _id: customerId }] },
@@ -294,7 +294,7 @@ describe('updateCustomerReferent', () => {
       sinon.assert.notCalled(updateLastHistory);
       sinon.assert.notCalled(createReferentHistory);
       sinon.assert.notCalled(deleteOneReferentHistory);
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         findReferentHistory,
         [
           { query: 'find', args: [{ customer: customerId, company: company._id }] },
@@ -303,7 +303,7 @@ describe('updateCustomerReferent', () => {
           { query: 'lean' },
         ]
       );
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         findOneCustomer,
         [
           { query: 'find', args: [{ _id: customerId }] },
@@ -330,7 +330,7 @@ describe('updateCustomerReferent', () => {
       );
       sinon.assert.notCalled(createReferentHistory);
       sinon.assert.notCalled(deleteOneReferentHistory);
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         findReferentHistory,
         [
           { query: 'find', args: [{ customer: customerId, company: company._id }] },
@@ -339,7 +339,7 @@ describe('updateCustomerReferent', () => {
           { query: 'lean' },
         ]
       );
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         findOneCustomer,
         [
           { query: 'find', args: [{ _id: customerId }] },
@@ -368,7 +368,7 @@ describe('updateCustomerReferent', () => {
       sinon.assert.calledOnceWithExactly(updateLastHistory, lastHistory, { auxiliary: referent.toHexString() });
       sinon.assert.notCalled(createReferentHistory);
       sinon.assert.notCalled(deleteOneReferentHistory);
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         findReferentHistory,
         [
           { query: 'find', args: [{ customer: customerId, company: company._id }] },
@@ -377,7 +377,7 @@ describe('updateCustomerReferent', () => {
           { query: 'lean' },
         ]
       );
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         findOneCustomer,
         [
           { query: 'find', args: [{ _id: customerId }] },
@@ -406,7 +406,7 @@ describe('updateCustomerReferent', () => {
       );
       sinon.assert.calledOnceWithExactly(createReferentHistory, customerId, referent.toHexString(), company);
       sinon.assert.notCalled(deleteOneReferentHistory);
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         findReferentHistory,
         [
           { query: 'find', args: [{ customer: customerId, company: company._id }] },
@@ -415,7 +415,7 @@ describe('updateCustomerReferent', () => {
           { query: 'lean' },
         ]
       );
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         findOneCustomer,
         [
           { query: 'find', args: [{ _id: customerId }] },

--- a/tests/unit/helpers/referentHistories.test.js
+++ b/tests/unit/helpers/referentHistories.test.js
@@ -204,7 +204,7 @@ describe('updateCustomerReferent', () => {
       SinonMongoose.calledOnceWithExactly(
         findOneCustomer,
         [
-          { query: 'find', args: [{ _id: customerId }] },
+          { query: 'findOne', args: [{ _id: customerId }] },
           {
             query: 'populate',
             args: [{ path: 'firstIntervention', select: 'startDate', match: { company: company._id } }],
@@ -235,7 +235,7 @@ describe('updateCustomerReferent', () => {
       SinonMongoose.calledOnceWithExactly(
         findOneCustomer,
         [
-          { query: 'find', args: [{ _id: customerId }] },
+          { query: 'findOne', args: [{ _id: customerId }] },
           {
             query: 'populate',
             args: [{ path: 'firstIntervention', select: 'startDate', match: { company: company._id } }],
@@ -272,7 +272,7 @@ describe('updateCustomerReferent', () => {
       SinonMongoose.calledOnceWithExactly(
         findOneCustomer,
         [
-          { query: 'find', args: [{ _id: customerId }] },
+          { query: 'findOne', args: [{ _id: customerId }] },
           {
             query: 'populate',
             args: [{ path: 'firstIntervention', select: 'startDate', match: { company: company._id } }],
@@ -306,7 +306,7 @@ describe('updateCustomerReferent', () => {
       SinonMongoose.calledOnceWithExactly(
         findOneCustomer,
         [
-          { query: 'find', args: [{ _id: customerId }] },
+          { query: 'findOne', args: [{ _id: customerId }] },
           {
             query: 'populate',
             args: [{ path: 'firstIntervention', select: 'startDate', match: { company: company._id } }],
@@ -342,7 +342,7 @@ describe('updateCustomerReferent', () => {
       SinonMongoose.calledOnceWithExactly(
         findOneCustomer,
         [
-          { query: 'find', args: [{ _id: customerId }] },
+          { query: 'findOne', args: [{ _id: customerId }] },
           {
             query: 'populate',
             args: [{ path: 'firstIntervention', select: 'startDate', match: { company: company._id } }],
@@ -380,7 +380,7 @@ describe('updateCustomerReferent', () => {
       SinonMongoose.calledOnceWithExactly(
         findOneCustomer,
         [
-          { query: 'find', args: [{ _id: customerId }] },
+          { query: 'findOne', args: [{ _id: customerId }] },
           {
             query: 'populate',
             args: [{ path: 'firstIntervention', select: 'startDate', match: { company: company._id } }],
@@ -418,7 +418,7 @@ describe('updateCustomerReferent', () => {
       SinonMongoose.calledOnceWithExactly(
         findOneCustomer,
         [
-          { query: 'find', args: [{ _id: customerId }] },
+          { query: 'findOne', args: [{ _id: customerId }] },
           {
             query: 'populate',
             args: [{ path: 'firstIntervention', select: 'startDate', match: { company: company._id } }],

--- a/tests/unit/helpers/repetitions.test.js
+++ b/tests/unit/helpers/repetitions.test.js
@@ -38,7 +38,7 @@ describe('updateRepetitions', () => {
     expect(result).toBeUndefined();
     SinonMongoose.calledOnceWithExactly(
       findOneRepetition,
-      [{ query: 'find', args: [{ parentId }] }, { query: 'lean' }]
+      [{ query: 'findOne', args: [{ parentId }] }, { query: 'lean' }]
     );
     sinon.assert.calledOnceWithExactly(findOneAndUpdateRepetition, { parentId }, { payload: 'payload' });
     sinon.assert.calledOnceWithExactly(
@@ -58,7 +58,7 @@ describe('updateRepetitions', () => {
     expect(result).toBeUndefined();
     SinonMongoose.calledOnceWithExactly(
       findOneRepetition,
-      [{ query: 'find', args: [{ parentId }] }, { query: 'lean' }]
+      [{ query: 'findOne', args: [{ parentId }] }, { query: 'lean' }]
     );
     sinon.assert.notCalled(findOneAndUpdateRepetition);
     sinon.assert.notCalled(formatEditionPayloadStub);

--- a/tests/unit/helpers/repetitions.test.js
+++ b/tests/unit/helpers/repetitions.test.js
@@ -36,7 +36,10 @@ describe('updateRepetitions', () => {
     const result = await RepetitionHelper.updateRepetitions(eventPayload, parentId);
 
     expect(result).toBeUndefined();
-    SinonMongoose.calledWithExactly(findOneRepetition, [{ query: 'find', args: [{ parentId }] }, { query: 'lean' }]);
+    SinonMongoose.calledOnceWithExactly(
+      findOneRepetition,
+      [{ query: 'find', args: [{ parentId }] }, { query: 'lean' }]
+    );
     sinon.assert.calledOnceWithExactly(findOneAndUpdateRepetition, { parentId }, { payload: 'payload' });
     sinon.assert.calledOnceWithExactly(
       formatEditionPayloadStub,
@@ -53,7 +56,10 @@ describe('updateRepetitions', () => {
     const result = await RepetitionHelper.updateRepetitions({}, parentId);
 
     expect(result).toBeUndefined();
-    SinonMongoose.calledWithExactly(findOneRepetition, [{ query: 'find', args: [{ parentId }] }, { query: 'lean' }]);
+    SinonMongoose.calledOnceWithExactly(
+      findOneRepetition,
+      [{ query: 'find', args: [{ parentId }] }, { query: 'lean' }]
+    );
     sinon.assert.notCalled(findOneAndUpdateRepetition);
     sinon.assert.notCalled(formatEditionPayloadStub);
   });

--- a/tests/unit/helpers/sectorHistories.test.js
+++ b/tests/unit/helpers/sectorHistories.test.js
@@ -39,7 +39,7 @@ describe('updateHistoryOnSectorUpdate', () => {
     const result = await SectorHistoryHelper.updateHistoryOnSectorUpdate(auxiliaryId, sector.toHexString(), companyId);
 
     expect(result).toBeUndefined();
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [{ query: 'findOne', args: [{ auxiliary: auxiliaryId, endDate: null }] }, { query: 'lean' }]
     );
@@ -59,7 +59,7 @@ describe('updateHistoryOnSectorUpdate', () => {
     const result = await SectorHistoryHelper.updateHistoryOnSectorUpdate(auxiliaryId, sector.toHexString(), companyId);
 
     expect(result).toEqual(null);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [{ query: 'findOne', args: [{ auxiliary: auxiliaryId, endDate: null }] }, { query: 'lean' }]
     );
@@ -79,7 +79,7 @@ describe('updateHistoryOnSectorUpdate', () => {
     } catch (e) {
       expect(e).toEqual(Boom.conflict('No last sector history for auxiliary in contract'));
     } finally {
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         findOne,
         [{ query: 'findOne', args: [{ auxiliary: auxiliaryId, endDate: null }] }, { query: 'lean' }]
       );
@@ -97,11 +97,11 @@ describe('updateHistoryOnSectorUpdate', () => {
     const result = await SectorHistoryHelper.updateHistoryOnSectorUpdate(auxiliaryId, sector.toHexString(), companyId);
 
     expect(result).toEqual({ sector });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [{ query: 'findOne', args: [{ auxiliary: auxiliaryId, endDate: null }] }, { query: 'lean' }]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       find,
       [{ query: 'find', args: [{ user: auxiliaryId, company: companyId, endDate: null }] }, { query: 'lean' }]
     );
@@ -124,11 +124,11 @@ describe('updateHistoryOnSectorUpdate', () => {
     const result = await SectorHistoryHelper.updateHistoryOnSectorUpdate(auxiliaryId, sector.toHexString(), companyId);
 
     expect(result).toEqual({ sector });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [{ query: 'findOne', args: [{ auxiliary: auxiliaryId, endDate: null }] }, { query: 'lean' }]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       find,
       [
         { query: 'find', args: [{ user: auxiliaryId, company: companyId, endDate: null }] },
@@ -153,11 +153,11 @@ describe('updateHistoryOnSectorUpdate', () => {
     const result = await SectorHistoryHelper.updateHistoryOnSectorUpdate(auxiliaryId, sector.toHexString(), companyId);
 
     expect(result).toEqual({ sector });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [{ query: 'findOne', args: [{ auxiliary: auxiliaryId, endDate: null }] }, { query: 'lean' }]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       find,
       [
         { query: 'find', args: [{ user: auxiliaryId, company: companyId, endDate: null }] },
@@ -193,11 +193,11 @@ describe('updateHistoryOnSectorUpdate', () => {
       companyId,
       moment().startOf('day').toDate()
     );
-    SinonMongoose.calledWithExactly(findOne, [
+    SinonMongoose.calledOnceWithExactly(findOne, [
       { query: 'findOne', args: [{ auxiliary: auxiliaryId, endDate: null }] },
       { query: 'lean' },
     ]);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       find, [
         { query: 'find', args: [{ user: auxiliaryId, company: companyId, endDate: null }] },
         { query: 'sort', args: [{ startDate: -1 }] },
@@ -246,7 +246,7 @@ describe('createHistoryOnContractCreation', () => {
 
     await SectorHistoryHelper.createHistoryOnContractCreation(user, newContract, companyId);
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       countDocuments,
       [
         {
@@ -256,7 +256,7 @@ describe('createHistoryOnContractCreation', () => {
         { query: 'lean' },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [
         { query: 'findOne', args: [{ startDate: { $exists: false }, auxiliary: auxiliaryId }] },
@@ -279,7 +279,7 @@ describe('createHistoryOnContractCreation', () => {
 
     await SectorHistoryHelper.createHistoryOnContractCreation(user, newContract, companyId);
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       countDocuments,
       [
         {
@@ -295,7 +295,7 @@ describe('createHistoryOnContractCreation', () => {
       companyId,
       moment(newContract.startDate).startOf('day').toDate()
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [
         { query: 'findOne', args: [{ startDate: { $exists: false }, auxiliary: auxiliaryId }] },
@@ -318,7 +318,7 @@ describe('createHistoryOnContractCreation', () => {
     } catch (e) {
       expect(e).toEqual(Boom.conflict('There is a sector history with a startDate without an endDate'));
     } finally {
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         countDocuments,
         [
           {
@@ -367,7 +367,7 @@ describe('updateHistoryOnContractUpdate', () => {
 
     await SectorHistoryHelper.updateHistoryOnContractUpdate(contractId, newContract, companyId);
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [{ query: 'findOne', args: [{ _id: contractId, company: companyId }] }, { query: 'lean' }]
     );
@@ -386,7 +386,7 @@ describe('updateHistoryOnContractUpdate', () => {
 
     await SectorHistoryHelper.updateHistoryOnContractUpdate(contractId, newContract, companyId);
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [{ query: 'findOne', args: [{ _id: contractId, company: companyId }] }, { query: 'lean' }]
     );
@@ -394,7 +394,7 @@ describe('updateHistoryOnContractUpdate', () => {
       remove,
       { auxiliary: auxiliaryId, endDate: { $gte: '2019-01-01', $lte: newContract.startDate } }
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       find,
       [
         {
@@ -439,7 +439,7 @@ describe('updateHistoryOnContractDeletion', () => {
 
     await SectorHistoryHelper.updateHistoryOnContractDeletion(contract, companyId);
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [{ query: 'findOne', args: [{ auxiliary: contract.user, endDate: null }] }, { query: 'lean' }]
     );
@@ -478,7 +478,7 @@ describe('createHistory', () => {
     const result = await SectorHistoryHelper.createHistory({ _id: auxiliaryId, sector }, companyId);
 
     expect(result).toEqual(sectorHistory);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       create,
       [
         { query: 'create', args: [{ auxiliary: auxiliaryId, sector, company: companyId }] },
@@ -495,7 +495,7 @@ describe('createHistory', () => {
     const result = await SectorHistoryHelper.createHistory({ _id: auxiliaryId, sector }, companyId, '2020-01-01');
 
     expect(result).toEqual(sectorHistory);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       create,
       [
         { query: 'create', args: [{ auxiliary: auxiliaryId, sector, company: companyId, startDate: '2020-01-01' }] },
@@ -553,7 +553,7 @@ describe('getAuxiliarySectors', () => {
     const result = await SectorHistoryHelper.getAuxiliarySectors(auxiliaryId, companyId, '2020-01-01', '2020-02-01');
 
     expect(result).toEqual([sectorId1.toHexString(), sectorId2.toHexString()]);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       sectorHistoryFind,
       [
         {

--- a/tests/unit/helpers/sectorHistories.test.js
+++ b/tests/unit/helpers/sectorHistories.test.js
@@ -193,12 +193,13 @@ describe('updateHistoryOnSectorUpdate', () => {
       companyId,
       moment().startOf('day').toDate()
     );
-    SinonMongoose.calledOnceWithExactly(findOne, [
-      { query: 'findOne', args: [{ auxiliary: auxiliaryId, endDate: null }] },
-      { query: 'lean' },
-    ]);
     SinonMongoose.calledOnceWithExactly(
-      find, [
+      findOne,
+      [{ query: 'findOne', args: [{ auxiliary: auxiliaryId, endDate: null }] }, { query: 'lean' }]
+    );
+    SinonMongoose.calledOnceWithExactly(
+      find,
+      [
         { query: 'find', args: [{ user: auxiliaryId, company: companyId, endDate: null }] },
         { query: 'sort', args: [{ startDate: -1 }] },
         { query: 'lean' },

--- a/tests/unit/helpers/sectors.test.js
+++ b/tests/unit/helpers/sectors.test.js
@@ -25,7 +25,7 @@ describe('create', () => {
 
     expect(result).toMatchObject({ name: 'toto', company: companyId });
 
-    SinonMongoose.calledWithExactly(create, [
+    SinonMongoose.calledOnceWithExactly(create, [
       { query: 'create', args: [{ name: 'toto', company: companyId }] },
       { query: 'toObject' },
     ]);
@@ -49,7 +49,7 @@ describe('list', () => {
 
     await SectorsHelper.list(credentials);
 
-    SinonMongoose.calledWithExactly(find, [
+    SinonMongoose.calledOnceWithExactly(find, [
       { query: 'find', args: [{ company: companyId }] },
       { query: 'lean' },
     ]);
@@ -75,7 +75,7 @@ describe('update', () => {
 
     await SectorsHelper.update(sectorId, payload, credentials);
 
-    SinonMongoose.calledWithExactly(findOneAndUpdate, [
+    SinonMongoose.calledOnceWithExactly(findOneAndUpdate, [
       { query: 'findOneAndUpdate', args: [{ _id: sectorId }, { $set: payload }, { new: true }] },
       { query: 'lean' },
     ]);

--- a/tests/unit/helpers/sectors.test.js
+++ b/tests/unit/helpers/sectors.test.js
@@ -25,10 +25,13 @@ describe('create', () => {
 
     expect(result).toMatchObject({ name: 'toto', company: companyId });
 
-    SinonMongoose.calledOnceWithExactly(create, [
-      { query: 'create', args: [{ name: 'toto', company: companyId }] },
-      { query: 'toObject' },
-    ]);
+    SinonMongoose.calledOnceWithExactly(
+      create,
+      [
+        { query: 'create', args: [{ name: 'toto', company: companyId }] },
+        { query: 'toObject' },
+      ]
+    );
   });
 });
 
@@ -49,10 +52,13 @@ describe('list', () => {
 
     await SectorsHelper.list(credentials);
 
-    SinonMongoose.calledOnceWithExactly(find, [
-      { query: 'find', args: [{ company: companyId }] },
-      { query: 'lean' },
-    ]);
+    SinonMongoose.calledOnceWithExactly(
+      find,
+      [
+        { query: 'find', args: [{ company: companyId }] },
+        { query: 'lean' },
+      ]
+    );
   });
 });
 
@@ -75,10 +81,13 @@ describe('update', () => {
 
     await SectorsHelper.update(sectorId, payload, credentials);
 
-    SinonMongoose.calledOnceWithExactly(findOneAndUpdate, [
-      { query: 'findOneAndUpdate', args: [{ _id: sectorId }, { $set: payload }, { new: true }] },
-      { query: 'lean' },
-    ]);
+    SinonMongoose.calledOnceWithExactly(
+      findOneAndUpdate,
+      [
+        { query: 'findOneAndUpdate', args: [{ _id: sectorId }, { $set: payload }, { new: true }] },
+        { query: 'lean' },
+      ]
+    );
   });
 });
 

--- a/tests/unit/helpers/services.test.js
+++ b/tests/unit/helpers/services.test.js
@@ -24,12 +24,15 @@ describe('list', () => {
 
     expect(result).toStrictEqual([{ name: 'test' }]);
 
-    SinonMongoose.calledOnceWithExactly(find, [
-      { query: 'find', args: [{ company: companyId, isArchived: true }] },
-      { query: 'populate', args: [{ path: 'versions.surcharge', match: { company: companyId } }] },
-      { query: 'populate', args: [{ path: 'versions.billingItems', select: 'name' }] },
-      { query: 'lean' },
-    ]);
+    SinonMongoose.calledOnceWithExactly(
+      find,
+      [
+        { query: 'find', args: [{ company: companyId, isArchived: true }] },
+        { query: 'populate', args: [{ path: 'versions.surcharge', match: { company: companyId } }] },
+        { query: 'populate', args: [{ path: 'versions.billingItems', select: 'name' }] },
+        { query: 'lean' },
+      ]
+    );
   });
 });
 

--- a/tests/unit/helpers/services.test.js
+++ b/tests/unit/helpers/services.test.js
@@ -24,7 +24,7 @@ describe('list', () => {
 
     expect(result).toStrictEqual([{ name: 'test' }]);
 
-    SinonMongoose.calledWithExactly(find, [
+    SinonMongoose.calledOnceWithExactly(find, [
       { query: 'find', args: [{ company: companyId, isArchived: true }] },
       { query: 'populate', args: [{ path: 'versions.surcharge', match: { company: companyId } }] },
       { query: 'populate', args: [{ path: 'versions.billingItems', select: 'name' }] },

--- a/tests/unit/helpers/steps.test.js
+++ b/tests/unit/helpers/steps.test.js
@@ -278,7 +278,7 @@ describe('list', () => {
       { _id: stepId1, name: 'etape 1', type: 'on_site' },
       { _id: stepId3, name: 'etape 3', type: 'remote' },
     ]);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       stepFind,
       [
         { query: 'find', args: [] },

--- a/tests/unit/helpers/subPrograms.test.js
+++ b/tests/unit/helpers/subPrograms.test.js
@@ -108,7 +108,7 @@ describe('updatedSubProgram', () => {
         { status: payload.status }
       );
       sinon.assert.calledWithExactly(activityUpdateManyStub, { _id: { $in: activities } }, { status: payload.status });
-      SinonMongoose.calledWithExactly(findOneAndUpdate, [
+      SinonMongoose.calledOnceWithExactly(findOneAndUpdate, [
         { query: 'findOneAndUpdate', args: [{ _id: subProgram._id }, { $set: payload }] },
         { query: 'populate', args: [{ path: 'steps', select: 'activities type' }] },
         { query: 'lean', args: [{ virtuals: true }] },
@@ -155,7 +155,7 @@ describe('updatedSubProgram', () => {
         { status: payload.status }
       );
       sinon.assert.calledWithExactly(activityUpdateManyStub, { _id: { $in: activities } }, { status: payload.status });
-      SinonMongoose.calledWithExactly(findOneAndUpdate, [
+      SinonMongoose.calledOnceWithExactly(findOneAndUpdate, [
         { query: 'findOneAndUpdate', args: [{ _id: subProgram._id }, { $set: { status: payload.status } }] },
         { query: 'populate', args: [{ path: 'steps', select: 'activities type' }] },
         { query: 'lean', args: [{ virtuals: true }] },
@@ -210,7 +210,7 @@ describe('updatedSubProgram', () => {
           { _id: { $in: activities } },
           { status: payload.status }
         );
-        SinonMongoose.calledWithExactly(findOneAndUpdate, [
+        SinonMongoose.calledOnceWithExactly(findOneAndUpdate, [
           { query: 'findOneAndUpdate', args: [{ _id: subProgram._id }, { $set: { status: payload.status } }] },
           { query: 'populate', args: [{ path: 'steps', select: 'activities type' }] },
           { query: 'lean', args: [{ virtuals: true }] },
@@ -260,7 +260,7 @@ describe('listELearningDraft', () => {
     const result = await SubProgramHelper.listELearningDraft();
 
     expect(result).toMatchObject([subProgramsList[0]]);
-    SinonMongoose.calledWithExactly(find, [
+    SinonMongoose.calledOnceWithExactly(find, [
       { query: 'find', args: [{ status: 'draft' }] },
       { query: 'populate', args: [{ path: 'program', select: '_id name description image' }] },
       { query: 'populate', args: [{ path: 'steps', select: 'type' }] },
@@ -296,7 +296,7 @@ describe('listELearningDraft', () => {
     const result = await SubProgramHelper.listELearningDraft(testerRestrictedPrograms);
 
     expect(result).toMatchObject([subProgramsList[0]]);
-    SinonMongoose.calledWithExactly(find, [
+    SinonMongoose.calledOnceWithExactly(find, [
       { query: 'find', args: [{ status: 'draft' }] },
       {
         query: 'populate',
@@ -336,7 +336,7 @@ describe('getSubProgram', () => {
     const result = await SubProgramHelper.getSubProgram(subProgram._id);
 
     expect(result).toMatchObject(subProgram);
-    SinonMongoose.calledWithExactly(findOne, [
+    SinonMongoose.calledOnceWithExactly(findOne, [
       { query: 'findOne', args: [{ _id: subProgram._id }] },
       { query: 'populate', args: [{ path: 'program', select: 'name image' }] },
       { query: 'populate', args: [{ path: 'steps', populate: { path: 'activities' } }] },

--- a/tests/unit/helpers/subPrograms.test.js
+++ b/tests/unit/helpers/subPrograms.test.js
@@ -108,11 +108,14 @@ describe('updatedSubProgram', () => {
         { status: payload.status }
       );
       sinon.assert.calledWithExactly(activityUpdateManyStub, { _id: { $in: activities } }, { status: payload.status });
-      SinonMongoose.calledOnceWithExactly(findOneAndUpdate, [
-        { query: 'findOneAndUpdate', args: [{ _id: subProgram._id }, { $set: payload }] },
-        { query: 'populate', args: [{ path: 'steps', select: 'activities type' }] },
-        { query: 'lean', args: [{ virtuals: true }] },
-      ]);
+      SinonMongoose.calledOnceWithExactly(
+        findOneAndUpdate,
+        [
+          { query: 'findOneAndUpdate', args: [{ _id: subProgram._id }, { $set: payload }] },
+          { query: 'populate', args: [{ path: 'steps', select: 'activities type' }] },
+          { query: 'lean', args: [{ virtuals: true }] },
+        ]
+      );
       sinon.assert.notCalled(courseCreateStub);
       sinon.assert.notCalled(sendNewElearningCourseNotification);
     });
@@ -155,11 +158,14 @@ describe('updatedSubProgram', () => {
         { status: payload.status }
       );
       sinon.assert.calledWithExactly(activityUpdateManyStub, { _id: { $in: activities } }, { status: payload.status });
-      SinonMongoose.calledOnceWithExactly(findOneAndUpdate, [
-        { query: 'findOneAndUpdate', args: [{ _id: subProgram._id }, { $set: { status: payload.status } }] },
-        { query: 'populate', args: [{ path: 'steps', select: 'activities type' }] },
-        { query: 'lean', args: [{ virtuals: true }] },
-      ]);
+      SinonMongoose.calledOnceWithExactly(
+        findOneAndUpdate,
+        [
+          { query: 'findOneAndUpdate', args: [{ _id: subProgram._id }, { $set: { status: payload.status } }] },
+          { query: 'populate', args: [{ path: 'steps', select: 'activities type' }] },
+          { query: 'lean', args: [{ virtuals: true }] },
+        ]
+      );
       sinon.assert.calledWithExactly(
         courseCreateStub,
         { subProgram: subProgram._id, type: 'inter_b2c', format: 'strictly_e_learning', accessRules: [] }
@@ -210,11 +216,14 @@ describe('updatedSubProgram', () => {
           { _id: { $in: activities } },
           { status: payload.status }
         );
-        SinonMongoose.calledOnceWithExactly(findOneAndUpdate, [
-          { query: 'findOneAndUpdate', args: [{ _id: subProgram._id }, { $set: { status: payload.status } }] },
-          { query: 'populate', args: [{ path: 'steps', select: 'activities type' }] },
-          { query: 'lean', args: [{ virtuals: true }] },
-        ]);
+        SinonMongoose.calledOnceWithExactly(
+          findOneAndUpdate,
+          [
+            { query: 'findOneAndUpdate', args: [{ _id: subProgram._id }, { $set: { status: payload.status } }] },
+            { query: 'populate', args: [{ path: 'steps', select: 'activities type' }] },
+            { query: 'lean', args: [{ virtuals: true }] },
+          ]
+        );
         sinon.assert.calledWithExactly(
           courseCreateStub,
           {
@@ -260,12 +269,15 @@ describe('listELearningDraft', () => {
     const result = await SubProgramHelper.listELearningDraft();
 
     expect(result).toMatchObject([subProgramsList[0]]);
-    SinonMongoose.calledOnceWithExactly(find, [
-      { query: 'find', args: [{ status: 'draft' }] },
-      { query: 'populate', args: [{ path: 'program', select: '_id name description image' }] },
-      { query: 'populate', args: [{ path: 'steps', select: 'type' }] },
-      { query: 'lean', args: [{ virtuals: true }] },
-    ]);
+    SinonMongoose.calledOnceWithExactly(
+      find,
+      [
+        { query: 'find', args: [{ status: 'draft' }] },
+        { query: 'populate', args: [{ path: 'program', select: '_id name description image' }] },
+        { query: 'populate', args: [{ path: 'steps', select: 'type' }] },
+        { query: 'lean', args: [{ virtuals: true }] },
+      ]
+    );
   });
 
   it('should return draft subprograms with elearning steps for tester', async () => {
@@ -296,19 +308,22 @@ describe('listELearningDraft', () => {
     const result = await SubProgramHelper.listELearningDraft(testerRestrictedPrograms);
 
     expect(result).toMatchObject([subProgramsList[0]]);
-    SinonMongoose.calledOnceWithExactly(find, [
-      { query: 'find', args: [{ status: 'draft' }] },
-      {
-        query: 'populate',
-        args: [{
-          path: 'program',
-          select: '_id name description image',
-          match: { _id: { $in: testerRestrictedPrograms } },
-        }],
-      },
-      { query: 'populate', args: [{ path: 'steps', select: 'type' }] },
-      { query: 'lean', args: [{ virtuals: true }] },
-    ]);
+    SinonMongoose.calledOnceWithExactly(
+      find,
+      [
+        { query: 'find', args: [{ status: 'draft' }] },
+        {
+          query: 'populate',
+          args: [{
+            path: 'program',
+            select: '_id name description image',
+            match: { _id: { $in: testerRestrictedPrograms } },
+          }],
+        },
+        { query: 'populate', args: [{ path: 'steps', select: 'type' }] },
+        { query: 'lean', args: [{ virtuals: true }] },
+      ]
+    );
   });
 });
 
@@ -336,12 +351,15 @@ describe('getSubProgram', () => {
     const result = await SubProgramHelper.getSubProgram(subProgram._id);
 
     expect(result).toMatchObject(subProgram);
-    SinonMongoose.calledOnceWithExactly(findOne, [
-      { query: 'findOne', args: [{ _id: subProgram._id }] },
-      { query: 'populate', args: [{ path: 'program', select: 'name image' }] },
-      { query: 'populate', args: [{ path: 'steps', populate: { path: 'activities' } }] },
-      { query: 'lean', args: [{ virtuals: true }] },
-    ]);
+    SinonMongoose.calledOnceWithExactly(
+      findOne,
+      [
+        { query: 'findOne', args: [{ _id: subProgram._id }] },
+        { query: 'populate', args: [{ path: 'program', select: 'name image' }] },
+        { query: 'populate', args: [{ path: 'steps', populate: { path: 'activities' } }] },
+        { query: 'lean', args: [{ virtuals: true }] },
+      ]
+    );
   });
 });
 

--- a/tests/unit/helpers/subscriptions.test.js
+++ b/tests/unit/helpers/subscriptions.test.js
@@ -241,7 +241,7 @@ describe('updateSubscription', () => {
 
     expect(result).toEqual(customer);
     sinon.assert.calledWithExactly(populateSubscriptionsServices, customer);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneAndUpdate,
       [
         {
@@ -287,8 +287,8 @@ describe('addSubscription', () => {
 
     expect(result).toEqual(customer);
     sinon.assert.calledWithExactly(populateSubscriptionsServices, customer);
-    SinonMongoose.calledWithExactly(findById, [{ query: 'findById', args: [customerId] }, { query: 'lean' }]);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(findById, [{ query: 'findById', args: [customerId] }, { query: 'lean' }]);
+    SinonMongoose.calledOnceWithExactly(
       findOneAndUpdate,
       [
         {
@@ -318,8 +318,8 @@ describe('addSubscription', () => {
 
     expect(result).toEqual(customer);
     sinon.assert.calledWithExactly(populateSubscriptionsServices, customer);
-    SinonMongoose.calledWithExactly(findById, [{ query: 'findById', args: [customerId] }, { query: 'lean' }]);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(findById, [{ query: 'findById', args: [customerId] }, { query: 'lean' }]);
+    SinonMongoose.calledOnceWithExactly(
       findOneAndUpdate,
       [
         {
@@ -349,7 +349,7 @@ describe('addSubscription', () => {
     } catch (e) {
       expect(e.output.statusCode).toEqual(409);
     } finally {
-      SinonMongoose.calledWithExactly(findById, [{ query: 'findById', args: [customerId] }, { query: 'lean' }]);
+      SinonMongoose.calledOnceWithExactly(findById, [{ query: 'findById', args: [customerId] }, { query: 'lean' }]);
       sinon.assert.notCalled(populateSubscriptionsServices);
       sinon.assert.notCalled(findOneAndUpdate);
     }
@@ -393,7 +393,7 @@ describe('deleteSubscription', () => {
         $set: { subscriptionsHistory: [{ subscriptions: [{ subscriptionId: secondSubId }] }] },
       }
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findByIdCustomer,
       [{ query: 'findById', args: [customerId.toHexString()] }, { query: 'lean' }]
     );
@@ -419,7 +419,7 @@ describe('createSubscriptionHistory', () => {
     const result = await SubscriptionsHelper.createSubscriptionHistory(customerId.toHexString(), payload);
 
     expect(result).toEqual(customer);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneAndUpdateCustomer,
       [
         {

--- a/tests/unit/helpers/surcharges.test.js
+++ b/tests/unit/helpers/surcharges.test.js
@@ -24,7 +24,7 @@ describe('list', () => {
     const result = await SurchargesHelper.list(credentials);
     expect(result).toEqual([{ company: companyId, name: 'Coucou' }]);
 
-    SinonMongoose.calledWithExactly(find, [
+    SinonMongoose.calledOnceWithExactly(find, [
       { query: 'find', args: [{ company: companyId }] },
       { query: 'lean' },
     ]);

--- a/tests/unit/helpers/taxCertificates.test.js
+++ b/tests/unit/helpers/taxCertificates.test.js
@@ -33,7 +33,7 @@ describe('list', () => {
     const result = await TaxCertificateHelper.list(customer, { company: { _id: companyId } });
 
     expect(result).toEqual(taxCertificates);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       find,
       [{ query: 'find', args: [{ customer, company: companyId }] }, { query: 'lean' }]
     );
@@ -228,7 +228,7 @@ describe('generateTaxCertificatePdf', () => {
     const result = await TaxCertificateHelper.generateTaxCertificatePdf(taxCertificateId, credentials);
 
     expect(result).toEqual('pdf');
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [
         { query: 'findOne', args: [{ _id: taxCertificateId }] },
@@ -347,7 +347,7 @@ describe('remove', () => {
     await TaxCertificateHelper.remove(taxCertificateId);
 
     sinon.assert.notCalled(deleteFileStub);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneAndDelete,
       [{ query: 'findOneAndDelete', args: [{ _id: taxCertificateId }] }, { query: 'lean' }]
     );
@@ -362,7 +362,7 @@ describe('remove', () => {
     await TaxCertificateHelper.remove(taxCertificateId);
 
     sinon.assert.calledWithExactly(deleteFileStub, taxCertificate.driveFile.driveId);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneAndDelete,
       [{ query: 'findOneAndDelete', args: [{ _id: taxCertificateId }] }, { query: 'lean' }]
     );

--- a/tests/unit/helpers/thirdPartyPayers.test.js
+++ b/tests/unit/helpers/thirdPartyPayers.test.js
@@ -36,7 +36,10 @@ describe('create', () => {
     const result = await ThirdPartyPayersHelper.create(payload, credentials);
 
     expect(result).toMatchObject(payloadWithCompany);
-    SinonMongoose.calledWithExactly(create, [{ query: 'create', args: [payloadWithCompany] }, { query: 'toObject' }]);
+    SinonMongoose.calledOnceWithExactly(
+      create,
+      [{ query: 'create', args: [payloadWithCompany] }, { query: 'toObject' }]
+    );
   });
 });
 
@@ -58,7 +61,7 @@ describe('list', () => {
     const result = await ThirdPartyPayersHelper.list(credentials);
 
     expect(result).toMatchObject(tppList);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       find,
       [{ query: 'find', args: [{ company: credentials.company._id }] }, { query: 'lean' }]
     );
@@ -83,7 +86,7 @@ describe('update', () => {
     const result = await ThirdPartyPayersHelper.update(tppId, payload);
 
     expect(result).toMatchObject({ _id: tppId });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOneAndUpdate,
       [
         { query: 'findOneAndUpdate', args: [{ _id: tppId }, { $set: payload }, { new: true }] },

--- a/tests/unit/helpers/userCompanies.test.js
+++ b/tests/unit/helpers/userCompanies.test.js
@@ -34,7 +34,7 @@ describe('create', () => {
 
     sinon.assert.calledOnceWithExactly(create, { user: userId, company: companyId });
     sinon.assert.calledOnceWithExactly(deleteManyCompanyLinkRequest, { user: userId });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [{ query: 'findOne', args: [{ user: userId }, { company: 1 }] }, { query: 'lean' }]
     );
@@ -50,7 +50,7 @@ describe('create', () => {
 
     sinon.assert.notCalled(create);
     sinon.assert.notCalled(deleteManyCompanyLinkRequest);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [{ query: 'findOne', args: [{ user: userId }, { company: 1 }] }, { query: 'lean' }]
     );
@@ -70,7 +70,7 @@ describe('create', () => {
       expect(e).toEqual(Boom.conflict());
       sinon.assert.notCalled(create);
       sinon.assert.notCalled(deleteManyCompanyLinkRequest);
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         findOne,
         [{ query: 'findOne', args: [{ user: userId }, { company: 1 }] }, { query: 'lean' }]
       );

--- a/tests/unit/helpers/users.test.js
+++ b/tests/unit/helpers/users.test.js
@@ -50,7 +50,7 @@ describe('formatQueryForUsersList', () => {
 
     expect(result).toEqual(omit(query, 'company'));
     sinon.assert.notCalled(find);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findUserCompany,
       [{ query: 'find', args: [{ company: companyId }, { user: 1 }] }, { query: 'lean' }]
     );
@@ -74,11 +74,11 @@ describe('formatQueryForUsersList', () => {
       'role.vendor': { $in: [query.role[0]._id, query.role[1]._id] },
     });
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       find,
       [{ query: 'find', args: [{ name: { $in: query.role } }, { _id: 1, interface: 1 }] }, { query: 'lean' }]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findUserCompany,
       [{ query: 'find', args: [{ company: companyId }, { user: 1 }] }, { query: 'lean' }]
     );
@@ -94,7 +94,7 @@ describe('formatQueryForUsersList', () => {
     } catch (e) {
       expect(e).toEqual(Boom.notFound(translate[language].roleNotFound));
     } finally {
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         find,
         [{ query: 'find', args: [{ name: { $in: query.role } }, { _id: 1, interface: 1 }] }, { query: 'lean' }]
       );
@@ -130,7 +130,7 @@ describe('getUsersList', () => {
 
     expect(result).toEqual(users);
     sinon.assert.calledOnceWithExactly(formatQueryForUsersListStub, query);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       find,
       [
         { query: 'find', args: [{ ...query, company: companyId }, {}, { autopopulate: false }] },
@@ -168,7 +168,7 @@ describe('getUsersList', () => {
 
     expect(result).toEqual(users);
     sinon.assert.calledOnceWithExactly(formatQueryForUsersListStub, query);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       find,
       [
         { query: 'find', args: [formattedQuery, {}, { autopopulate: false }] },
@@ -232,7 +232,7 @@ describe('getUsersListWithSectorHistories', () => {
       formatQueryForUsersListStub,
       { ...query, role: ['auxiliary', 'planning_referent', 'auxiliary_without_company'] }
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       find,
       [
         { query: 'find', args: [formattedQuery, {}, { autopopulate: false }] },
@@ -294,7 +294,7 @@ describe('getLearnerList', () => {
 
     expect(result).toEqual(usersWithVirtuals);
     sinon.assert.notCalled(findRole);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findUser,
       [
         {
@@ -340,15 +340,15 @@ describe('getLearnerList', () => {
     const result = await UsersHelper.getLearnerList(query, credentials);
 
     expect(result).toEqual(usersWithVirtuals);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findRole,
       [{ query: 'find', args: [{ name: { $in: [HELPER, AUXILIARY_WITHOUT_COMPANY] } }] }, { query: 'lean' }]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findUserCompany,
       [{ query: 'find', args: [{ company: query.company }, { user: 1 }] }, { query: 'lean' }]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findUser,
       [
         {
@@ -394,11 +394,11 @@ describe('getLearnerList', () => {
 
     expect(result).toEqual(usersWithVirtuals);
     sinon.assert.notCalled(findRole);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findUserCompany,
       [{ query: 'find', args: [{}, { user: 1 }] }, { query: 'lean' }]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findUser,
       [
         {
@@ -441,7 +441,7 @@ describe('getUser', () => {
 
     await UsersHelper.getUser(userId, credentials);
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [
         { query: 'findOne', args: [{ _id: userId }] },
@@ -490,7 +490,7 @@ describe('getUser', () => {
 
     await UsersHelper.getUser(userId, credentials);
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [
         { query: 'findOne', args: [{ _id: userId }] },
@@ -536,7 +536,7 @@ describe('getUser', () => {
 
     await UsersHelper.getUser(userId, credentials);
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [
         { query: 'findOne', args: [{ _id: userId }] },
@@ -582,7 +582,7 @@ describe('getUser', () => {
 
     await UsersHelper.getUser(userId, credentials);
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [
         { query: 'findOne', args: [{ _id: userId }] },
@@ -634,7 +634,7 @@ describe('getUser', () => {
     } catch (e) {
       expect(e.output.statusCode).toEqual(404);
     } finally {
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         findOne,
         [
           { query: 'findOne', args: [{ _id: userId }] },
@@ -701,7 +701,7 @@ describe('userExists', () => {
     expect(rep.exists).toBe(true);
     expect(rep.user).toEqual(omit(user, 'local'));
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [
         { query: 'findOne', args: [{ 'local.email': email }, { role: 1 }] },
@@ -719,7 +719,7 @@ describe('userExists', () => {
     expect(rep.exists).toBe(false);
     expect(rep.user).toEqual({});
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [
         { query: 'findOne', args: [{ 'local.email': nonExistantEmail }, { role: 1 }] },
@@ -736,7 +736,7 @@ describe('userExists', () => {
 
     expect(rep.exists).toBe(true);
     expect(rep.user).toEqual({});
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [
         { query: 'findOne', args: [{ 'local.email': email }, { role: 1 }] },
@@ -754,7 +754,7 @@ describe('userExists', () => {
     expect(rep.exists).toBe(true);
     expect(rep.user).toEqual(omit(userWithoutCompany, 'local'));
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [
         { query: 'findOne', args: [{ 'local.email': email }, { role: 1 }] },
@@ -772,7 +772,7 @@ describe('userExists', () => {
     expect(rep.exists).toBe(true);
     expect(rep.user).toEqual({});
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findOne,
       [
         { query: 'findOne', args: [{ 'local.email': email }, { role: 1 }] },
@@ -939,7 +939,7 @@ describe('createUser', () => {
     expect(result).toEqual(newUser);
     sinon.assert.calledOnceWithExactly(createHistoryStub, { _id: userId, sector: payload.sector }, companyId);
     sinon.assert.calledOnceWithExactly(userCompanyCreate, userId, companyId);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       roleFindById,
       [{ query: 'findById', args: [payload.role, { name: 1, interface: 1 }] }, { query: 'lean' }]
     );
@@ -953,7 +953,7 @@ describe('createUser', () => {
         role: { client: roleId },
       }
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       userFindOne,
       [
         { query: 'findOne', args: [{ _id: userId }] },
@@ -990,12 +990,12 @@ describe('createUser', () => {
     expect(result).toEqual(newUser);
     sinon.assert.notCalled(createHistoryStub);
     sinon.assert.calledOnceWithExactly(userCompanyCreate, userId, companyId);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       roleFindById,
       [{ query: 'findById', args: [payload.role, { name: 1, interface: 1 }] }, { query: 'lean' }]
     );
     sinon.assert.calledOnceWithExactly(userCreate, { ...payload, refreshToken: sinon.match.string });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       userFindOne,
       [
         { query: 'findOne', args: [{ _id: userId }] },
@@ -1032,7 +1032,7 @@ describe('createUser', () => {
 
     expect(result).toEqual(newUser);
     sinon.assert.calledOnceWithExactly(userCompanyCreate, userId, userCompanyId);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       roleFindById,
       [{ query: 'findById', args: [payload.role, { name: 1, interface: 1 }] }, { query: 'lean' }]
     );
@@ -1040,7 +1040,7 @@ describe('createUser', () => {
       userCreate,
       { ...payload, role: { client: roleId }, refreshToken: sinon.match.string }
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       userFindOne,
       [
         { query: 'findOne', args: [{ _id: userId }] },
@@ -1075,7 +1075,7 @@ describe('createUser', () => {
     expect(result).toEqual(newUser);
     sinon.assert.notCalled(userFindOne);
     sinon.assert.notCalled(userCompanyCreate);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       roleFindById,
       [{ query: 'findById', args: [payload.role, { name: 1, interface: 1 }] }, { query: 'lean' }]
     );
@@ -1126,7 +1126,7 @@ describe('createUser', () => {
       sinon.assert.notCalled(createHistoryStub);
       sinon.assert.notCalled(userCreate);
       sinon.assert.notCalled(userCompanyCreate);
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         roleFindById,
         [{ query: 'findById', args: [payload.role, { name: 1, interface: 1 }] }, { query: 'lean' }]
       );
@@ -1220,7 +1220,7 @@ describe('updateUser', () => {
     sinon.assert.calledOnceWithExactly(userUpdateOne, { _id: userId }, { $set: payloadWithRole });
     sinon.assert.calledOnceWithExactly(createHelper, userId, payload.customer, credentials.company._id);
     sinon.assert.notCalled(updateHistoryOnSectorUpdateStub);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       roleFindById,
       [{ query: 'findById', args: [payload.role, { name: 1, interface: 1 }] }, { query: 'lean' }]
     );
@@ -1257,7 +1257,7 @@ describe('updateUser', () => {
 
     sinon.assert.calledOnceWithExactly(userUpdateOne, { _id: userId }, { $set: payloadWithRole });
     sinon.assert.notCalled(createHelper);
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       roleFindById,
       [{ query: 'findById', args: [payload.role, { name: 1, interface: 1 }] }, { query: 'lean' }]
     );
@@ -1287,7 +1287,7 @@ describe('updateUser', () => {
     } catch (e) {
       expect(e).toEqual(Boom.badRequest('Le rôle n\'existe pas.'));
     } finally {
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         roleFindById,
         [{ query: 'findById', args: [payload.role, { name: 1, interface: 1 }] }, { query: 'lean' }]
       );
@@ -1465,7 +1465,7 @@ describe('createDriveFolder', () => {
 
     await UsersHelper.createDriveFolder(userId);
 
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       userCompanyFindOne,
       [
         { query: 'findOne', args: [{ user: userId }] },
@@ -1491,7 +1491,7 @@ describe('createDriveFolder', () => {
     } catch (e) {
       expect(e.output.statusCode).toEqual(422);
     } finally {
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         userCompanyFindOne,
         [
           { query: 'findOne', args: [{ user: userId }] },
@@ -1517,7 +1517,7 @@ describe('createDriveFolder', () => {
     } catch (e) {
       expect(e.output.statusCode).toEqual(422);
     } finally {
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         userCompanyFindOne,
         [
           { query: 'findOne', args: [{ user: userId }] },

--- a/tests/unit/jobs/billDispatch.test.js
+++ b/tests/unit/jobs/billDispatch.test.js
@@ -65,7 +65,7 @@ describe('method', () => {
     expect(billAlertEmailStub.getCall(0).calledWithExactly('leroi@lion.com'));
     expect(billAlertEmailStub.getCall(1).calledWithExactly('rox@rouky.com'));
     sinon.assert.calledOnceWithExactly(updateManyBill, { _id: { $in: billsIds } }, { $set: { sentAt: fakeDate } });
-    SinonMongoose.calledWithExactly(findCompany, [{ query: 'find' }, { query: 'lean' }]);
+    SinonMongoose.calledOnceWithExactly(findCompany, [{ query: 'find' }, { query: 'lean' }]);
   });
 
   it('should log emails which can not be sent', async () => {
@@ -100,7 +100,7 @@ describe('method', () => {
     expect(billAlertEmailStub.getCall(1).calledWithExactly('rox@rouky.com'));
     sinon.assert.calledWith(serverLogStub, ['error', 'cron', 'jobs'], error);
     sinon.assert.notCalled(updateManyBill);
-    SinonMongoose.calledWithExactly(findCompany, [{ query: 'find' }, { query: 'lean' }]);
+    SinonMongoose.calledOnceWithExactly(findCompany, [{ query: 'find' }, { query: 'lean' }]);
     serverLogStub.restore();
   });
 });

--- a/tests/unit/jobs/eventRepetitions.test.js
+++ b/tests/unit/jobs/eventRepetitions.test.js
@@ -95,7 +95,7 @@ describe('method', () => {
 
       expect(result).toMatchObject({ results: [futureEvent], errors: [], deletedRepetitions: [] });
       sinon.assert.calledWith(formatEventBasedOnRepetitionStub, repetition[0], new Date());
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         findRepetition,
         [
           { query: 'find', args: [{ startDate: { $lt: fakeDate }, company: companyId }] },
@@ -103,7 +103,7 @@ describe('method', () => {
           { query: 'lean' },
         ]
       );
-      SinonMongoose.calledWithExactly(
+      SinonMongoose.calledOnceWithExactly(
         findCompany,
         [{ query: 'find', args: [{ 'subscriptions.erp': true }] }, { query: 'lean' }]
       );
@@ -134,7 +134,7 @@ describe('method', () => {
     const result = await eventRepetitions.method(server);
 
     expect(result).toMatchObject({ results: [], errors: [], deletedRepetitions: [repetitions[0]] });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findRepetition,
       [
         { query: 'find', args: [{ startDate: { $lt: fakeDate }, company: companyId }] },
@@ -142,7 +142,7 @@ describe('method', () => {
         { query: 'lean' },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findCompany,
       [{ query: 'find', args: [{ 'subscriptions.erp': true }] }, { query: 'lean' }]
     );
@@ -197,7 +197,7 @@ describe('method', () => {
 
     expect(result).toMatchObject({ results: [futureEvent], errors: [], deletedRepetitions: [] });
     sinon.assert.calledWith(formatEventBasedOnRepetitionStub, repetitions[1], new Date());
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findRepetition,
       [
         { query: 'find', args: [{ startDate: { $lt: fakeDate }, company: companyId }] },
@@ -205,7 +205,7 @@ describe('method', () => {
         { query: 'lean' },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findCompany,
       [{ query: 'find', args: [{ 'subscriptions.erp': true }] }, { query: 'lean' }]
     );
@@ -238,7 +238,7 @@ describe('method', () => {
     const result = await eventRepetitions.method(server);
 
     expect(result).toMatchObject({ results: [], errors: [repetition[0]._id], deletedRepetitions: [] });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findRepetition,
       [
         { query: 'find', args: [{ startDate: { $lt: fakeDate }, company: companyId }] },
@@ -246,7 +246,7 @@ describe('method', () => {
         { query: 'lean' },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findCompany,
       [{ query: 'find', args: [{ 'subscriptions.erp': true }] }, { query: 'lean' }]
     );
@@ -293,7 +293,7 @@ describe('method', () => {
     const result = await eventRepetitions.method(server);
 
     expect(result).toMatchObject({ results: [], errors: [], deletedRepetitions: [] });
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findRepetition,
       [
         { query: 'find', args: [{ startDate: { $lt: fakeDate }, company: companyId }] },
@@ -301,7 +301,7 @@ describe('method', () => {
         { query: 'lean' },
       ]
     );
-    SinonMongoose.calledWithExactly(
+    SinonMongoose.calledOnceWithExactly(
       findCompany,
       [{ query: 'find', args: [{ 'subscriptions.erp': true }] }, { query: 'lean' }]
     );

--- a/tests/unit/sinonMongoose.js
+++ b/tests/unit/sinonMongoose.js
@@ -32,7 +32,22 @@ const calledWithExactly = (stubbedMethod, chainedPayload, callCount = 0) => {
   }
 };
 
+const calledOnceWithExactly = (stubbedMethod, chainedPayload) => {
+  let chainedQuery = stubbedMethod;
+  if (chainedPayload[0].args) {
+    sinon.assert.calledOnceWithExactly(chainedQuery, ...chainedPayload[0].args);
+  } else sinon.assert.calledOnceWithExactly(chainedQuery);
+  for (let i = 1; i < chainedPayload.length; i++) {
+    const { query, args } = chainedPayload[i];
+
+    chainedQuery = chainedQuery.getCall(0).returnValue[query];
+    if (args && args.length) sinon.assert.calledWithExactly(chainedQuery, ...args);
+    else sinon.assert.calledWithExactly(chainedQuery);
+  }
+};
+
 module.exports = {
   stubChainedQueries,
   calledWithExactly,
+  calledOnceWithExactly,
 };

--- a/tests/unit/sinonMongoose.js
+++ b/tests/unit/sinonMongoose.js
@@ -20,6 +20,10 @@ const stubChainedQueries = (stubbedMethodReturns, chainedQueries = ['populate', 
 
 const calledWithExactly = (stubbedMethod, chainedPayload, callCount = 0) => {
   let chainedQuery = stubbedMethod;
+
+  if (String(chainedQuery.getCall(0).proxy) !== chainedPayload[0].query) {
+    sinon.assert.fail(`Error in principal query : ${String(chainedQuery.getCall(callCount).proxy)} expected`);
+  }
   if (chainedPayload[0].args) {
     sinon.assert.calledWithExactly(chainedQuery.getCall(callCount), ...chainedPayload[0].args);
   } else sinon.assert.calledWithExactly(chainedQuery.getCall(callCount));
@@ -27,6 +31,7 @@ const calledWithExactly = (stubbedMethod, chainedPayload, callCount = 0) => {
   for (let i = 1; i < chainedPayload.length; i++) {
     const { query, args } = chainedPayload[i];
     chainedQuery = chainedQuery.getCall(callCount).returnValue[query];
+    if (!chainedQuery) sinon.assert.fail('Error in secondary queries');
     if (args && args.length) sinon.assert.calledWithExactly(chainedQuery, ...args);
     else sinon.assert.calledWithExactly(chainedQuery);
   }
@@ -34,13 +39,18 @@ const calledWithExactly = (stubbedMethod, chainedPayload, callCount = 0) => {
 
 const calledOnceWithExactly = (stubbedMethod, chainedPayload) => {
   let chainedQuery = stubbedMethod;
+
+  if (String(chainedQuery.getCall(0).proxy) !== chainedPayload[0].query) {
+    sinon.assert.fail(`Error in principal query : ${String(chainedQuery.getCall(0).proxy)} expected`);
+  }
   if (chainedPayload[0].args) {
     sinon.assert.calledOnceWithExactly(chainedQuery, ...chainedPayload[0].args);
   } else sinon.assert.calledOnceWithExactly(chainedQuery);
+
   for (let i = 1; i < chainedPayload.length; i++) {
     const { query, args } = chainedPayload[i];
-
     chainedQuery = chainedQuery.getCall(0).returnValue[query];
+    if (!chainedQuery) sinon.assert.fail('Error in secondary queries');
     if (args && args.length) sinon.assert.calledWithExactly(chainedQuery, ...args);
     else sinon.assert.calledWithExactly(chainedQuery);
   }


### PR DESCRIPTION
|  |  | TESTS  :computer: | |
|----------|----------|----------|----------|
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | J'ai codé les tests unitaires
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | J'ai codé les tests d'intégration
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | C'est une ancienne route utilisée par les apps mobiles. | <ul><li>[ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens</li></ul>

---

|  |  | POINTS D'ATTENTION POUR CETTE PR  :warning:  | |
|----------|----------|----------|----------|
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | J'ai fait des modifications sur une route utilisée sur plusieurs plateformes | [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/n3bq2hr9Ia)
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | J'ai modifié un modèle utilisé en mobile | [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/rqTfwpUib)
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | J'ai ajouté un modèle spécifique à une structure | <ul><li>[ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés</li></ul>
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile |  <ul><li>[ ] Si oui, j'ai précisé sur le [slite de MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) qu'il faut forcer la mise à jour</li></ul>
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | J'ai ajouté une variable d'environnement | <ul><li>[ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites</li></ul>

---

|  |  |  FONCTIONNALITÉS APPS MOBILES  :iphone: | |
|----------|----------|----------|----------|
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | Mes changements impactent l'application formation | <ul><li>[ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours</li></ul>
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | Mes changements impactent l'application erp | <ul><li>[ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours</li></ul>

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : tous

- Cas d'usage : ajout de calledOnceWithExactly sous sinon Mongoose + remplacement de l'erreur "fake is not a spy" quand une query secondaire (populate, lean, etc.) est incorrecte par un message plus parlant + vérification que la query primaire (find, update, remove, etc) est bien la bonne (ce n'était pas le cas dans une trentaine de test qui passaient quand même)

- Comment tester ? : lancer les tests unitaires + s'assurer qu'on reçoit bien les bonnes erreurs quand mauvaise query primaire ou secondaire 
relisez les commits séparément ça sera plus simple

Si tu as lu cette description, pense a réagir avec un :eye:
