### PR TITLE
COM-2586 - modify CompaniDate.diff() to return an object

### DIFF
--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -471,4 +471,17 @@ module.exports = {
   ACTIVATED: 'Actif',
   STOPPED: 'Arrêté',
   ARCHIVED: 'Archivé',
+  // DURATION
+  get DURATION_UNITS() {
+    return [
+      'years',
+      'quarters',
+      'months',
+      'weeks',
+      'days',
+      'hours',
+      'minutes',
+      'seconds',
+    ];
+  },
 };

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -472,16 +472,24 @@ module.exports = {
   STOPPED: 'Arrêté',
   ARCHIVED: 'Archivé',
   // DURATION
+  YEARS: 'years',
+  QUARTERS: 'quarters',
+  MONTHS: 'months',
+  WEEKS: 'weeks',
+  DAYS: 'days',
+  HOURS: 'hours',
+  MINUTES: 'minutes',
+  SECONDS: 'seconds',
   get DURATION_UNITS() {
     return [
-      'years',
-      'quarters',
-      'months',
-      'weeks',
-      'days',
-      'hours',
-      'minutes',
-      'seconds',
+      this.YEARS,
+      this.QUARTERS,
+      this.MONTHS,
+      this.WEEKS,
+      this.DAYS,
+      this.HOURS,
+      this.MINUTES,
+      this.SECONDS,
     ];
   },
 };

--- a/src/helpers/courses.js
+++ b/src/helpers/courses.js
@@ -395,7 +395,7 @@ exports.formatIntraCourseSlotsForPdf = slot => ({
 });
 
 exports.formatInterCourseSlotsForPdf = (slot) => {
-  const duration = CompaniDuration(CompaniDate(slot.endDate).diff(slot.startDate));
+  const duration = CompaniDuration(CompaniDate(slot.endDate).diff(slot.startDate, 'minutes'));
 
   return {
     address: get(slot, 'address.fullAddress') || null,
@@ -408,7 +408,7 @@ exports.formatInterCourseSlotsForPdf = (slot) => {
 
 exports.getCourseDuration = (slots) => {
   const duration = slots.reduce(
-    (acc, slot) => acc.add(CompaniDuration(CompaniDate(slot.endDate).diff(slot.startDate))),
+    (acc, slot) => acc.add(CompaniDuration(CompaniDate(slot.endDate).diff(slot.startDate, 'minutes'))),
     CompaniDuration()
   );
 

--- a/src/helpers/dates/companiDates.js
+++ b/src/helpers/dates/companiDates.js
@@ -63,12 +63,12 @@ const CompaniDateFactory = (inputDate) => {
       return CompaniDateFactory(_date.endOf(unit));
     },
 
-    diff(miscTypeOtherDate, unit = 'milliseconds', typeFloat = false) {
+    diff(miscTypeOtherDate, unit) {
       const otherDate = exports._formatMiscToCompaniDate(miscTypeOtherDate);
-      const floatDiff = _date.diff(otherDate, unit).as(unit);
+      const floatedDiff = _date.diff(otherDate, unit).as(unit);
+      const roundedDiff = floatedDiff > 0 ? Math.floor(floatedDiff) : Math.ceil(floatedDiff);
 
-      if (typeFloat) return floatDiff;
-      return floatDiff > 0 ? Math.floor(floatDiff) : Math.ceil(floatDiff);
+      return { [unit]: roundedDiff };
     },
 
     add(amount) {

--- a/src/helpers/dates/companiDurations.js
+++ b/src/helpers/dates/companiDurations.js
@@ -29,7 +29,7 @@ exports._formatMiscToCompaniDuration = (...args) => {
   if (args.length === 1) {
     if (args[0] instanceof Object) {
       if (args[0]._duration && args[0]._duration instanceof luxon.Duration) return args[0]._duration;
-      if (every(Object.keys, key => DURATION_UNITS.includes(key))) return luxon.Duration.fromObject(args[0]);
+      if (every(Object.keys(args[0]), key => DURATION_UNITS.includes(key))) return luxon.Duration.fromObject(args[0]);
     }
   }
   return luxon.Duration.invalid('wrong arguments');

--- a/src/helpers/dates/companiDurations.js
+++ b/src/helpers/dates/companiDurations.js
@@ -1,4 +1,3 @@
-const { every } = require('lodash');
 const { DURATION_UNITS } = require('../constants');
 const luxon = require('./luxon');
 
@@ -29,7 +28,7 @@ exports._formatMiscToCompaniDuration = (...args) => {
   if (args.length === 1) {
     if (args[0] instanceof Object) {
       if (args[0]._duration && args[0]._duration instanceof luxon.Duration) return args[0]._duration;
-      if (every(Object.keys(args[0]), key => DURATION_UNITS.includes(key))) return luxon.Duration.fromObject(args[0]);
+      if (Object.keys(args[0]).every(key => DURATION_UNITS.includes(key))) return luxon.Duration.fromObject(args[0]);
     }
   }
   return luxon.Duration.invalid('wrong arguments');

--- a/src/helpers/dates/companiDurations.js
+++ b/src/helpers/dates/companiDurations.js
@@ -1,3 +1,5 @@
+const { every } = require('lodash');
+const { DURATION_UNITS } = require('../constants');
 const luxon = require('./luxon');
 
 exports.CompaniDuration = (...args) => companiDurationFactory(exports._formatMiscToCompaniDuration(...args));
@@ -25,11 +27,9 @@ exports._formatMiscToCompaniDuration = (...args) => {
   if (args.length === 0) return luxon.Duration.fromObject({});
 
   if (args.length === 1) {
-    if (args[0] instanceof Object && args[0]._duration && args[0]._duration instanceof luxon.Duration) {
-      return args[0]._duration;
-    }
-    if (typeof args[0] === 'number') {
-      return luxon.Duration.fromMillis(args[0]);
+    if (args[0] instanceof Object) {
+      if (args[0]._duration && args[0]._duration instanceof luxon.Duration) return args[0]._duration;
+      if (every(Object.keys, key => DURATION_UNITS.includes(key))) return luxon.Duration.fromObject(args[0]);
     }
   }
   return luxon.Duration.invalid('wrong arguments');

--- a/tests/unit/helpers/dates/companiDates.test.js
+++ b/tests/unit/helpers/dates/companiDates.test.js
@@ -416,7 +416,7 @@ describe('MANIPULATE', () => {
       const otherDate = '2021-11-22T21:00:00.000Z';
       const result = companiDate.diff(otherDate, 'days');
 
-      expect(result).toStrictEqual({ days: 1 }); // 1.54 days = 1 day and 13 hours
+      expect(result).toStrictEqual({ days: 1 });
       sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, otherDate);
     });
 

--- a/tests/unit/helpers/dates/companiDates.test.js
+++ b/tests/unit/helpers/dates/companiDates.test.js
@@ -400,16 +400,7 @@ describe('MANIPULATE', () => {
       const otherDate = '2021-11-20T10:00:00.000Z';
       const result = companiDate.diff(otherDate, 'days');
 
-      expect(result).toBe(4);
-      sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, otherDate);
-    });
-
-    it('should return diff in milliseconds, if no unit specified', () => {
-      const otherDate = '2021-11-24T08:29:48.000Z';
-      const result = companiDate.diff(otherDate);
-      const expectedDiffInMillis = 1 * 60 * 60 * 1000 + 30 * 60 * 1000 + 12 * 1000;
-
-      expect(result).toBe(expectedDiffInMillis);
+      expect(result).toStrictEqual({ days: 4 });
       sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, otherDate);
     });
 
@@ -417,16 +408,15 @@ describe('MANIPULATE', () => {
       const otherDate = '2021-11-23T21:00:00.000Z';
       const result = companiDate.diff(otherDate, 'days');
 
-      expect(result).toBe(0);
+      expect(result).toStrictEqual({ days: 0 });
       sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, otherDate);
     });
 
-    it('should return difference in positive floated days', () => {
+    it('should return difference in positive days', () => {
       const otherDate = '2021-11-22T21:00:00.000Z';
-      const result = companiDate.diff(otherDate, 'days', true);
+      const result = companiDate.diff(otherDate, 'days');
 
-      expect(result).toBeGreaterThan(0);
-      expect(result - 1.54).toBeLessThan(0.01); // 1.54 days = 1 day and 13 hours
+      expect(result).toStrictEqual({ days: 1 }); // 1.54 days = 1 day and 13 hours
       sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, otherDate);
     });
 
@@ -434,22 +424,13 @@ describe('MANIPULATE', () => {
       const otherDate = '2021-11-30T10:00:00.000Z';
       const result = companiDate.diff(otherDate, 'days');
 
-      expect(result).toBe(-6);
-      sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, otherDate);
-    });
-
-    it('should return difference in negative floated days', () => {
-      const otherDate = '2021-11-30T08:00:00.000Z';
-      const result = companiDate.diff(otherDate, 'days', true);
-
-      expect(result).toBeLessThan(0);
-      expect(Math.abs(result) - 5.91).toBeLessThan(0.01); // 5.91 days = 5 days and 22 hours
+      expect(result).toStrictEqual({ days: -6 });
       sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, otherDate);
     });
 
     it('should return error if invalid otherDate', () => {
       try {
-        companiDate.diff(null, 'days', true);
+        companiDate.diff(null, 'days');
       } catch (e) {
         expect(e).toEqual(new Error('Invalid DateTime: wrong arguments'));
       } finally {
@@ -460,9 +441,20 @@ describe('MANIPULATE', () => {
     it('should return error if invalid unit', () => {
       const otherDate = '2021-11-30T08:00:00.000Z';
       try {
-        companiDate.diff(otherDate, 'jour', true);
+        companiDate.diff(otherDate, 'jour');
       } catch (e) {
         expect(e).toEqual(new Error('Invalid unit jour'));
+      } finally {
+        sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, otherDate);
+      }
+    });
+
+    it('should return error if missing unit', () => {
+      const otherDate = '2021-11-30T08:00:00.000Z';
+      try {
+        companiDate.diff(otherDate);
+      } catch (e) {
+        expect(e).toEqual(new Error('Invalid unit undefined'));
       } finally {
         sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, otherDate);
       }

--- a/tests/unit/helpers/dates/companiDuration.test.js
+++ b/tests/unit/helpers/dates/companiDuration.test.js
@@ -15,7 +15,7 @@ describe('CompaniDuration', () => {
   });
 
   it('should return duration', () => {
-    const duration = 1200000000;
+    const duration = { seconds: 1200000 };
 
     const result = CompaniDurationsHelper.CompaniDuration(duration);
 
@@ -31,7 +31,7 @@ describe('CompaniDuration', () => {
 
 describe('format', () => {
   it('should return formatted duration with minutes', () => {
-    const durationAmount = 5 * 60 * 60 * 1000 + 16 * 60 * 1000;
+    const durationAmount = { seconds: 5 * 60 * 60 + 16 * 60 };
     const companiDuration = CompaniDurationsHelper.CompaniDuration(durationAmount);
     const result = companiDuration.format();
 
@@ -39,7 +39,7 @@ describe('format', () => {
   });
 
   it('should return formatted duration with minutes, leading zero on minutes', () => {
-    const durationAmount = 5 * 60 * 60 * 1000 + 3 * 60 * 1000;
+    const durationAmount = { seconds: 5 * 60 * 60 + 3 * 60 };
     const companiDuration = CompaniDurationsHelper.CompaniDuration(durationAmount);
     const result = companiDuration.format();
 
@@ -47,7 +47,7 @@ describe('format', () => {
   });
 
   it('should return formatted duration without minutes', () => {
-    const durationAmount = 13 * 60 * 60 * 1000;
+    const durationAmount = { seconds: 13 * 60 * 60 };
     const companiDuration = CompaniDurationsHelper.CompaniDuration(durationAmount);
     const result = companiDuration.format();
 
@@ -55,7 +55,7 @@ describe('format', () => {
   });
 
   it('should return formatted duration, days are converted to hours', () => {
-    const durationAmount = 2 * 24 * 60 * 60 * 1000 + 1 * 60 * 60 * 1000;
+    const durationAmount = { seconds: 2 * 24 * 60 * 60 + 1 * 60 * 60 };
     const companiDuration = CompaniDurationsHelper.CompaniDuration(durationAmount);
     const result = companiDuration.format();
 
@@ -63,7 +63,7 @@ describe('format', () => {
   });
 
   it('should return formatted duration with minutes, seconds and milliseconds have no effect', () => {
-    const durationAmount = 1 * 60 * 60 * 1000 + 2 * 60 * 1000 + 30 * 1000 + 400;
+    const durationAmount = { seconds: 1 * 60 * 60 + 2 * 60 + 30 + 0.4 };
     const companiDuration = CompaniDurationsHelper.CompaniDuration(durationAmount);
     const result = companiDuration.format();
 
@@ -71,7 +71,7 @@ describe('format', () => {
   });
 
   it('should return formatted duration without minutes, seconds and milliseconds have no effect', () => {
-    const durationAmount = 1 * 60 * 60 * 1000 + 55 * 1000 + 900;
+    const durationAmount = { seconds: 1 * 60 * 60 + 55 + 0.9 };
     const companiDuration = CompaniDurationsHelper.CompaniDuration(durationAmount);
     const result = companiDuration.format();
 
@@ -82,7 +82,7 @@ describe('format', () => {
 describe('add', () => {
   let _formatMiscToCompaniDuration;
   const durationAmountInMillis = 60 * 60 * 1000;
-  const companiDuration = CompaniDurationsHelper.CompaniDuration(durationAmountInMillis);
+  const companiDuration = CompaniDurationsHelper.CompaniDuration({ seconds: durationAmountInMillis / 1000 });
 
   beforeEach(() => {
     _formatMiscToCompaniDuration = sinon.spy(CompaniDurationsHelper, '_formatMiscToCompaniDuration');
@@ -94,11 +94,11 @@ describe('add', () => {
 
   it('should increase companiDuration, and return a reference', () => {
     const addedAmountInMillis = 2 * 60 * 60 * 1000 + 5 * 60 * 1000;
-    const result = companiDuration.add(addedAmountInMillis);
+    const result = companiDuration.add({ seconds: addedAmountInMillis / 1000 });
 
     expect(result).toBe(companiDuration);
     expect(companiDuration._duration.toMillis()).toBe(durationAmountInMillis + addedAmountInMillis);
-    sinon.assert.calledWithExactly(_formatMiscToCompaniDuration.getCall(0), addedAmountInMillis);
+    sinon.assert.calledWithExactly(_formatMiscToCompaniDuration.getCall(0), { seconds: addedAmountInMillis / 1000 });
   });
 });
 
@@ -141,14 +141,12 @@ describe('_formatMiscToCompaniDuration', () => {
     sinon.assert.notCalled(invalid);
   });
 
-  it('should return duration if arg is number', () => {
-    const payload = 3000000000;
+  it('should return duration if arg is an object with luxon duration keys', () => {
+    const payload = { hours: 3, minutes: 35, seconds: 12 };
     const result = CompaniDurationsHelper._formatMiscToCompaniDuration(payload);
 
-    expect(result instanceof luxon.Duration).toBe(true);
-    expect(new luxon.Duration(result).toMillis()).toBe(payload);
-    sinon.assert.calledOnceWithExactly(fromMillis, payload);
-    sinon.assert.calledOnce(fromObject); // fromMillis calls fromObject
+    expect(result.values).toEqual(payload);
+    sinon.assert.calledOnce(fromObject);
     sinon.assert.notCalled(invalid);
   });
 

--- a/tests/unit/helpers/dates/companiDuration.test.js
+++ b/tests/unit/helpers/dates/companiDuration.test.js
@@ -146,6 +146,7 @@ describe('_formatMiscToCompaniDuration', () => {
     const payload = { hours: 3, minutes: 35, seconds: 12 };
     const result = CompaniDurationsHelper._formatMiscToCompaniDuration(payload);
 
+    expect(result instanceof luxon.Duration).toBe(true);
     expect(new luxon.Duration(result).toMillis()).toEqual(3 * 60 * 60 * 1000 + 35 * 60 * 1000 + 12 * 1000);
     sinon.assert.calledOnce(fromObject);
     sinon.assert.notCalled(invalid);


### PR DESCRIPTION
|  |  | TESTS  :computer: | |
|----------|----------|----------|----------|
| <ul><li>[x] oui </li></ul> | <ul><li>[ ] non</li></ul> | J'ai codé les tests unitaires
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | J'ai codé les tests d'intégration
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | C'est une ancienne route utilisée par les apps mobiles. | <ul><li>[ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens</li></ul>

---

|  |  | POINTS D'ATTENTION POUR CETTE PR  :warning:  | |
|----------|----------|----------|----------|
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | J'ai fait des modifications sur une route utilisée sur plusieurs plateformes | [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/n3bq2hr9Ia)
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | J'ai modifié un modèle utilisé en mobile | [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/rqTfwpUib)
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | J'ai ajouté un modèle spécifique à une structure | <ul><li>[ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés</li></ul>
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile |  <ul><li>[ ] Si oui, j'ai précisé sur le [slite de MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) qu'il faut forcer la mise à jour</li></ul>
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | J'ai ajouté une variable d'environnement | <ul><li>[ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites</li></ul>

---

|  |  |  FONCTIONNALITÉS APPS MOBILES  :iphone: | |
|----------|----------|----------|----------|
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | Mes changements impactent l'application formation | <ul><li>[ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours</li></ul>
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | Mes changements impactent l'application erp | <ul><li>[ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours</li></ul>

---

### POUR TESTER LA PR  :white_check_mark:
- Refacto de la methode diff de CompaniDate pour retourner un objet plutôt qu'un nombre 

- Comment tester ? : Pour une formation intra et une formation inter: 
   - télécharger les feuilles d'émargement
       - verifier que la durée totale de la formation est bonne
       - verifier que la durée associée a chaque créneau est bonne
   - télécharger une attestation de fin de formation et verifier que la durée indiquée est bonne 

Si tu as lu cette description, pense a réagir avec un :eye:
