### PR TITLE
Com 2605

### DIFF
--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -51,6 +51,7 @@ module.exports = {
     return {
       [this.HOURLY]: 'Horaire',
       [this.DAILY]: 'Journalière',
+      [this.HALF_DAILY]: 'Demi-journalière',
     };
   },
   PLANNING_VIEW_END_HOUR: 22,

--- a/src/helpers/historyExport.js
+++ b/src/helpers/historyExport.js
@@ -22,6 +22,7 @@ const {
   MANUAL_TIME_STAMPING_REASONS,
   EVENT_TRANSPORT_MODE_LIST,
   INTRA,
+  HALF_DAILY,
 } = require('./constants');
 const DatesHelper = require('./dates');
 const UtilsHelper = require('./utils');
@@ -185,12 +186,13 @@ exports.exportWorkingEventsHistory = async (startDate, endDate, credentials) => 
 };
 
 exports.getAbsenceHours = (absence, contracts) => {
-  if (absence.absenceNature === HOURLY) return moment(absence.endDate).diff(absence.startDate, 'm') / 60;
-
-  return contracts
-    .filter(c => moment(c.startDate).isSameOrBefore(absence.endDate) &&
-      (!c.endDate || moment(c.endDate).isAfter(absence.startDate)))
+  const dailyAbsenceHours = contracts.filter(c => moment(c.startDate).isSameOrBefore(absence.endDate) &&
+    (!c.endDate || moment(c.endDate).isAfter(absence.startDate)))
     .reduce((acc, c) => acc + DraftPayHelper.getHoursFromDailyAbsence(absence, c), 0);
+
+  if (absence.absenceNature === HOURLY) return moment(absence.endDate).diff(absence.startDate, 'm') / 60;
+  if (absence.absenceNature === HALF_DAILY) return dailyAbsenceHours / 2;
+  return dailyAbsenceHours;
 };
 
 const absenceExportHeader = [

--- a/src/helpers/historyExport.js
+++ b/src/helpers/historyExport.js
@@ -186,13 +186,12 @@ exports.exportWorkingEventsHistory = async (startDate, endDate, credentials) => 
 };
 
 exports.getAbsenceHours = (absence, contracts) => {
+  if (absence.absenceNature === HOURLY) return moment(absence.endDate).diff(absence.startDate, 'm') / 60;
+
   const dailyAbsenceHours = contracts.filter(c => moment(c.startDate).isSameOrBefore(absence.endDate) &&
     (!c.endDate || moment(c.endDate).isAfter(absence.startDate)))
     .reduce((acc, c) => acc + DraftPayHelper.getHoursFromDailyAbsence(absence, c), 0);
-
-  if (absence.absenceNature === HOURLY) return moment(absence.endDate).diff(absence.startDate, 'm') / 60;
-  if (absence.absenceNature === HALF_DAILY) return dailyAbsenceHours / 2;
-  return dailyAbsenceHours;
+  return absence.absenceNature === HALF_DAILY ? dailyAbsenceHours / 2 : dailyAbsenceHours;
 };
 
 const absenceExportHeader = [

--- a/tests/unit/helpers/eventsValidation.test.js
+++ b/tests/unit/helpers/eventsValidation.test.js
@@ -367,7 +367,7 @@ describe('isEditionAllowed', () => {
     sinon.assert.notCalled(isCustomerSubscriptionValid);
   });
 
-  it('should return false as auxiliary does not have contracts #tag', async () => {
+  it('should return false as auxiliary does not have contracts', async () => {
     const companyId = new ObjectId();
     const credentials = { company: { _id: companyId } };
     const event = {

--- a/tests/unit/helpers/historyExport.test.js
+++ b/tests/unit/helpers/historyExport.test.js
@@ -392,7 +392,7 @@ describe('getAbsenceHours', () => {
     sinon.assert.calledOnceWithExactly(getHoursFromDailyAbsence, absence, contracts[0]);
   });
 
-  it('should return half-daily absence hours with mutiple contracts', async () => {
+  it('should return half-daily absence hours', async () => {
     const absence = { absenceNature: 'half-daily', startDate: '2019-05-18T10:00:00', endDate: '2019-05-18T12:00:00' };
     const contracts = [
       {
@@ -432,7 +432,7 @@ describe('getAbsenceHours', () => {
     const absenceHours = await ExportHelper.getAbsenceHours(absence, contracts);
 
     expect(absenceHours).toEqual(2);
-    sinon.assert.calledOnceWithExactly(getHoursFromDailyAbsence, absence, contracts[0]);
+    sinon.assert.notCalled(getHoursFromDailyAbsence);
   });
 });
 

--- a/tests/unit/helpers/historyExport.test.js
+++ b/tests/unit/helpers/historyExport.test.js
@@ -371,7 +371,7 @@ describe('getAbsenceHours', () => {
   });
 
   it('should return daily absence hours', async () => {
-    const absence = { absenceNature: 'daily', startDate: '2019-05-18T10:00:00', endDate: '2019-05-18T12:00:00' };
+    const absence = { absenceNature: 'daily', startDate: '2019-07-17T10:00:00', endDate: '2019-07-20T12:00:00' };
     const contracts = [
       {
         startDate: '2019-02-18T07:00:00',
@@ -385,11 +385,14 @@ describe('getAbsenceHours', () => {
       },
     ];
 
-    getHoursFromDailyAbsence.returns(2);
+    getHoursFromDailyAbsence.onCall(0).returns(4);
+    getHoursFromDailyAbsence.onCall(1).returns(4);
     const absenceHours = await ExportHelper.getAbsenceHours(absence, contracts);
 
-    expect(absenceHours).toEqual(2);
-    sinon.assert.calledOnceWithExactly(getHoursFromDailyAbsence, absence, contracts[0]);
+    expect(absenceHours).toEqual(8);
+    sinon.assert.calledTwice(getHoursFromDailyAbsence);
+    sinon.assert.calledWithExactly(getHoursFromDailyAbsence, absence, contracts[0]);
+    sinon.assert.calledWithExactly(getHoursFromDailyAbsence, absence, contracts[1]);
   });
 
   it('should return half-daily absence hours', async () => {

--- a/tests/unit/helpers/historyExport.test.js
+++ b/tests/unit/helpers/historyExport.test.js
@@ -370,24 +370,7 @@ describe('getAbsenceHours', () => {
     getHoursFromDailyAbsence.restore();
   });
 
-  it('should return daily absence hours by calling getHoursFromDailyAbsence', async () => {
-    const absence = { absenceNature: 'daily', startDate: '2019-05-18T10:00:00', endDate: '2019-05-18T12:00:00' };
-    const contracts = [
-      {
-        startDate: '2019-02-18T07:00:00',
-        endDate: '2019-07-18T22:00:00',
-        versions: [{ weeklyHours: 12 }, { weeklyHours: 24 }],
-      },
-    ];
-
-    getHoursFromDailyAbsence.returns(2);
-    const absenceHours = await ExportHelper.getAbsenceHours(absence, contracts);
-
-    expect(absenceHours).toEqual(2);
-    sinon.assert.calledOnceWithExactly(getHoursFromDailyAbsence, absence, contracts[0]);
-  });
-
-  it('should return daily absence hours with multiple contracts', async () => {
+  it('should return daily absence hours', async () => {
     const absence = { absenceNature: 'daily', startDate: '2019-05-18T10:00:00', endDate: '2019-05-18T12:00:00' };
     const contracts = [
       {
@@ -409,7 +392,29 @@ describe('getAbsenceHours', () => {
     sinon.assert.calledOnceWithExactly(getHoursFromDailyAbsence, absence, contracts[0]);
   });
 
-  it('should return hourly absence hours without calling getHoursFromDailyAbsence', async () => {
+  it('should return half-daily absence hours with mutiple contracts', async () => {
+    const absence = { absenceNature: 'half-daily', startDate: '2019-05-18T10:00:00', endDate: '2019-05-18T12:00:00' };
+    const contracts = [
+      {
+        startDate: '2019-02-18T07:00:00',
+        endDate: '2019-07-18T22:00:00',
+        versions: [{ weeklyHours: 12 }, { weeklyHours: 24 }],
+      },
+      {
+        startDate: '2019-07-19T07:00:00',
+        endDate: '2019-09-18T22:00:00',
+        versions: [{ weeklyHours: 12 }],
+      },
+    ];
+
+    getHoursFromDailyAbsence.returns(1);
+    const absenceHours = await ExportHelper.getAbsenceHours(absence, contracts);
+
+    expect(absenceHours).toEqual(1);
+    sinon.assert.calledOnceWithExactly(getHoursFromDailyAbsence, absence, contracts[0]);
+  });
+
+  it('should return hourly absence hours', async () => {
     const absence = { absenceNature: 'hourly', startDate: '2019-05-18T10:00:00', endDate: '2019-05-18T12:00:00' };
     const contracts = [
       {
@@ -427,7 +432,7 @@ describe('getAbsenceHours', () => {
     const absenceHours = await ExportHelper.getAbsenceHours(absence, contracts);
 
     expect(absenceHours).toEqual(2);
-    sinon.assert.notCalled(getHoursFromDailyAbsence);
+    sinon.assert.calledOnceWithExactly(getHoursFromDailyAbsence, absence, contracts[0]);
   });
 });
 


### PR DESCRIPTION
|  |  | TESTS  :computer: | |
|----------|----------|----------|----------|
| <ul><li>[x] oui </li></ul> | <ul><li>[ ] non</li></ul> | J'ai codé les tests unitaires
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | J'ai codé les tests d'intégration
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | C'est une ancienne route utilisée par les apps mobiles. | <ul><li>[ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens</li></ul>

---

|  |  | POINTS D'ATTENTION POUR CETTE PR  :warning:  | |
|----------|----------|----------|----------|
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | J'ai fait des modifications sur une route utilisée sur plusieurs plateformes | [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/n3bq2hr9Ia)
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | J'ai modifié un modèle utilisé en mobile | [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/rqTfwpUib)
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | J'ai ajouté un modèle spécifique à une structure | <ul><li>[ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés</li></ul>
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile |  <ul><li>[ ] Si oui, j'ai précisé sur le [slite de MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) qu'il faut forcer la mise à jour</li></ul>
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | J'ai ajouté une variable d'environnement | <ul><li>[ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites</li></ul>

---

|  |  |  FONCTIONNALITÉS APPS MOBILES  :iphone: | |
|----------|----------|----------|----------|
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | Mes changements impactent l'application formation | <ul><li>[ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours</li></ul>
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | Mes changements impactent l'application erp | <ul><li>[ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours</li></ul>

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : client coach/admin/auxiliaire

- Cas d'usage : Je peux éditer des congés payées a la demi-journée

- Comment tester ? :
  - editer une absence demi-journalière
  - exporter l'historique des absences et verifier que les absences demi-journalière sont bien prises en compte

Si tu as lu cette description, pense a réagir avec un :eye:
