### PR TITLE
Com 2606

### DIFF
--- a/src/helpers/123paie/absences.js
+++ b/src/helpers/123paie/absences.js
@@ -15,7 +15,7 @@ const {
   WORK_ACCIDENT,
   TRANSPORT_ACCIDENT,
 } = require('../constants');
-const HistoryExportHelper = require('../historyExport');
+const DraftPayHelper = require('../draftPay');
 const Event = require('../../models/Event');
 const Pay = require('../../models/Pay');
 
@@ -104,7 +104,7 @@ exports.exportAbsences = async (query, credentials) => {
         va_abs_nb22: [1, 2, 3, 4, 5].includes(moment(day).isoWeekday()) ? 1 : 0,
         va_abs_nb26: [1, 2, 3, 4, 5, 6].includes(moment(day).isoWeekday()) ? 1 : 0,
         va_abs_nb30: 1,
-        va_abs_nbh: HistoryExportHelper.getAbsenceHours(formattedAbsence, [matchingContract]),
+        va_abs_nbh: DraftPayHelper.getAbsenceHours(formattedAbsence, [matchingContract]),
       });
     }
   }

--- a/src/helpers/123paie/absences.js
+++ b/src/helpers/123paie/absences.js
@@ -3,7 +3,6 @@ const moment = require('moment');
 const FileHelper = require('../file');
 const {
   ABSENCE,
-  DAILY,
   HOURLY,
   PAID_LEAVE,
   UNPAID_LEAVE,
@@ -94,7 +93,7 @@ exports.exportAbsences = async (query, credentials) => {
       const formattedAbsence = abs.absenceNature === HOURLY
         ? { ...abs }
         : {
-          absenceNature: DAILY,
+          absenceNature: abs.absenceNature,
           startDate: moment(day).startOf('d').toISOString(),
           endDate: moment(day).endOf('d').toISOString(),
         };

--- a/src/helpers/draftPay.js
+++ b/src/helpers/draftPay.js
@@ -21,6 +21,8 @@ const {
   DAILY,
   INTERNAL_HOUR,
   WEEKS_PER_MONTH,
+  HOURLY,
+  HALF_DAILY,
 } = require('./constants');
 const DistanceMatrixHelper = require('./distanceMatrix');
 const UtilsHelper = require('./utils');
@@ -314,6 +316,15 @@ exports.getHoursFromDailyAbsence = (absence, contract, query = absence) => {
   }
 
   return hours;
+};
+
+exports.getAbsenceHours = (absence, contracts) => {
+  if (absence.absenceNature === HOURLY) return moment(absence.endDate).diff(absence.startDate, 'm') / 60;
+
+  const dailyAbsenceHours = contracts.filter(c => moment(c.startDate).isSameOrBefore(absence.endDate) &&
+    (!c.endDate || moment(c.endDate).isAfter(absence.startDate)))
+    .reduce((acc, c) => acc + this.getHoursFromDailyAbsence(absence, c), 0);
+  return absence.absenceNature === HALF_DAILY ? dailyAbsenceHours / 2 : dailyAbsenceHours;
 };
 
 exports.getPayFromAbsences = (absences, contract, query) => absences.reduce((acc, abs) => {

--- a/src/helpers/historyExport.js
+++ b/src/helpers/historyExport.js
@@ -22,7 +22,6 @@ const {
   MANUAL_TIME_STAMPING_REASONS,
   EVENT_TRANSPORT_MODE_LIST,
   INTRA,
-  HALF_DAILY,
 } = require('./constants');
 const DatesHelper = require('./dates');
 const UtilsHelper = require('./utils');
@@ -185,15 +184,6 @@ exports.exportWorkingEventsHistory = async (startDate, endDate, credentials) => 
   return rows;
 };
 
-exports.getAbsenceHours = (absence, contracts) => {
-  if (absence.absenceNature === HOURLY) return moment(absence.endDate).diff(absence.startDate, 'm') / 60;
-
-  const dailyAbsenceHours = contracts.filter(c => moment(c.startDate).isSameOrBefore(absence.endDate) &&
-    (!c.endDate || moment(c.endDate).isAfter(absence.startDate)))
-    .reduce((acc, c) => acc + DraftPayHelper.getHoursFromDailyAbsence(absence, c), 0);
-  return absence.absenceNature === HALF_DAILY ? dailyAbsenceHours / 2 : dailyAbsenceHours;
-};
-
 const absenceExportHeader = [
   'Id Auxiliaire',
   'Auxiliaire - Prénom',
@@ -211,7 +201,7 @@ const absenceExportHeader = [
 ];
 
 exports.formatAbsence = (absence) => {
-  const hours = exports.getAbsenceHours(absence, absence.auxiliary.contracts);
+  const hours = DraftPayHelper.getAbsenceHours(absence, absence.auxiliary.contracts);
   const datetimeFormat = absence.absenceNature === HOURLY ? 'DD/MM/YYYY HH:mm' : 'DD/MM/YYYY';
 
   return [

--- a/tests/unit/helpers/123Paie/absences.test.js
+++ b/tests/unit/helpers/123Paie/absences.test.js
@@ -7,7 +7,7 @@ const Event = require('../../../../src/models/Event');
 const Pay = require('../../../../src/models/Pay');
 const Absences123PayHelper = require('../../../../src/helpers/123paie/absences');
 const FileHelper = require('../../../../src/helpers/file');
-const HistoryExportHelper = require('../../../../src/helpers/historyExport');
+const DraftPayHelper = require('../../../../src/helpers/draftPay');
 const {
   PAID_LEAVE,
   UNPAID_LEAVE,
@@ -139,7 +139,7 @@ describe('exportsAbsence', () => {
   let exportToTxt;
   beforeEach(() => {
     getAbsences = sinon.stub(Absences123PayHelper, 'getAbsences');
-    getAbsenceHours = sinon.stub(HistoryExportHelper, 'getAbsenceHours');
+    getAbsenceHours = sinon.stub(DraftPayHelper, 'getAbsenceHours');
     exportToTxt = sinon.stub(FileHelper, 'exportToTxt');
     process.env.AP_SOC = 'ap_soc';
   });

--- a/tests/unit/helpers/draftPay.test.js
+++ b/tests/unit/helpers/draftPay.test.js
@@ -1320,6 +1320,84 @@ describe('getHoursFromDailyAbsence', () => {
   });
 });
 
+describe('getAbsenceHours', () => {
+  let getHoursFromDailyAbsence;
+  beforeEach(() => {
+    getHoursFromDailyAbsence = sinon.stub(DraftPayHelper, 'getHoursFromDailyAbsence');
+  });
+  afterEach(() => {
+    getHoursFromDailyAbsence.restore();
+  });
+
+  it('should return daily absence hours', async () => {
+    const absence = { absenceNature: 'daily', startDate: '2019-07-17T10:00:00', endDate: '2019-07-20T12:00:00' };
+    const contracts = [
+      {
+        startDate: '2019-02-18T07:00:00',
+        endDate: '2019-07-18T22:00:00',
+        versions: [{ weeklyHours: 12 }, { weeklyHours: 24 }],
+      },
+      {
+        startDate: '2019-07-19T07:00:00',
+        endDate: '2019-09-18T22:00:00',
+        versions: [{ weeklyHours: 12 }],
+      },
+    ];
+
+    getHoursFromDailyAbsence.onCall(0).returns(4);
+    getHoursFromDailyAbsence.onCall(1).returns(4);
+    const absenceHours = await DraftPayHelper.getAbsenceHours(absence, contracts);
+
+    expect(absenceHours).toEqual(8);
+    sinon.assert.calledTwice(getHoursFromDailyAbsence);
+    sinon.assert.calledWithExactly(getHoursFromDailyAbsence, absence, contracts[0]);
+    sinon.assert.calledWithExactly(getHoursFromDailyAbsence, absence, contracts[1]);
+  });
+
+  it('should return half-daily absence hours', async () => {
+    const absence = { absenceNature: 'half-daily', startDate: '2019-05-18T10:00:00', endDate: '2019-05-18T12:00:00' };
+    const contracts = [
+      {
+        startDate: '2019-02-18T07:00:00',
+        endDate: '2019-07-18T22:00:00',
+        versions: [{ weeklyHours: 12 }, { weeklyHours: 24 }],
+      },
+      {
+        startDate: '2019-07-19T07:00:00',
+        endDate: '2019-09-18T22:00:00',
+        versions: [{ weeklyHours: 12 }],
+      },
+    ];
+
+    getHoursFromDailyAbsence.returns(1);
+    const absenceHours = await DraftPayHelper.getAbsenceHours(absence, contracts);
+
+    expect(absenceHours).toEqual(1);
+    sinon.assert.calledOnceWithExactly(getHoursFromDailyAbsence, absence, contracts[0]);
+  });
+
+  it('should return hourly absence hours', async () => {
+    const absence = { absenceNature: 'hourly', startDate: '2019-05-18T10:00:00', endDate: '2019-05-18T12:00:00' };
+    const contracts = [
+      {
+        startDate: '2019-02-18T07:00:00',
+        endDate: '2019-07-18T22:00:00',
+        versions: [{ weeklyHours: 12 }, { weeklyHours: 24 }],
+      },
+      {
+        startDate: '2019-07-19T07:00:00',
+        endDate: '2019-09-18T22:00:00',
+        versions: [{ weeklyHours: 12 }],
+      },
+    ];
+
+    const absenceHours = await DraftPayHelper.getAbsenceHours(absence, contracts);
+
+    expect(absenceHours).toEqual(2);
+    sinon.assert.notCalled(getHoursFromDailyAbsence);
+  });
+});
+
 describe('getPayFromAbsences', () => {
   let getHoursFromDailyAbsence;
   beforeEach(() => {

--- a/tests/unit/helpers/draftPay.test.js
+++ b/tests/unit/helpers/draftPay.test.js
@@ -1350,8 +1350,8 @@ describe('getAbsenceHours', () => {
 
     expect(absenceHours).toEqual(8);
     sinon.assert.calledTwice(getHoursFromDailyAbsence);
-    sinon.assert.calledWithExactly(getHoursFromDailyAbsence, absence, contracts[0]);
-    sinon.assert.calledWithExactly(getHoursFromDailyAbsence, absence, contracts[1]);
+    sinon.assert.calledWithExactly(getHoursFromDailyAbsence, absence, contracts[0], absence);
+    sinon.assert.calledWithExactly(getHoursFromDailyAbsence, absence, contracts[1], absence);
   });
 
   it('should return half-daily absence hours', async () => {
@@ -1370,10 +1370,10 @@ describe('getAbsenceHours', () => {
     ];
 
     getHoursFromDailyAbsence.returns(1);
-    const absenceHours = await DraftPayHelper.getAbsenceHours(absence, contracts);
+    const absenceHours = await DraftPayHelper.getAbsenceHours(absence, contracts, absence);
 
     expect(absenceHours).toEqual(1);
-    sinon.assert.calledOnceWithExactly(getHoursFromDailyAbsence, absence, contracts[0]);
+    sinon.assert.calledOnceWithExactly(getHoursFromDailyAbsence, absence, contracts[0], absence);
   });
 
   it('should return hourly absence hours', async () => {

--- a/tests/unit/helpers/historyExport.test.js
+++ b/tests/unit/helpers/historyExport.test.js
@@ -361,88 +361,10 @@ describe('exportWorkingEventsHistory', () => {
   });
 });
 
-describe('getAbsenceHours', () => {
-  let getHoursFromDailyAbsence;
-  beforeEach(() => {
-    getHoursFromDailyAbsence = sinon.stub(DraftPayHelper, 'getHoursFromDailyAbsence');
-  });
-  afterEach(() => {
-    getHoursFromDailyAbsence.restore();
-  });
-
-  it('should return daily absence hours', async () => {
-    const absence = { absenceNature: 'daily', startDate: '2019-07-17T10:00:00', endDate: '2019-07-20T12:00:00' };
-    const contracts = [
-      {
-        startDate: '2019-02-18T07:00:00',
-        endDate: '2019-07-18T22:00:00',
-        versions: [{ weeklyHours: 12 }, { weeklyHours: 24 }],
-      },
-      {
-        startDate: '2019-07-19T07:00:00',
-        endDate: '2019-09-18T22:00:00',
-        versions: [{ weeklyHours: 12 }],
-      },
-    ];
-
-    getHoursFromDailyAbsence.onCall(0).returns(4);
-    getHoursFromDailyAbsence.onCall(1).returns(4);
-    const absenceHours = await ExportHelper.getAbsenceHours(absence, contracts);
-
-    expect(absenceHours).toEqual(8);
-    sinon.assert.calledTwice(getHoursFromDailyAbsence);
-    sinon.assert.calledWithExactly(getHoursFromDailyAbsence, absence, contracts[0]);
-    sinon.assert.calledWithExactly(getHoursFromDailyAbsence, absence, contracts[1]);
-  });
-
-  it('should return half-daily absence hours', async () => {
-    const absence = { absenceNature: 'half-daily', startDate: '2019-05-18T10:00:00', endDate: '2019-05-18T12:00:00' };
-    const contracts = [
-      {
-        startDate: '2019-02-18T07:00:00',
-        endDate: '2019-07-18T22:00:00',
-        versions: [{ weeklyHours: 12 }, { weeklyHours: 24 }],
-      },
-      {
-        startDate: '2019-07-19T07:00:00',
-        endDate: '2019-09-18T22:00:00',
-        versions: [{ weeklyHours: 12 }],
-      },
-    ];
-
-    getHoursFromDailyAbsence.returns(1);
-    const absenceHours = await ExportHelper.getAbsenceHours(absence, contracts);
-
-    expect(absenceHours).toEqual(1);
-    sinon.assert.calledOnceWithExactly(getHoursFromDailyAbsence, absence, contracts[0]);
-  });
-
-  it('should return hourly absence hours', async () => {
-    const absence = { absenceNature: 'hourly', startDate: '2019-05-18T10:00:00', endDate: '2019-05-18T12:00:00' };
-    const contracts = [
-      {
-        startDate: '2019-02-18T07:00:00',
-        endDate: '2019-07-18T22:00:00',
-        versions: [{ weeklyHours: 12 }, { weeklyHours: 24 }],
-      },
-      {
-        startDate: '2019-07-19T07:00:00',
-        endDate: '2019-09-18T22:00:00',
-        versions: [{ weeklyHours: 12 }],
-      },
-    ];
-
-    const absenceHours = await ExportHelper.getAbsenceHours(absence, contracts);
-
-    expect(absenceHours).toEqual(2);
-    sinon.assert.notCalled(getHoursFromDailyAbsence);
-  });
-});
-
 describe('formatAbsence', () => {
   let getAbsenceHours;
   beforeEach(() => {
-    getAbsenceHours = sinon.stub(ExportHelper, 'getAbsenceHours');
+    getAbsenceHours = sinon.stub(DraftPayHelper, 'getAbsenceHours');
   });
   afterEach(() => {
     getAbsenceHours.restore();


### PR DESCRIPTION
|  |  | TESTS  :computer: | |
|----------|----------|----------|----------|
| <ul><li>[x] oui </li></ul> | <ul><li>[ ] non</li></ul> | J'ai codé les tests unitaires
| <ul><li>[] oui </li></ul> | <ul><li>[x] non</li></ul> | J'ai codé les tests d'intégration
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | C'est une ancienne route utilisée par les apps mobiles. | <ul><li>[ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens</li></ul>

---

|  |  | POINTS D'ATTENTION POUR CETTE PR  :warning:  | |
|----------|----------|----------|----------|
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | J'ai fait des modifications sur une route utilisée sur plusieurs plateformes | [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/n3bq2hr9Ia)
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | J'ai modifié un modèle utilisé en mobile | [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/rqTfwpUib)
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | J'ai ajouté un modèle spécifique à une structure | <ul><li>[ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés</li></ul>
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile |  <ul><li>[ ] Si oui, j'ai précisé sur le [slite de MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) qu'il faut forcer la mise à jour</li></ul>
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | J'ai ajouté une variable d'environnement | <ul><li>[ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites</li></ul>

---

|  |  |  FONCTIONNALITÉS APPS MOBILES  :iphone: | |
|----------|----------|----------|----------|
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | Mes changements impactent l'application formation | <ul><li>[ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours</li></ul>
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | Mes changements impactent l'application erp | <ul><li>[ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours</li></ul>

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : ETQ coach / admin / auxiliaire 

- Cas d'usage : la durée d'un CP semi journalier est prise en compte pour le calcul des heures à travailler

- Comment tester ? : 
   - creer des absences semi-journalières ( si un.e auxiliaire a un contrat de 24h/semaine --> une absence journalière a une durée de 4h et une absence semi-journalière a une durée de 2h) 
   - verifier que les absences semi-journalières sont bien prises en compte:
       - sur le tableau de bord de l'auxiliaire et de l'équipe de l'auxiliaire
       - sur le planning de l'auxiliaire
       - dans le solde de tout compte
       - dans l'export des absences 

Si tu as lu cette description, pense a réagir avec un :eye:
