### PR TITLE
Com 2612

### DIFF
--- a/src/helpers/courses.js
+++ b/src/helpers/courses.js
@@ -406,15 +406,6 @@ exports.formatInterCourseSlotsForPdf = (slot) => {
   };
 };
 
-exports.getCourseDuration = (slots) => {
-  const duration = slots.reduce(
-    (acc, slot) => acc.add(CompaniDuration(CompaniDate(slot.endDate).diff(slot.startDate, 'minutes'))),
-    CompaniDuration()
-  );
-
-  return duration.format();
-};
-
 exports.groupSlotsByDate = (slots) => {
   const group = groupBy(slots, slot => CompaniDate(slot.startDate).format('dd/LL/yyyy'));
 
@@ -426,7 +417,7 @@ exports.formatIntraCourseForPdf = (course) => {
   const name = course.subProgram.program.name + possibleMisc;
   const courseData = {
     name,
-    duration: exports.getCourseDuration(course.slots),
+    duration: UtilsHelper.computeTotalDuration(course.slots),
     company: course.company.name,
     trainer: course.trainer ? UtilsHelper.formatIdentity(course.trainer.identity, 'FL') : '',
   };
@@ -461,7 +452,7 @@ exports.formatInterCourseForPdf = (course) => {
     lastDate: filteredSlots.length
       ? CompaniDate(filteredSlots[filteredSlots.length - 1].startDate).format('dd/LL/yyyy')
       : '',
-    duration: exports.getCourseDuration(filteredSlots),
+    duration: UtilsHelper.computeTotalDuration(filteredSlots),
   };
 
   return {
@@ -494,7 +485,7 @@ exports.formatCourseForDocx = (course) => {
   const sortedCourseSlots = course.slots.sort((a, b) => DatesHelper.ascendingSort('startDate')(a, b));
 
   return {
-    duration: exports.getCourseDuration(course.slots),
+    duration: UtilsHelper.computeTotalDuration(course.slots),
     learningGoals: get(course, 'subProgram.program.learningGoals') || '',
     programName: get(course, 'subProgram.program.name').toUpperCase() || '',
     startDate: CompaniDate(sortedCourseSlots[0].startDate).format('dd/LL/yyyy'),

--- a/src/helpers/courses.js
+++ b/src/helpers/courses.js
@@ -418,7 +418,7 @@ exports.formatIntraCourseForPdf = (course) => {
   const name = course.subProgram.program.name + possibleMisc;
   const courseData = {
     name,
-    duration: UtilsHelper.computeTotalDuration(course.slots),
+    duration: UtilsHelper.getTotalDuration(course.slots),
     company: course.company.name,
     trainer: course.trainer ? UtilsHelper.formatIdentity(course.trainer.identity, 'FL') : '',
   };
@@ -453,7 +453,7 @@ exports.formatInterCourseForPdf = (course) => {
     lastDate: filteredSlots.length
       ? CompaniDate(filteredSlots[filteredSlots.length - 1].startDate).format('dd/LL/yyyy')
       : '',
-    duration: UtilsHelper.computeTotalDuration(filteredSlots),
+    duration: UtilsHelper.getTotalDuration(filteredSlots),
   };
 
   return {
@@ -486,7 +486,7 @@ exports.formatCourseForDocx = (course) => {
   const sortedCourseSlots = course.slots.sort((a, b) => DatesHelper.ascendingSort('startDate')(a, b));
 
   return {
-    duration: UtilsHelper.computeTotalDuration(course.slots),
+    duration: UtilsHelper.getTotalDuration(course.slots),
     learningGoals: get(course, 'subProgram.program.learningGoals') || '',
     programName: get(course, 'subProgram.program.name').toUpperCase() || '',
     startDate: CompaniDate(sortedCourseSlots[0].startDate).format('dd/LL/yyyy'),
@@ -518,7 +518,7 @@ exports.generateCompletionCertificates = async (courseId) => {
     const traineeSlots = courseAttendances
       .filter(a => UtilsHelper.areObjectIdsEquals(trainee._id, a.trainee))
       .map(a => a.courseSlot);
-    const attendanceDuration = UtilsHelper.computeTotalDuration(traineeSlots);
+    const attendanceDuration = UtilsHelper.getTotalDuration(traineeSlots);
     const filePath = await DocxHelper.createDocx(
       certificateTemplatePath,
       {

--- a/src/helpers/historyExport.js
+++ b/src/helpers/historyExport.js
@@ -701,7 +701,7 @@ exports.exportCourseHistory = async (startDate, endDate) => {
       'Nombre d\'inscrits': get(course, 'trainees.length') || '',
       'Nombre de dates': slotsGroupedByDate.length,
       'Nombre de créneaux': get(course, 'slots.length') || '',
-      'Durée Totale': UtilsHelper.computeTotalDuration(course.slots),
+      'Durée Totale': UtilsHelper.getTotalDuration(course.slots),
       'Nombre de SMS envoyés': smsCount,
       'Nombre de personnes connectées à l\'app': course.trainees
         .filter(trainee => trainee.firstMobileConnection).length,

--- a/src/helpers/historyExport.js
+++ b/src/helpers/historyExport.js
@@ -701,7 +701,7 @@ exports.exportCourseHistory = async (startDate, endDate) => {
       'Nombre d\'inscrits': get(course, 'trainees.length') || '',
       'Nombre de dates': slotsGroupedByDate.length,
       'Nombre de créneaux': get(course, 'slots.length') || '',
-      'Durée Totale': CourseHelper.getCourseDuration(course.slots),
+      'Durée Totale': UtilsHelper.computeTotalDuration(course.slots),
       'Nombre de SMS envoyés': smsCount,
       'Nombre de personnes connectées à l\'app': course.trainees
         .filter(trainee => trainee.firstMobileConnection).length,

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -217,7 +217,7 @@ exports.computeExclTaxesWithDiscount = (exclTaxes, discount, vat) => {
   return NumbersHelper.subtract(exclTaxes, discountExclTaxes);
 };
 
-exports.computeTotalDuration = (timePeriods) => {
+exports.getTotalDuration = (timePeriods) => {
   const totalDuration = timePeriods.reduce(
     (acc, tp) => acc.add(CompaniDuration(CompaniDate(tp.endDate).diff(tp.startDate, 'minutes'))),
     CompaniDuration()

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -5,6 +5,8 @@ const Intl = require('intl');
 const moment = require('../extensions/moment');
 const { CIVILITY_LIST } = require('./constants');
 const DatesHelper = require('./dates');
+const { CompaniDate } = require('./dates/companiDates');
+const { CompaniDuration } = require('./dates/companiDurations');
 const NumbersHelper = require('./numbers');
 
 exports.getLastVersion = (versions, dateKey) => {
@@ -213,4 +215,13 @@ exports.computeExclTaxesWithDiscount = (exclTaxes, discount, vat) => {
   const discountExclTaxes = exports.getExclTaxes(discount, vat);
 
   return NumbersHelper.subtract(exclTaxes, discountExclTaxes);
+};
+
+exports.computeTotalDuration = (timePeriods) => {
+  const totalDuration = timePeriods.reduce(
+    (acc, tp) => acc.add(CompaniDuration(CompaniDate(tp.endDate).diff(tp.startDate, 'minutes'))),
+    CompaniDuration()
+  );
+
+  return totalDuration.format();
 };

--- a/tests/unit/helpers/courses.test.js
+++ b/tests/unit/helpers/courses.test.js
@@ -1435,49 +1435,6 @@ describe('formatInterCourseSlotsForPdf', () => {
   });
 });
 
-describe('getCourseDuration', () => {
-  it('should return course duration with minutes', () => {
-    const slots = [
-      { startDate: '2020-03-20T09:00:00', endDate: '2020-03-20T11:00:00' },
-      { startDate: '2020-04-21T09:00:00', endDate: '2020-04-21T11:30:00' },
-    ];
-
-    const result = CourseHelper.getCourseDuration(slots);
-
-    expect(result).toEqual('4h30');
-  });
-  it('should return course duration with leading zero minutes', () => {
-    const slots = [
-      { startDate: '2020-03-20T09:00:00', endDate: '2020-03-20T11:08:00' },
-      { startDate: '2020-04-21T09:00:00', endDate: '2020-04-21T11:00:00' },
-    ];
-
-    const result = CourseHelper.getCourseDuration(slots);
-
-    expect(result).toEqual('4h08');
-  });
-  it('should return course duration without minutes', () => {
-    const slots = [
-      { startDate: '2020-03-20T09:00:00', endDate: '2020-03-20T11:00:00' },
-      { startDate: '2020-04-21T09:00:00', endDate: '2020-04-21T11:00:00' },
-    ];
-
-    const result = CourseHelper.getCourseDuration(slots);
-
-    expect(result).toEqual('4h');
-  });
-  it('should return course duration with days', () => {
-    const slots = [
-      { startDate: '2020-03-20T07:00:00', endDate: '2020-03-20T22:00:00' },
-      { startDate: '2020-04-21T07:00:00', endDate: '2020-04-21T22:00:00' },
-    ];
-
-    const result = CourseHelper.getCourseDuration(slots);
-
-    expect(result).toEqual('30h');
-  });
-});
-
 describe('groupSlotsByDate', () => {
   it('should group slots by date', () => {
     const slots = [
@@ -1507,18 +1464,18 @@ describe('groupSlotsByDate', () => {
 
 describe('formatIntraCourseForPdf', () => {
   let formatIdentity;
-  let getCourseDuration;
+  let computeTotalDuration;
   let groupSlotsByDate;
   let formatIntraCourseSlotsForPdf;
   beforeEach(() => {
     formatIdentity = sinon.stub(UtilsHelper, 'formatIdentity');
-    getCourseDuration = sinon.stub(CourseHelper, 'getCourseDuration');
+    computeTotalDuration = sinon.stub(UtilsHelper, 'computeTotalDuration');
     groupSlotsByDate = sinon.stub(CourseHelper, 'groupSlotsByDate');
     formatIntraCourseSlotsForPdf = sinon.stub(CourseHelper, 'formatIntraCourseSlotsForPdf');
   });
   afterEach(() => {
     formatIdentity.restore();
-    getCourseDuration.restore();
+    computeTotalDuration.restore();
     groupSlotsByDate.restore();
     formatIntraCourseSlotsForPdf.restore();
   });
@@ -1542,7 +1499,7 @@ describe('formatIntraCourseForPdf', () => {
       company: { name: 'alenvi' },
     };
 
-    getCourseDuration.returns('8h');
+    computeTotalDuration.returns('8h');
     formatIdentity.returns('MasterClass');
     groupSlotsByDate.returns([[{
       startDate: '2020-03-20T09:00:00',
@@ -1572,7 +1529,7 @@ describe('formatIntraCourseForPdf', () => {
         date: '12/04/2020',
       }],
     });
-    sinon.assert.calledOnceWithExactly(getCourseDuration, course.slots);
+    sinon.assert.calledOnceWithExactly(computeTotalDuration, course.slots);
     sinon.assert.calledOnceWithExactly(formatIdentity, { lastname: 'MasterClass' }, 'FL');
     sinon.assert.calledOnceWithExactly(groupSlotsByDate, [
       {
@@ -1593,16 +1550,16 @@ describe('formatIntraCourseForPdf', () => {
 
 describe('formatInterCourseForPdf', () => {
   let formatIdentity;
-  let getCourseDuration;
+  let computeTotalDuration;
   let formatInterCourseSlotsForPdf;
   beforeEach(() => {
     formatIdentity = sinon.stub(UtilsHelper, 'formatIdentity');
-    getCourseDuration = sinon.stub(CourseHelper, 'getCourseDuration');
+    computeTotalDuration = sinon.stub(UtilsHelper, 'computeTotalDuration');
     formatInterCourseSlotsForPdf = sinon.stub(CourseHelper, 'formatInterCourseSlotsForPdf');
   });
   afterEach(() => {
     formatIdentity.restore();
-    getCourseDuration.restore();
+    computeTotalDuration.restore();
     formatInterCourseSlotsForPdf.restore();
   });
 
@@ -1631,7 +1588,7 @@ describe('formatInterCourseForPdf', () => {
     formatIdentity.onCall(0).returns('Pere Castor');
     formatIdentity.onCall(1).returns('trainee 1');
     formatIdentity.onCall(2).returns('trainee 2');
-    getCourseDuration.returns('7h');
+    computeTotalDuration.returns('7h');
 
     const result = CourseHelper.formatInterCourseForPdf(course);
 
@@ -1666,7 +1623,7 @@ describe('formatInterCourseForPdf', () => {
     sinon.assert.calledWithExactly(formatIdentity.getCall(0), { lastname: 'MasterClass' }, 'FL');
     sinon.assert.calledWithExactly(formatIdentity.getCall(1), { lastname: 'trainee 1' }, 'FL');
     sinon.assert.calledWithExactly(formatIdentity.getCall(2), { lastname: 'trainee 2' }, 'FL');
-    sinon.assert.calledOnceWithExactly(getCourseDuration, sortedSlots);
+    sinon.assert.calledOnceWithExactly(computeTotalDuration, sortedSlots);
     sinon.assert.callCount(formatInterCourseSlotsForPdf, 3);
   });
 });
@@ -1764,12 +1721,12 @@ describe('generateAttendanceSheets', () => {
 });
 
 describe('formatCourseForDocx', () => {
-  let getCourseDuration;
+  let computeTotalDuration;
   beforeEach(() => {
-    getCourseDuration = sinon.stub(CourseHelper, 'getCourseDuration');
+    computeTotalDuration = sinon.stub(UtilsHelper, 'computeTotalDuration');
   });
   afterEach(() => {
-    getCourseDuration.restore();
+    computeTotalDuration.restore();
   });
 
   it('should format course for docx', () => {
@@ -1781,7 +1738,7 @@ describe('formatCourseForDocx', () => {
       ],
       subProgram: { program: { learningGoals: 'Apprendre', name: 'nom du programme' } },
     };
-    getCourseDuration.returns('7h');
+    computeTotalDuration.returns('7h');
 
     const result = CourseHelper.formatCourseForDocx(course);
 
@@ -1793,7 +1750,7 @@ describe('formatCourseForDocx', () => {
       programName: 'NOM DU PROGRAMME',
     });
     sinon.assert.calledOnceWithExactly(
-      getCourseDuration,
+      computeTotalDuration,
       [
         { startDate: '2020-03-20T09:00:00', endDate: '2020-03-20T11:00:00' },
         { startDate: '2020-04-12T09:00:00', endDate: '2020-04-12T11:30:00' },

--- a/tests/unit/helpers/courses.test.js
+++ b/tests/unit/helpers/courses.test.js
@@ -1465,18 +1465,18 @@ describe('groupSlotsByDate', () => {
 
 describe('formatIntraCourseForPdf', () => {
   let formatIdentity;
-  let computeTotalDuration;
+  let getTotalDuration;
   let groupSlotsByDate;
   let formatIntraCourseSlotsForPdf;
   beforeEach(() => {
     formatIdentity = sinon.stub(UtilsHelper, 'formatIdentity');
-    computeTotalDuration = sinon.stub(UtilsHelper, 'computeTotalDuration');
+    getTotalDuration = sinon.stub(UtilsHelper, 'getTotalDuration');
     groupSlotsByDate = sinon.stub(CourseHelper, 'groupSlotsByDate');
     formatIntraCourseSlotsForPdf = sinon.stub(CourseHelper, 'formatIntraCourseSlotsForPdf');
   });
   afterEach(() => {
     formatIdentity.restore();
-    computeTotalDuration.restore();
+    getTotalDuration.restore();
     groupSlotsByDate.restore();
     formatIntraCourseSlotsForPdf.restore();
   });
@@ -1500,7 +1500,7 @@ describe('formatIntraCourseForPdf', () => {
       company: { name: 'alenvi' },
     };
 
-    computeTotalDuration.returns('8h');
+    getTotalDuration.returns('8h');
     formatIdentity.returns('MasterClass');
     groupSlotsByDate.returns([[{
       startDate: '2020-03-20T09:00:00',
@@ -1530,7 +1530,7 @@ describe('formatIntraCourseForPdf', () => {
         date: '12/04/2020',
       }],
     });
-    sinon.assert.calledOnceWithExactly(computeTotalDuration, course.slots);
+    sinon.assert.calledOnceWithExactly(getTotalDuration, course.slots);
     sinon.assert.calledOnceWithExactly(formatIdentity, { lastname: 'MasterClass' }, 'FL');
     sinon.assert.calledOnceWithExactly(groupSlotsByDate, [
       {
@@ -1551,16 +1551,16 @@ describe('formatIntraCourseForPdf', () => {
 
 describe('formatInterCourseForPdf', () => {
   let formatIdentity;
-  let computeTotalDuration;
+  let getTotalDuration;
   let formatInterCourseSlotsForPdf;
   beforeEach(() => {
     formatIdentity = sinon.stub(UtilsHelper, 'formatIdentity');
-    computeTotalDuration = sinon.stub(UtilsHelper, 'computeTotalDuration');
+    getTotalDuration = sinon.stub(UtilsHelper, 'getTotalDuration');
     formatInterCourseSlotsForPdf = sinon.stub(CourseHelper, 'formatInterCourseSlotsForPdf');
   });
   afterEach(() => {
     formatIdentity.restore();
-    computeTotalDuration.restore();
+    getTotalDuration.restore();
     formatInterCourseSlotsForPdf.restore();
   });
 
@@ -1589,7 +1589,7 @@ describe('formatInterCourseForPdf', () => {
     formatIdentity.onCall(0).returns('Pere Castor');
     formatIdentity.onCall(1).returns('trainee 1');
     formatIdentity.onCall(2).returns('trainee 2');
-    computeTotalDuration.returns('7h');
+    getTotalDuration.returns('7h');
 
     const result = CourseHelper.formatInterCourseForPdf(course);
 
@@ -1624,7 +1624,7 @@ describe('formatInterCourseForPdf', () => {
     sinon.assert.calledWithExactly(formatIdentity.getCall(0), { lastname: 'MasterClass' }, 'FL');
     sinon.assert.calledWithExactly(formatIdentity.getCall(1), { lastname: 'trainee 1' }, 'FL');
     sinon.assert.calledWithExactly(formatIdentity.getCall(2), { lastname: 'trainee 2' }, 'FL');
-    sinon.assert.calledOnceWithExactly(computeTotalDuration, sortedSlots);
+    sinon.assert.calledOnceWithExactly(getTotalDuration, sortedSlots);
     sinon.assert.callCount(formatInterCourseSlotsForPdf, 3);
   });
 });
@@ -1722,12 +1722,12 @@ describe('generateAttendanceSheets', () => {
 });
 
 describe('formatCourseForDocx', () => {
-  let computeTotalDuration;
+  let getTotalDuration;
   beforeEach(() => {
-    computeTotalDuration = sinon.stub(UtilsHelper, 'computeTotalDuration');
+    getTotalDuration = sinon.stub(UtilsHelper, 'getTotalDuration');
   });
   afterEach(() => {
-    computeTotalDuration.restore();
+    getTotalDuration.restore();
   });
 
   it('should format course for docx', () => {
@@ -1739,7 +1739,7 @@ describe('formatCourseForDocx', () => {
       ],
       subProgram: { program: { learningGoals: 'Apprendre', name: 'nom du programme' } },
     };
-    computeTotalDuration.returns('7h');
+    getTotalDuration.returns('7h');
 
     const result = CourseHelper.formatCourseForDocx(course);
 
@@ -1751,7 +1751,7 @@ describe('formatCourseForDocx', () => {
       programName: 'NOM DU PROGRAMME',
     });
     sinon.assert.calledOnceWithExactly(
-      computeTotalDuration,
+      getTotalDuration,
       [
         { startDate: '2020-03-20T09:00:00', endDate: '2020-03-20T11:00:00' },
         { startDate: '2020-04-12T09:00:00', endDate: '2020-04-12T11:30:00' },
@@ -1766,7 +1766,7 @@ describe('generateCompletionCertificate', () => {
   let attendanceFind;
   let formatCourseForDocx;
   let formatIdentity;
-  let computeTotalDuration;
+  let getTotalDuration;
   let createDocx;
   let generateZip;
   let luxonNow;
@@ -1778,7 +1778,7 @@ describe('generateCompletionCertificate', () => {
     attendanceFind = sinon.stub(Attendance, 'find');
     formatCourseForDocx = sinon.stub(CourseHelper, 'formatCourseForDocx');
     formatIdentity = sinon.stub(UtilsHelper, 'formatIdentity');
-    computeTotalDuration = sinon.stub(UtilsHelper, 'computeTotalDuration');
+    getTotalDuration = sinon.stub(UtilsHelper, 'getTotalDuration');
     createDocx = sinon.stub(DocxHelper, 'createDocx');
     generateZip = sinon.stub(ZipHelper, 'generateZip');
     luxonNow = sinon.stub(luxon.DateTime, 'now');
@@ -1791,7 +1791,7 @@ describe('generateCompletionCertificate', () => {
     attendanceFind.restore();
     formatCourseForDocx.restore();
     formatIdentity.restore();
-    computeTotalDuration.restore();
+    getTotalDuration.restore();
     createDocx.restore();
     generateZip.restore();
     luxonNow.restore();
@@ -1800,7 +1800,7 @@ describe('generateCompletionCertificate', () => {
     tmpDir.restore();
   });
 
-  it('should download completion certificates #tag', async () => {
+  it('should download completion certificates', async () => {
     const currentTimeISO = '2020-01-20T07:00:00.000Z';
     const courseId = new ObjectId();
     const readable1 = new PassThrough();
@@ -1846,9 +1846,9 @@ describe('generateCompletionCertificate', () => {
     formatIdentity.onCall(0).returns('trainee 1');
     formatIdentity.onCall(1).returns('trainee 2');
     formatIdentity.onCall(2).returns('trainee 3');
-    computeTotalDuration.onCall(0).returns('4h30');
-    computeTotalDuration.onCall(1).returns('3h');
-    computeTotalDuration.onCall(2).returns('0h');
+    getTotalDuration.onCall(0).returns('4h30');
+    getTotalDuration.onCall(1).returns('3h');
+    getTotalDuration.onCall(2).returns('0h');
     createReadStream.onCall(0).returns(readable1);
     createReadStream.onCall(1).returns(readable2);
     createReadStream.onCall(2).returns(readable3);
@@ -1860,11 +1860,11 @@ describe('generateCompletionCertificate', () => {
     sinon.assert.calledWithExactly(formatIdentity.getCall(1), { lastname: 'trainee 2' }, 'FL');
     sinon.assert.calledWithExactly(formatIdentity.getCall(2), { lastname: 'trainee 3' }, 'FL');
     sinon.assert.calledWithExactly(
-      computeTotalDuration.getCall(0),
+      getTotalDuration.getCall(0),
       [attendances[0].courseSlot, attendances[1].courseSlot]
     );
-    sinon.assert.calledWithExactly(computeTotalDuration.getCall(1), [attendances[2].courseSlot]);
-    sinon.assert.calledWithExactly(computeTotalDuration.getCall(2), []);
+    sinon.assert.calledWithExactly(getTotalDuration.getCall(1), [attendances[2].courseSlot]);
+    sinon.assert.calledWithExactly(getTotalDuration.getCall(2), []);
     sinon.assert.calledWithExactly(
       createDocx.getCall(0),
       '/path/certificate_template.docx',

--- a/tests/unit/helpers/historyExport.test.js
+++ b/tests/unit/helpers/historyExport.test.js
@@ -1752,7 +1752,7 @@ describe('exportCourseHistory', () => {
   let findCourseSlot;
   let findCourse;
   let groupSlotsByDate;
-  let getCourseDuration;
+  let computeTotalDuration;
   let countDocumentsCourseSmsHistory;
   let countDocumentsAttendanceSheet;
 
@@ -1760,7 +1760,7 @@ describe('exportCourseHistory', () => {
     findCourseSlot = sinon.stub(CourseSlot, 'find');
     findCourse = sinon.stub(Course, 'find');
     groupSlotsByDate = sinon.stub(CourseHelper, 'groupSlotsByDate');
-    getCourseDuration = sinon.stub(CourseHelper, 'getCourseDuration');
+    computeTotalDuration = sinon.stub(UtilsHelper, 'computeTotalDuration');
     countDocumentsCourseSmsHistory = sinon.stub(CourseSmsHistory, 'countDocuments');
     countDocumentsAttendanceSheet = sinon.stub(AttendanceSheet, 'countDocuments');
   });
@@ -1769,7 +1769,7 @@ describe('exportCourseHistory', () => {
     findCourseSlot.restore();
     findCourse.restore();
     groupSlotsByDate.restore();
-    getCourseDuration.restore();
+    computeTotalDuration.restore();
     countDocumentsCourseSmsHistory.restore();
     countDocumentsAttendanceSheet.restore();
   });
@@ -1779,8 +1779,8 @@ describe('exportCourseHistory', () => {
     findCourse.returns(SinonMongoose.stubChainedQueries([courseList]));
     groupSlotsByDate.onCall(0).returns([[courseSlotList[0], courseSlotList[1]]]);
     groupSlotsByDate.onCall(1).returns([[courseSlotList[2]], [courseSlotList[3]]]);
-    getCourseDuration.onCall(0).returns('4h');
-    getCourseDuration.onCall(1).returns('4h');
+    computeTotalDuration.onCall(0).returns('4h');
+    computeTotalDuration.onCall(1).returns('4h');
     countDocumentsCourseSmsHistory.onCall(0).returns(2);
     countDocumentsCourseSmsHistory.onCall(1).returns(1);
     countDocumentsAttendanceSheet.onCall(0).returns(1);

--- a/tests/unit/helpers/historyExport.test.js
+++ b/tests/unit/helpers/historyExport.test.js
@@ -1752,7 +1752,7 @@ describe('exportCourseHistory', () => {
   let findCourseSlot;
   let findCourse;
   let groupSlotsByDate;
-  let computeTotalDuration;
+  let getTotalDuration;
   let countDocumentsCourseSmsHistory;
   let countDocumentsAttendanceSheet;
 
@@ -1760,7 +1760,7 @@ describe('exportCourseHistory', () => {
     findCourseSlot = sinon.stub(CourseSlot, 'find');
     findCourse = sinon.stub(Course, 'find');
     groupSlotsByDate = sinon.stub(CourseHelper, 'groupSlotsByDate');
-    computeTotalDuration = sinon.stub(UtilsHelper, 'computeTotalDuration');
+    getTotalDuration = sinon.stub(UtilsHelper, 'getTotalDuration');
     countDocumentsCourseSmsHistory = sinon.stub(CourseSmsHistory, 'countDocuments');
     countDocumentsAttendanceSheet = sinon.stub(AttendanceSheet, 'countDocuments');
   });
@@ -1769,7 +1769,7 @@ describe('exportCourseHistory', () => {
     findCourseSlot.restore();
     findCourse.restore();
     groupSlotsByDate.restore();
-    computeTotalDuration.restore();
+    getTotalDuration.restore();
     countDocumentsCourseSmsHistory.restore();
     countDocumentsAttendanceSheet.restore();
   });
@@ -1779,8 +1779,8 @@ describe('exportCourseHistory', () => {
     findCourse.returns(SinonMongoose.stubChainedQueries([courseList]));
     groupSlotsByDate.onCall(0).returns([[courseSlotList[0], courseSlotList[1]]]);
     groupSlotsByDate.onCall(1).returns([[courseSlotList[2]], [courseSlotList[3]]]);
-    computeTotalDuration.onCall(0).returns('4h');
-    computeTotalDuration.onCall(1).returns('4h');
+    getTotalDuration.onCall(0).returns('4h');
+    getTotalDuration.onCall(1).returns('4h');
     countDocumentsCourseSmsHistory.onCall(0).returns(2);
     countDocumentsCourseSmsHistory.onCall(1).returns(1);
     countDocumentsAttendanceSheet.onCall(0).returns(1);

--- a/tests/unit/helpers/utils.test.js
+++ b/tests/unit/helpers/utils.test.js
@@ -360,3 +360,48 @@ describe('computeExclTaxesWithDiscount', () => {
     expect(result).toEqual(17);
   });
 });
+
+describe('computeTotalDuration', () => {
+  describe('computeTotalDuration', () => {
+    it('should return duration with minutes', () => {
+      const slots = [
+        { startDate: '2020-03-20T09:00:00.000Z', endDate: '2020-03-20T11:00:00.000Z' },
+        { startDate: '2020-04-21T09:00:00.000Z', endDate: '2020-04-21T11:30:00.000Z' },
+      ];
+
+      const result = UtilsHelper.computeTotalDuration(slots);
+
+      expect(result).toEqual('4h30');
+    });
+    it('should return duration with leading zero minutes', () => {
+      const slots = [
+        { startDate: '2020-03-20T09:00:00.000Z', endDate: '2020-03-20T11:08:00.000Z' },
+        { startDate: '2020-04-21T09:00:00.000Z', endDate: '2020-04-21T11:00:00.000Z' },
+      ];
+
+      const result = UtilsHelper.computeTotalDuration(slots);
+
+      expect(result).toEqual('4h08');
+    });
+    it('should return duration without minutes', () => {
+      const slots = [
+        { startDate: '2020-03-20T09:00:00.000Z', endDate: '2020-03-20T11:00:00.000Z' },
+        { startDate: '2020-04-21T09:00:00.000Z', endDate: '2020-04-21T11:00:00.000Z' },
+      ];
+
+      const result = UtilsHelper.computeTotalDuration(slots);
+
+      expect(result).toEqual('4h');
+    });
+    it('should return duration with days', () => {
+      const slots = [
+        { startDate: '2020-03-20T07:00:00.000Z', endDate: '2020-03-20T22:00:00.000Z' },
+        { startDate: '2020-04-21T07:00:00.000Z', endDate: '2020-04-21T22:00:00.000Z' },
+      ];
+
+      const result = UtilsHelper.computeTotalDuration(slots);
+
+      expect(result).toEqual('30h');
+    });
+  });
+});

--- a/tests/unit/helpers/utils.test.js
+++ b/tests/unit/helpers/utils.test.js
@@ -361,15 +361,15 @@ describe('computeExclTaxesWithDiscount', () => {
   });
 });
 
-describe('computeTotalDuration', () => {
-  describe('computeTotalDuration', () => {
+describe('getTotalDuration', () => {
+  describe('getTotalDuration', () => {
     it('should return duration with minutes', () => {
       const slots = [
         { startDate: '2020-03-20T09:00:00.000Z', endDate: '2020-03-20T11:00:00.000Z' },
         { startDate: '2020-04-21T09:00:00.000Z', endDate: '2020-04-21T11:30:00.000Z' },
       ];
 
-      const result = UtilsHelper.computeTotalDuration(slots);
+      const result = UtilsHelper.getTotalDuration(slots);
 
       expect(result).toEqual('4h30');
     });
@@ -379,7 +379,7 @@ describe('computeTotalDuration', () => {
         { startDate: '2020-04-21T09:00:00.000Z', endDate: '2020-04-21T11:00:00.000Z' },
       ];
 
-      const result = UtilsHelper.computeTotalDuration(slots);
+      const result = UtilsHelper.getTotalDuration(slots);
 
       expect(result).toEqual('4h08');
     });
@@ -389,7 +389,7 @@ describe('computeTotalDuration', () => {
         { startDate: '2020-04-21T09:00:00.000Z', endDate: '2020-04-21T11:00:00.000Z' },
       ];
 
-      const result = UtilsHelper.computeTotalDuration(slots);
+      const result = UtilsHelper.getTotalDuration(slots);
 
       expect(result).toEqual('4h');
     });
@@ -399,7 +399,7 @@ describe('computeTotalDuration', () => {
         { startDate: '2020-04-21T07:00:00.000Z', endDate: '2020-04-21T22:00:00.000Z' },
       ];
 
-      const result = UtilsHelper.computeTotalDuration(slots);
+      const result = UtilsHelper.getTotalDuration(slots);
 
       expect(result).toEqual('30h');
     });

--- a/tests/unit/helpers/utils.test.js
+++ b/tests/unit/helpers/utils.test.js
@@ -362,46 +362,44 @@ describe('computeExclTaxesWithDiscount', () => {
 });
 
 describe('getTotalDuration', () => {
-  describe('getTotalDuration', () => {
-    it('should return duration with minutes', () => {
-      const slots = [
-        { startDate: '2020-03-20T09:00:00.000Z', endDate: '2020-03-20T11:00:00.000Z' },
-        { startDate: '2020-04-21T09:00:00.000Z', endDate: '2020-04-21T11:30:00.000Z' },
-      ];
+  it('should return duration with minutes', () => {
+    const slots = [
+      { startDate: '2020-03-20T09:00:00.000Z', endDate: '2020-03-20T11:00:00.000Z' },
+      { startDate: '2020-04-21T09:00:00.000Z', endDate: '2020-04-21T11:30:00.000Z' },
+    ];
 
-      const result = UtilsHelper.getTotalDuration(slots);
+    const result = UtilsHelper.getTotalDuration(slots);
 
-      expect(result).toEqual('4h30');
-    });
-    it('should return duration with leading zero minutes', () => {
-      const slots = [
-        { startDate: '2020-03-20T09:00:00.000Z', endDate: '2020-03-20T11:08:00.000Z' },
-        { startDate: '2020-04-21T09:00:00.000Z', endDate: '2020-04-21T11:00:00.000Z' },
-      ];
+    expect(result).toEqual('4h30');
+  });
+  it('should return duration with leading zero minutes', () => {
+    const slots = [
+      { startDate: '2020-03-20T09:00:00.000Z', endDate: '2020-03-20T11:08:00.000Z' },
+      { startDate: '2020-04-21T09:00:00.000Z', endDate: '2020-04-21T11:00:00.000Z' },
+    ];
 
-      const result = UtilsHelper.getTotalDuration(slots);
+    const result = UtilsHelper.getTotalDuration(slots);
 
-      expect(result).toEqual('4h08');
-    });
-    it('should return duration without minutes', () => {
-      const slots = [
-        { startDate: '2020-03-20T09:00:00.000Z', endDate: '2020-03-20T11:00:00.000Z' },
-        { startDate: '2020-04-21T09:00:00.000Z', endDate: '2020-04-21T11:00:00.000Z' },
-      ];
+    expect(result).toEqual('4h08');
+  });
+  it('should return duration without minutes', () => {
+    const slots = [
+      { startDate: '2020-03-20T09:00:00.000Z', endDate: '2020-03-20T11:00:00.000Z' },
+      { startDate: '2020-04-21T09:00:00.000Z', endDate: '2020-04-21T11:00:00.000Z' },
+    ];
 
-      const result = UtilsHelper.getTotalDuration(slots);
+    const result = UtilsHelper.getTotalDuration(slots);
 
-      expect(result).toEqual('4h');
-    });
-    it('should return duration with days', () => {
-      const slots = [
-        { startDate: '2020-03-20T07:00:00.000Z', endDate: '2020-03-20T22:00:00.000Z' },
-        { startDate: '2020-04-21T07:00:00.000Z', endDate: '2020-04-21T22:00:00.000Z' },
-      ];
+    expect(result).toEqual('4h');
+  });
+  it('should return duration with days', () => {
+    const slots = [
+      { startDate: '2020-03-20T07:00:00.000Z', endDate: '2020-03-20T22:00:00.000Z' },
+      { startDate: '2020-04-21T07:00:00.000Z', endDate: '2020-04-21T22:00:00.000Z' },
+    ];
 
-      const result = UtilsHelper.getTotalDuration(slots);
+    const result = UtilsHelper.getTotalDuration(slots);
 
-      expect(result).toEqual('30h');
-    });
+    expect(result).toEqual('30h');
   });
 });


### PR DESCRIPTION
|  |  | TESTS  :computer: | |
|----------|----------|----------|----------|
| <ul><li>[x] oui </li></ul> | <ul><li>[ ] non</li></ul> | J'ai codé les tests unitaires
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | J'ai codé les tests d'intégration
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | C'est une ancienne route utilisée par les apps mobiles. | <ul><li>[ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens</li></ul>

---

|  |  | POINTS D'ATTENTION POUR CETTE PR  :warning:  | |
|----------|----------|----------|----------|
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | J'ai fait des modifications sur une route utilisée sur plusieurs plateformes | [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/n3bq2hr9Ia)
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | J'ai modifié un modèle utilisé en mobile | [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/rqTfwpUib)
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | J'ai ajouté un modèle spécifique à une structure | <ul><li>[ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés</li></ul>
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile |  <ul><li>[ ] Si oui, j'ai précisé sur le [slite de MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) qu'il faut forcer la mise à jour</li></ul>
| <ul><li>[x] oui </li></ul> | <ul><li>[ ] non</li></ul> | J'ai modifié une variable d'environnement | <ul><li>[x] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites</li></ul>

---

|  |  |  FONCTIONNALITÉS APPS MOBILES  :iphone: | |
|----------|----------|----------|----------|
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | Mes changements impactent l'application formation | <ul><li>[ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours</li></ul>
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | Mes changements impactent l'application erp | <ul><li>[ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours</li></ul>

---

### POUR TESTER LA PR  :white_check_mark:
- Périmetre interface : client / vendeur

- Périmetre roles :   rof / coach

- Cas d'usage : 
   - Je peux telecharger les attestations de fin de formation non plus dans l'onglet "Admin" mais dans "Suivi des stagiaires"
      - Si les infos necessaires ne sont pas remplies (un stagiaire, un créneau, un.e formateur.ice avec tel) le bouton est grisé.
      - Si les objectifs peda du programme ne sont pas remplis, le bouton est grisé et une banniere m'informe
   - Lorsque je genere une attestation, la durée de presence du/de la stagiaire est inscrite automatiquement

- Comment tester: 
   - dans les .env coté API, modifier GOOGLE_DRIVE_TRAINING_CERTIFICATE_TEMPLATE_ID pour pointer vers ce fichier test  https://docs.google.com/document/d/1I5BbWGzyvXoV-G35lU2whVfiLX5lL1AL/edit
   - formation sans formateur.ice => bouton indisponible
   - formation sans objectif peda => bouton indisponible + banniere
   - formation valide avec plusieurs stagiaire et des participations differentes => attestations dispos + verifier les durées totales de presence des different.es stagiaires.

Si tu as lu cette description, pense a réagir avec un :eye:
