### PR TITLE
COM-2622 prehandler check all matching numbers

### DIFF
--- a/src/routes/preHandlers/sms.js
+++ b/src/routes/preHandlers/sms.js
@@ -8,13 +8,14 @@ const { language } = translate;
 
 exports.authorizeSendSms = async (req) => {
   const companyId = get(req, 'auth.credentials.company._id');
-  const user = await User
-    .findOne({ 'contact.phone': `0${req.payload.recipient.substring(3)}` })
+  const users = await User
+    .find({ 'contact.phone': `0${req.payload.recipient.substring(3)}` })
     .populate({ path: 'company' })
     .lean();
-  if (!user) throw Boom.notFound(translate[language].userNotFound);
+  if (!users.length) throw Boom.notFound(translate[language].userNotFound);
 
-  if (!UtilsHelper.areObjectIdsEquals(user.company, companyId)) throw Boom.notFound();
+  const userCompanies = users.map(user => user.company);
+  if (!UtilsHelper.doesArrayIncludeId(userCompanies, companyId)) throw Boom.notFound();
 
   return null;
 };

--- a/tests/integration/seed/smsSeed.js
+++ b/tests/integration/seed/smsSeed.js
@@ -10,7 +10,17 @@ const { deleteNonAuthenticationSeeds } = require('../helpers/authentication');
 const smsUser = {
   _id: new ObjectId(),
   identity: { firstname: 'sms', lastname: 'Test' },
-  local: { email: 'email_user@alenvi.io', password: '123456!eR' },
+  local: { email: 'email_user@alenvi.io' },
+  contact: { phone: '0987654321' },
+  refreshToken: uuidv4(),
+  role: { client: clientAdminRoleId },
+  origin: WEBAPP,
+};
+
+const smsUserWithSameNumberAndNoCompany = {
+  _id: new ObjectId(),
+  identity: { firstname: 'mms', lastname: 'Test' },
+  local: { email: 'email_user_with_same_number@alenvi.io' },
   contact: { phone: '0987654321' },
   refreshToken: uuidv4(),
   role: { client: clientAdminRoleId },
@@ -20,7 +30,7 @@ const smsUser = {
 const smsUserFromOtherCompany = {
   _id: new ObjectId(),
   identity: { firstname: 'texto', lastname: 'Test' },
-  local: { email: 'email_user_other_company@alenvi.io', password: '123456!eR' },
+  local: { email: 'email_user_other_company@alenvi.io' },
   contact: { phone: '0253647382' },
   refreshToken: uuidv4(),
   role: { client: clientAdminRoleId },
@@ -35,8 +45,10 @@ const userCompanies = [
 const populateDB = async () => {
   await deleteNonAuthenticationSeeds();
 
-  await User.create(smsUser, smsUserFromOtherCompany);
-  await UserCompany.insertMany(userCompanies);
+  await Promise.all([
+    User.create(smsUser, smsUserFromOtherCompany, smsUserWithSameNumberAndNoCompany),
+    UserCompany.insertMany(userCompanies),
+  ]);
 };
 
 module.exports = { populateDB, smsUser, smsUserFromOtherCompany };

--- a/tests/integration/sms.test.js
+++ b/tests/integration/sms.test.js
@@ -27,7 +27,7 @@ describe('POST /sms', () => {
       SmsHelperStub.restore();
     });
 
-    it('should send a SMS to user from company', async () => {
+    it('should send a SMS if phone in the company', async () => {
       const payload = { recipient: `+33${smsUser.contact.phone.substring(1)}`, content: 'Test', tag: HR_SMS };
       const response = await app.inject({
         method: 'POST',
@@ -41,7 +41,7 @@ describe('POST /sms', () => {
       sinon.assert.calledWithExactly(SmsHelperStub, payload, sinon.match({ company: { _id: authCompany._id } }));
     });
 
-    it('should throw error if phone is not in the same company', async () => {
+    it('should throw error if no phone in the company', async () => {
       const payload = {
         recipient: `+33${smsUserFromOtherCompany.contact.phone.substring(1)}`,
         content: 'Ceci est un test',


### PR DESCRIPTION
|  |  | TESTS  :computer: | |
|----------|----------|----------|----------|
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | J'ai codé les tests unitaires
| <ul><li>[x] oui </li></ul> | <ul><li>[ ] non</li></ul> | J'ai codé les tests d'intégration
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | C'est une ancienne route utilisée par les apps mobiles. | <ul><li>[ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens</li></ul>

---

|  |  | POINTS D'ATTENTION POUR CETTE PR  :warning:  | |
|----------|----------|----------|----------|
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | J'ai fait des modifications sur une route utilisée sur plusieurs plateformes | [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/n3bq2hr9Ia)
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | J'ai modifié un modèle utilisé en mobile | [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/rqTfwpUib)
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | J'ai ajouté un modèle spécifique à une structure | <ul><li>[ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés</li></ul>
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile |  <ul><li>[ ] Si oui, j'ai précisé sur le [slite de MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) qu'il faut forcer la mise à jour</li></ul>
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | J'ai ajouté une variable d'environnement | <ul><li>[ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites</li></ul>

---

|  |  |  FONCTIONNALITÉS APPS MOBILES  :iphone: | |
|----------|----------|----------|----------|
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | Mes changements impactent l'application formation | <ul><li>[ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours</li></ul>
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | Mes changements impactent l'application erp | <ul><li>[ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours</li></ul>

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : outil / coach, admin

- D'ou vient le bug : 
Une auxiliaire a plusieurs compte avec tous le meme numero : 06XXXXXX61.
   - un compte rattaché a aucune structure
   - deux compte rattachés a Alliance serenite (aka alenvi fontainebleau)

le premier compte pose pb qd on essaie d'envoyer un sms depuis le profile de l'auxiliaire. En effet dans le prehandler on recupere le premier utilisateur de la base qui a le numero demander : 
`if (!UtilsHelper.areObjectIdsEquals(user.company, companyId)) throw Boom.notFound();` 
Si c'est pas le compte lié a la structure, on recoit une 401

- resolution du bug : je prend tous les utilisateur.ices avec le numero destinataire et je verifie que l'un d'entre eux est de la bonne structure.

- Comment tester ? : 
   - En local, donner un numero de telephone a un utilisateur d'alenvi. 
   - Puis donner le meme numero de telephone a plusieurs utilisateurs avec des structures differentes (ou sans structure).
   - Sur la branche dev, qd tu cliques sur  "Accès WebApp activé - Envoyer un SMS"  => KO (il se peux que ce soit OK si la requete mongo trouve le bon utilisateur en premier, dans ce cas essaye d'ajouter le num a encore plus d'utilisateurs qui n'ont pas la mm structure)
   - Sur cette branche => OK

Si tu as lu cette description, pense a réagir avec un :eye:
