### PR TITLE
Com 2634

### DIFF
--- a/tests/unit/helpers/123Paie/absences.test.js
+++ b/tests/unit/helpers/123Paie/absences.test.js
@@ -39,9 +39,9 @@ describe('getAbsences', () => {
     const query = { startDate: '2020-11-01T00:00:00', endDate: '2020-11-30T22:00:00' };
 
     findPay.returns(
-      SinonMongoose.stubChainedQueries([[{ createdAt: '2020-10-29T10:31:00' }]], ['sort', 'limit', 'lean'])
+      SinonMongoose.stubChainedQueries([{ createdAt: '2020-10-29T10:31:00' }], ['sort', 'limit', 'lean'])
     );
-    findEvent.returns(SinonMongoose.stubChainedQueries([absences], ['populate', 'sort', 'lean']));
+    findEvent.returns(SinonMongoose.stubChainedQueries(absences, ['populate', 'sort', 'lean']));
 
     const result = await Absences123PayHelper.getAbsences(query, { company: { _id: companyId } });
 
@@ -88,8 +88,8 @@ describe('getAbsences', () => {
     const absences = [{ _id: new ObjectId() }];
     const query = { startDate: '2020-11-01T00:00:00', endDate: '2020-11-30T22:00:00' };
 
-    findPay.returns(SinonMongoose.stubChainedQueries([[]], ['sort', 'limit', 'lean']));
-    findEvent.returns(SinonMongoose.stubChainedQueries([absences], ['populate', 'sort', 'lean']));
+    findPay.returns(SinonMongoose.stubChainedQueries([], ['sort', 'limit', 'lean']));
+    findEvent.returns(SinonMongoose.stubChainedQueries(absences, ['populate', 'sort', 'lean']));
 
     const result = await Absences123PayHelper.getAbsences(query, { company: { _id: companyId } });
 

--- a/tests/unit/helpers/123Paie/contracts.test.js
+++ b/tests/unit/helpers/123Paie/contracts.test.js
@@ -46,7 +46,7 @@ describe('exportsContractVersions', () => {
     }];
 
     getQuery.returns([{ endDate: null }, { endDate: { $exists: false } }]);
-    findContract.returns(SinonMongoose.stubChainedQueries([versions]));
+    findContract.returns(SinonMongoose.stubChainedQueries(versions));
     exportToTxt.returns('file');
 
     const result = await Contracts123PayHelper.exportContractVersions(query, { company: { _id: companyId } });
@@ -101,7 +101,7 @@ describe('exportContractEnds', () => {
       endReason: SERIOUS_MISCONDUCT_LAYOFF,
     }];
 
-    findContract.returns(SinonMongoose.stubChainedQueries([contracts]));
+    findContract.returns(SinonMongoose.stubChainedQueries(contracts));
     exportToTxt.returns('file');
 
     const result = await Contracts123PayHelper.exportContractEnds(query, { company: { _id: companyId } });

--- a/tests/unit/helpers/123Paie/identification.test.js
+++ b/tests/unit/helpers/123Paie/identification.test.js
@@ -181,7 +181,7 @@ describe('exportDpae', () => {
     };
     const auxiliary = { serialNumber: 'serialNumber' };
 
-    findOneUser.returns(SinonMongoose.stubChainedQueries([auxiliary]));
+    findOneUser.returns(SinonMongoose.stubChainedQueries(auxiliary));
     formatIdentificationInfo.returns({ ap_matr: 'serialNumber' });
     formatBankingInfo.returns({ fs_bq_dom: 'BANK AUDI FRANCE' });
     formatContractInfo.returns({ ap_contrat: '1234567890' });
@@ -233,7 +233,7 @@ describe('exportIdentification', () => {
     const endDate = moment('2020-01-11T14:00:00').toDate();
     const companyId = new ObjectId();
 
-    findContract.returns(SinonMongoose.stubChainedQueries([[{ user: 'first user' }, { user: 'second user' }]]));
+    findContract.returns(SinonMongoose.stubChainedQueries([{ user: 'first user' }, { user: 'second user' }]));
     formatIdentificationInfo.onFirstCall().returns({ identity: 1 }).onSecondCall().returns({ identity: 2 });
     formatBankingInfo.onFirstCall().returns({ bank: 1 }).onSecondCall().returns({ bank: 2 });
     exportToTxt.returns('file');

--- a/tests/unit/helpers/123Paie/pay.test.js
+++ b/tests/unit/helpers/123Paie/pay.test.js
@@ -83,7 +83,7 @@ describe('exportPay', () => {
       },
     ];
 
-    findPay.returns(SinonMongoose.stubChainedQueries([payList]));
+    findPay.returns(SinonMongoose.stubChainedQueries(payList));
     exportToTxt.returns('file');
 
     const result = await Pay123PayHelper.exportPay(query, { company: { _id: companyId } });
@@ -186,7 +186,7 @@ describe('exportPay', () => {
       },
     ];
 
-    findPay.returns(SinonMongoose.stubChainedQueries([payList]));
+    findPay.returns(SinonMongoose.stubChainedQueries(payList));
     exportToTxt.returns('file');
 
     const result = await Pay123PayHelper.exportPay(query, { company: { _id: companyId } });

--- a/tests/unit/helpers/activities.test.js
+++ b/tests/unit/helpers/activities.test.js
@@ -19,7 +19,7 @@ describe('getActivity', () => {
   });
 
   it('should return the requested activity', async () => {
-    findOne.returns(SinonMongoose.stubChainedQueries([{ _id: 'skusku' }]));
+    findOne.returns(SinonMongoose.stubChainedQueries({ _id: 'skusku' }));
 
     const activity = { _id: new ObjectId() };
 
@@ -192,7 +192,7 @@ describe('removeCard', () => {
   it('should remove card without media from activity', async () => {
     const cardId = new ObjectId();
 
-    findOneAndRemoveCard.returns(SinonMongoose.stubChainedQueries([null], ['lean']));
+    findOneAndRemoveCard.returns(SinonMongoose.stubChainedQueries(null, ['lean']));
 
     await ActivityHelper.removeCard(cardId, null);
 
@@ -211,7 +211,7 @@ describe('removeCard', () => {
     const cardId = new ObjectId();
     const card = { _id: cardId, media: { publicId: 'publicId' } };
 
-    findOneAndRemoveCard.returns(SinonMongoose.stubChainedQueries([card], ['lean']));
+    findOneAndRemoveCard.returns(SinonMongoose.stubChainedQueries(card, ['lean']));
 
     await ActivityHelper.removeCard(cardId, 'media-test-20210505104400');
 

--- a/tests/unit/helpers/activityHistories.test.js
+++ b/tests/unit/helpers/activityHistories.test.js
@@ -88,9 +88,9 @@ describe('list', () => {
     };
 
     findUserCompanies.returns(
-      SinonMongoose.stubChainedQueries([[{ user: firstUserId }, { user: secondUserId }]], ['lean'])
+      SinonMongoose.stubChainedQueries([{ user: firstUserId }, { user: secondUserId }], ['lean'])
     );
-    findHistories.returns(SinonMongoose.stubChainedQueries([activityHistories]));
+    findHistories.returns(SinonMongoose.stubChainedQueries(activityHistories));
 
     const result = await ActivityHistoryHelper.list(query, { company: { _id: companyId } });
 

--- a/tests/unit/helpers/administrativeDocument.test.js
+++ b/tests/unit/helpers/administrativeDocument.test.js
@@ -36,7 +36,7 @@ describe('createAdministrativeDocument', () => {
     const uploadedFile = { id: '12345', webViewLink: 'www.12345.fr' };
     addFileStub.returns(uploadedFile);
 
-    findByIdCompany.returns(SinonMongoose.stubChainedQueries([{ folderId: '1234' }], ['lean']));
+    findByIdCompany.returns(SinonMongoose.stubChainedQueries({ folderId: '1234' }, ['lean']));
 
     await AdministrativeDocumentHelper.createAdministrativeDocument(payload, credentials);
 
@@ -58,7 +58,7 @@ describe('createAdministrativeDocument', () => {
   it('should return an error if uploaded file is not defined', async () => {
     try {
       addFileStub.returns();
-      findByIdCompany.returns(SinonMongoose.stubChainedQueries([{ folderId: '1234' }], ['lean']));
+      findByIdCompany.returns(SinonMongoose.stubChainedQueries({ folderId: '1234' }, ['lean']));
 
       await AdministrativeDocumentHelper.createAdministrativeDocument(payload, credentials);
     } catch (e) {
@@ -94,7 +94,7 @@ describe('listAdministrativeDocuments', () => {
   it('should create an administrative document', async () => {
     const administrativeDocuments = [{ _id: new ObjectId() }];
 
-    findAdministrativeDocument.returns(SinonMongoose.stubChainedQueries([administrativeDocuments], ['lean']));
+    findAdministrativeDocument.returns(SinonMongoose.stubChainedQueries(administrativeDocuments, ['lean']));
 
     const res = await AdministrativeDocumentHelper.listAdministrativeDocuments(credentials);
 
@@ -123,7 +123,7 @@ describe('removeAdministrativeDocument', () => {
 
   it('should remove a document from bdd + drive', async () => {
     deleteFileStub.returns();
-    findOneAndDelete.returns(SinonMongoose.stubChainedQueries([{ driveFile: { driveId: '1234' } }], ['lean']));
+    findOneAndDelete.returns(SinonMongoose.stubChainedQueries({ driveFile: { driveId: '1234' } }, ['lean']));
 
     await AdministrativeDocumentHelper.removeAdministrativeDocument(administrativeDocumentId);
 

--- a/tests/unit/helpers/attendanceSheets.test.js
+++ b/tests/unit/helpers/attendanceSheets.test.js
@@ -25,7 +25,7 @@ describe('list', () => {
       date: '2020-04-03T10:00:00',
     }];
 
-    find.returns(SinonMongoose.stubChainedQueries([attendanceSheets]));
+    find.returns(SinonMongoose.stubChainedQueries(attendanceSheets));
 
     const result = await attendanceSheetHelper.list(courseId, null);
 
@@ -57,7 +57,7 @@ describe('list', () => {
       },
     ];
 
-    find.returns(SinonMongoose.stubChainedQueries([attendanceSheets]));
+    find.returns(SinonMongoose.stubChainedQueries(attendanceSheets));
 
     const result = await attendanceSheetHelper.list(courseId, authCompanyId);
 
@@ -115,7 +115,7 @@ describe('create', () => {
     const payload = { trainee: 'id de quelqun', course: new ObjectId(), file: 'test.pdf' };
     const returnedUser = { identity: { firstName: 'monsieur', lastname: 'patate' } };
     uploadCourseFile.returns({ publicId: 'yo', link: 'yo' });
-    findOne.returns(SinonMongoose.stubChainedQueries([returnedUser], ['lean']));
+    findOne.returns(SinonMongoose.stubChainedQueries(returnedUser, ['lean']));
     formatIdentity.returns('monsieurPATATE');
 
     await attendanceSheetHelper.create(payload);

--- a/tests/unit/helpers/attendances.test.js
+++ b/tests/unit/helpers/attendances.test.js
@@ -41,7 +41,7 @@ describe('list', () => {
       { trainee: { _id: new ObjectId(), company: new ObjectId() }, courseSlot: courseSlots[1] },
     ];
 
-    find.returns(SinonMongoose.stubChainedQueries([attendancesList]));
+    find.returns(SinonMongoose.stubChainedQueries(attendancesList));
 
     const result = await AttendanceHelper.list([courseSlots], null);
 
@@ -65,7 +65,7 @@ describe('list', () => {
       { trainee: { _id: new ObjectId(), company: otherCompanyId }, courseSlot: courseSlots[1] },
     ];
 
-    find.returns(SinonMongoose.stubChainedQueries([attendancesList]));
+    find.returns(SinonMongoose.stubChainedQueries(attendancesList));
 
     const result = await AttendanceHelper.list([courseSlots], companyId);
 
@@ -148,8 +148,8 @@ describe('listUnsubscribed', () => {
       },
     ];
 
-    courseFindOne.returns(SinonMongoose.stubChainedQueries([course]));
-    courseFind.returns(SinonMongoose.stubChainedQueries([courseWithSameSubProgramList]));
+    courseFindOne.returns(SinonMongoose.stubChainedQueries(course));
+    courseFind.returns(SinonMongoose.stubChainedQueries(courseWithSameSubProgramList));
 
     const result = await AttendanceHelper.listUnsubscribed(courseId, companyId);
 
@@ -259,8 +259,8 @@ describe('listUnsubscribed', () => {
       },
     ];
 
-    courseFindOne.returns(SinonMongoose.stubChainedQueries([course]));
-    courseFind.returns(SinonMongoose.stubChainedQueries([courseWithSameSubProgramList]));
+    courseFindOne.returns(SinonMongoose.stubChainedQueries(course));
+    courseFind.returns(SinonMongoose.stubChainedQueries(courseWithSameSubProgramList));
 
     const result = await AttendanceHelper.listUnsubscribed(courseId);
 

--- a/tests/unit/helpers/authentication.test.js
+++ b/tests/unit/helpers/authentication.test.js
@@ -49,7 +49,7 @@ describe('authenticate', () => {
       local: { password: 'toto' },
     };
     momentToDate.onCall(0).returns('2020-12-08T13:45:25.437Z');
-    findOne.returns(SinonMongoose.stubChainedQueries([user], ['select', 'lean']));
+    findOne.returns(SinonMongoose.stubChainedQueries(user, ['select', 'lean']));
     compare.returns(true);
     encode.returns('token');
 
@@ -83,7 +83,7 @@ describe('authenticate', () => {
     const payload = { email: 'toto@email.com', password: 'toto', origin: 'webapp' };
     const user = { _id: new ObjectId(), refreshToken: 'refreshToken', local: { password: 'toto' } };
 
-    findOne.returns(SinonMongoose.stubChainedQueries([user], ['select', 'lean']));
+    findOne.returns(SinonMongoose.stubChainedQueries(user, ['select', 'lean']));
     compare.returns(true);
     encode.returns('token');
 
@@ -119,7 +119,7 @@ describe('authenticate', () => {
       firstMobileConnection: '2020-12-08T13:45:25.437Z',
     };
 
-    findOne.returns(SinonMongoose.stubChainedQueries([user], ['select', 'lean']));
+    findOne.returns(SinonMongoose.stubChainedQueries(user, ['select', 'lean']));
     compare.returns(true);
     encode.returns('token');
 
@@ -150,7 +150,7 @@ describe('authenticate', () => {
     const payload = { email: 'toto@email.com', password: '123456!eR' };
 
     try {
-      findOne.returns(SinonMongoose.stubChainedQueries([], ['select', 'lean']));
+      findOne.returns(SinonMongoose.stubChainedQueries(null, ['select', 'lean']));
 
       await AuthenticationHelper.authenticate(payload);
     } catch (e) {
@@ -175,7 +175,7 @@ describe('authenticate', () => {
   it('should throw an error if refresh token does not exist', async () => {
     const payload = { email: 'toto@email.com', password: '123456!eR' };
     try {
-      findOne.returns(SinonMongoose.stubChainedQueries([{ _id: new ObjectId() }], ['select', 'lean']));
+      findOne.returns(SinonMongoose.stubChainedQueries({ _id: new ObjectId() }, ['select', 'lean']));
 
       await AuthenticationHelper.authenticate(payload);
     } catch (e) {
@@ -202,7 +202,7 @@ describe('authenticate', () => {
       const payload = { email: 'toto@email.com', password: '123456!eR' };
 
       findOne.returns(SinonMongoose.stubChainedQueries(
-        [{ _id: new ObjectId(), refreshToken: 'refreshToken', local: { password: 'password_hash' } }],
+        { _id: new ObjectId(), refreshToken: 'refreshToken', local: { password: 'password_hash' } },
         ['select', 'lean']
       ));
       compare.returns(false);
@@ -245,7 +245,7 @@ describe('refreshToken', () => {
 
   it('should throw an error if user does not exist', async () => {
     try {
-      findOne.returns(SinonMongoose.stubChainedQueries([], ['lean']));
+      findOne.returns(SinonMongoose.stubChainedQueries(null, ['lean']));
 
       await AuthenticationHelper.refreshToken('refreshToken');
     } catch (e) {
@@ -263,7 +263,7 @@ describe('refreshToken', () => {
   it('should return refresh token', async () => {
     const user = { _id: new ObjectId(), refreshToken: 'refreshToken', local: { password: 'toto' } };
 
-    findOne.returns(SinonMongoose.stubChainedQueries([user], ['lean']));
+    findOne.returns(SinonMongoose.stubChainedQueries(user, ['lean']));
     encode.returns('token');
 
     const result = await AuthenticationHelper.refreshToken('refreshToken');
@@ -297,7 +297,7 @@ describe('updatePassword', () => {
     const payload = { local: { password: '123456!eR' } };
 
     findOneAndUpdate.returns(SinonMongoose.stubChainedQueries(
-      [{ _id: userId, local: { password: '123456!eR' } }],
+      { _id: userId, local: { password: '123456!eR' } },
       ['lean']
     ));
 
@@ -367,7 +367,7 @@ describe('checkPasswordToken', () => {
     const filter = { passwordToken: { token: '1234567890', expiresIn: { $gt: date } } };
 
     try {
-      userFindOne.returns(SinonMongoose.stubChainedQueries([], ['select', 'lean']));
+      userFindOne.returns(SinonMongoose.stubChainedQueries(null, ['select', 'lean']));
 
       await AuthenticationHelper.checkPasswordToken('1234567890');
     } catch (e) {
@@ -391,10 +391,10 @@ describe('checkPasswordToken', () => {
     const user = { _id: new ObjectId(), local: { email } };
     const userPayload = { _id: user._id, email };
 
-    userFindOne.returns(SinonMongoose.stubChainedQueries([user], ['select', 'lean']));
-    identityVerificationFindOne.returns(SinonMongoose.stubChainedQueries([
+    userFindOne.returns(SinonMongoose.stubChainedQueries(user, ['select', 'lean']));
+    identityVerificationFindOne.returns(SinonMongoose.stubChainedQueries(
       { code: '3310', email, updatedAt: new Date('2021-01-25T10:05:32.582Z') },
-    ], ['lean']));
+      ['lean']));
     fakeDate.returns(new Date('2021-01-25T10:08:32.582Z'));
     sendToken.returns({ token: '1234567890', user: userPayload });
 
@@ -421,7 +421,7 @@ describe('checkPasswordToken', () => {
     const token = '3311';
 
     try {
-      identityVerificationFindOne.returns(SinonMongoose.stubChainedQueries([], ['lean']));
+      identityVerificationFindOne.returns(SinonMongoose.stubChainedQueries(null, ['lean']));
 
       await AuthenticationHelper.checkPasswordToken(token, email);
     } catch (e) {
@@ -440,9 +440,9 @@ describe('checkPasswordToken', () => {
     fakeDate.returns(new Date('2021-01-25T10:08:32.582Z'));
     const email = 'carolyn@alenvi.io';
     const token = '3310';
-    identityVerificationFindOne.returns(SinonMongoose.stubChainedQueries([
+    identityVerificationFindOne.returns(SinonMongoose.stubChainedQueries(
       { code: '3310', email, updatedAt: new Date('2021-01-25T09:05:32.582Z') },
-    ], ['lean']));
+      ['lean']));
     try {
       await AuthenticationHelper.checkPasswordToken(token, email);
     } catch (e) {
@@ -463,7 +463,7 @@ describe('checkPasswordToken', () => {
     const user = { _id: new ObjectId(), local: { email: 'toto@toto.com' } };
     const userPayload = { _id: user._id, email: user.local.email };
 
-    userFindOne.returns(SinonMongoose.stubChainedQueries([user], ['select', 'lean']));
+    userFindOne.returns(SinonMongoose.stubChainedQueries(user, ['select', 'lean']));
     sendToken.returns({ token: '1234567890', user: userPayload });
 
     const result = await AuthenticationHelper.checkPasswordToken('1234567890');
@@ -554,7 +554,7 @@ describe('forgotPassword', () => {
   it('should create and send a verification code if origin mobile and type email', async () => {
     const email = 'toto@toto.com';
     codeVerification.returns(0.1111);
-    identityVerificationFindOneAndUpdate.returns(SinonMongoose.stubChainedQueries([null], ['lean']));
+    identityVerificationFindOneAndUpdate.returns(SinonMongoose.stubChainedQueries(null, ['lean']));
     identityVerificationCreate.returns({ email, code: '1999' });
     sendVerificationCodeEmail.returns({ sent: true });
 
@@ -575,7 +575,7 @@ describe('forgotPassword', () => {
   it('should update and send new verification code if already exists one', async () => {
     const email = 'toto@toto.com';
     codeVerification.returns(0.1111);
-    identityVerificationFindOneAndUpdate.returns(SinonMongoose.stubChainedQueries([{ email, code: '1999' }], ['lean']));
+    identityVerificationFindOneAndUpdate.returns(SinonMongoose.stubChainedQueries({ email, code: '1999' }, ['lean']));
     identityVerificationCreate.returns(null);
     sendVerificationCodeEmail.returns({ sent: true });
 
@@ -598,9 +598,9 @@ describe('forgotPassword', () => {
     const email = 'toto@toto.com';
     const user = { local: { email: 'toto@toto.com' }, contact: { phone: '0687654321' } };
     codeVerification.returns(0.1111);
-    identityVerificationFindOneAndUpdate.returns(SinonMongoose.stubChainedQueries([{ email, code: '1999' }], ['lean']));
+    identityVerificationFindOneAndUpdate.returns(SinonMongoose.stubChainedQueries({ email, code: '1999' }, ['lean']));
     identityVerificationCreate.returns(null);
-    userFindOne.returns(SinonMongoose.stubChainedQueries([user], ['lean']));
+    userFindOne.returns(SinonMongoose.stubChainedQueries(user, ['lean']));
     sendVerificationCodeSms.returns({ phone: '0687654321' });
 
     const result = await AuthenticationHelper.forgotPassword({ email, origin: MOBILE, type: PHONE });
@@ -627,9 +627,9 @@ describe('forgotPassword', () => {
       const user = { local: { email: 'toto@toto.com' } };
       codeVerification.returns(0.1111);
       identityVerificationFindOneAndUpdate
-        .returns(SinonMongoose.stubChainedQueries([{ email, code: '1999' }], ['lean']));
+        .returns(SinonMongoose.stubChainedQueries({ email, code: '1999' }, ['lean']));
       identityVerificationCreate.returns(null);
-      userFindOne.returns(SinonMongoose.stubChainedQueries([user], ['lean']));
+      userFindOne.returns(SinonMongoose.stubChainedQueries(user, ['lean']));
       sendVerificationCodeSms.returns({ phone: '06P87654321' });
 
       await AuthenticationHelper.forgotPassword({ email, origin: MOBILE, type: PHONE });
@@ -664,7 +664,7 @@ describe('generatePasswordToken', () => {
 
   it('should throw an error if user does not exist', async () => {
     try {
-      findOneAndUpdate.returns(SinonMongoose.stubChainedQueries([], ['lean']));
+      findOneAndUpdate.returns(SinonMongoose.stubChainedQueries(null, ['lean']));
 
       await AuthenticationHelper.generatePasswordToken('toto@toto.com', 3600000);
     } catch (e) {
@@ -694,7 +694,7 @@ describe('generatePasswordToken', () => {
       passwordToken: { token: sinon.match.string, expiresIn: date.getTime() + 3600000 },
     };
 
-    findOneAndUpdate.returns(SinonMongoose.stubChainedQueries([user], ['lean']));
+    findOneAndUpdate.returns(SinonMongoose.stubChainedQueries(user, ['lean']));
 
     const result = await AuthenticationHelper.generatePasswordToken('toto@toto.com', 3600000);
 

--- a/tests/unit/helpers/authorization.test.js
+++ b/tests/unit/helpers/authorization.test.js
@@ -24,7 +24,7 @@ describe('validate', () => {
     const userId = new ObjectId();
     const user = { _id: userId, identity: { lastname: 'lastname' }, local: { email: 'email@email.com' } };
 
-    findById.returns(SinonMongoose.stubChainedQueries([user], ['populate', 'lean']));
+    findById.returns(SinonMongoose.stubChainedQueries(user, ['populate', 'lean']));
 
     const result = await AuthorizationHelper.validate({ _id: userId });
 
@@ -67,7 +67,7 @@ describe('validate', () => {
       sector: sectorId,
     };
 
-    findById.returns(SinonMongoose.stubChainedQueries([user], ['populate', 'lean']));
+    findById.returns(SinonMongoose.stubChainedQueries(user, ['populate', 'lean']));
 
     const result = await AuthorizationHelper.validate({ _id: userId });
 
@@ -134,7 +134,7 @@ describe('validate', () => {
       sector: sectorId,
     };
 
-    findById.returns(SinonMongoose.stubChainedQueries([user], ['populate', 'lean']));
+    findById.returns(SinonMongoose.stubChainedQueries(user, ['populate', 'lean']));
 
     const result = await AuthorizationHelper.validate({ _id: userId });
 
@@ -218,7 +218,7 @@ describe('validate', () => {
       sector: sectorId,
     };
 
-    findById.returns(SinonMongoose.stubChainedQueries([user], ['populate', 'lean']));
+    findById.returns(SinonMongoose.stubChainedQueries(user, ['populate', 'lean']));
 
     const result = await AuthorizationHelper.validate({ _id: userId });
 
@@ -258,7 +258,7 @@ describe('validate', () => {
       sector: sectorId,
     };
 
-    findById.returns(SinonMongoose.stubChainedQueries([user], ['populate', 'lean']));
+    findById.returns(SinonMongoose.stubChainedQueries(user, ['populate', 'lean']));
 
     const result = await AuthorizationHelper.validate({ _id: userId });
 
@@ -298,7 +298,7 @@ describe('validate', () => {
       sector: sectorId,
     };
 
-    findById.returns(SinonMongoose.stubChainedQueries([user], ['populate', 'lean']));
+    findById.returns(SinonMongoose.stubChainedQueries(user, ['populate', 'lean']));
 
     const result = await AuthorizationHelper.validate({ _id: userId });
 

--- a/tests/unit/helpers/balances.test.js
+++ b/tests/unit/helpers/balances.test.js
@@ -690,12 +690,12 @@ describe('getBalances', () => {
       { _id: { customer: nonArchivedCustomers[1], tpp: tpps[1] }, payments: [{ netInclTaxes: 145 }] },
     ];
 
-    findCustomers.returns(SinonMongoose.stubChainedQueries([nonArchivedCustomers], ['lean']));
+    findCustomers.returns(SinonMongoose.stubChainedQueries(nonArchivedCustomers, ['lean']));
     findBillsAmountsGroupedByClient.returns(billsAmountsGroupedByClient);
     findCNAmountsGroupedByCustomer.returns(cnAmountsGroupedByCustomer);
     findCNAmountsGroupedByTpp.returns(cnAmountsGroupedByTpp);
     findPaymentsAmountsGroupedByClient.returns(paymentsAmountsGroupedByClient);
-    findThirdPartyPayer.returns(SinonMongoose.stubChainedQueries([tpps], ['lean']));
+    findThirdPartyPayer.returns(SinonMongoose.stubChainedQueries(tpps, ['lean']));
 
     const balances = await BalanceHelper.getBalances(credentials, null, maxDate);
 
@@ -789,7 +789,7 @@ describe('getBalances', () => {
     findCNAmountsGroupedByCustomer.returns(cnAmountsGroupedByCustomer);
     findCNAmountsGroupedByTpp.returns(cnAmountsGroupedByTpp);
     findPaymentsAmountsGroupedByClient.returns(paymentsAmountsGroupedByClient);
-    findThirdPartyPayer.returns(SinonMongoose.stubChainedQueries([tpps], ['lean']));
+    findThirdPartyPayer.returns(SinonMongoose.stubChainedQueries(tpps, ['lean']));
 
     const balances = await BalanceHelper.getBalances(credentials, customerId, maxDate);
 
@@ -833,12 +833,12 @@ describe('getBalances', () => {
       { _id: { customer: nonArchivedCustomers[0], tpp: tpps[0] }, billed: 450 },
     ];
 
-    findCustomers.returns(SinonMongoose.stubChainedQueries([nonArchivedCustomers], ['lean']));
+    findCustomers.returns(SinonMongoose.stubChainedQueries(nonArchivedCustomers, ['lean']));
     findBillsAmountsGroupedByClient.returns(billsAmountsGroupedByClient);
     findCNAmountsGroupedByCustomer.returns([]);
     findCNAmountsGroupedByTpp.returns([]);
     findPaymentsAmountsGroupedByClient.returns([]);
-    findThirdPartyPayer.returns(SinonMongoose.stubChainedQueries([tpps], ['lean']));
+    findThirdPartyPayer.returns(SinonMongoose.stubChainedQueries(tpps, ['lean']));
 
     const balances = await BalanceHelper.getBalances(credentials, null, maxDate);
 
@@ -858,12 +858,12 @@ describe('getBalances', () => {
       { _id: { customer: nonArchivedCustomers[1] }, refund: 40 },
     ];
 
-    findCustomers.returns(SinonMongoose.stubChainedQueries([nonArchivedCustomers], ['lean']));
+    findCustomers.returns(SinonMongoose.stubChainedQueries(nonArchivedCustomers, ['lean']));
     findBillsAmountsGroupedByClient.returns([]);
     findCNAmountsGroupedByCustomer.returns(cnAmountsGroupedByCustomer);
     findCNAmountsGroupedByTpp.returns([]);
     findPaymentsAmountsGroupedByClient.returns([]);
-    findThirdPartyPayer.returns(SinonMongoose.stubChainedQueries([tpps], ['lean']));
+    findThirdPartyPayer.returns(SinonMongoose.stubChainedQueries(tpps, ['lean']));
 
     const balances = await BalanceHelper.getBalances(credentials, null, maxDate);
 
@@ -883,12 +883,12 @@ describe('getBalances', () => {
       { _id: { customer: nonArchivedCustomers[1], tpp: tpps[1], refund: 50 } },
     ];
 
-    findCustomers.returns(SinonMongoose.stubChainedQueries([nonArchivedCustomers], ['lean']));
+    findCustomers.returns(SinonMongoose.stubChainedQueries(nonArchivedCustomers, ['lean']));
     findBillsAmountsGroupedByClient.returns([]);
     findCNAmountsGroupedByCustomer.returns([]);
     findCNAmountsGroupedByTpp.returns(cnAmountsGroupedByTpp);
     findPaymentsAmountsGroupedByClient.returns([]);
-    findThirdPartyPayer.returns(SinonMongoose.stubChainedQueries([tpps], ['lean']));
+    findThirdPartyPayer.returns(SinonMongoose.stubChainedQueries(tpps, ['lean']));
 
     const balances = await BalanceHelper.getBalances(credentials, null, maxDate);
 
@@ -909,12 +909,12 @@ describe('getBalances', () => {
       { _id: { customer: nonArchivedCustomers[1], tpp: tpps[1] }, payments: [{ netInclTaxes: 145 }] },
     ];
 
-    findCustomers.returns(SinonMongoose.stubChainedQueries([nonArchivedCustomers], ['lean']));
+    findCustomers.returns(SinonMongoose.stubChainedQueries(nonArchivedCustomers, ['lean']));
     findBillsAmountsGroupedByClient.returns([]);
     findCNAmountsGroupedByCustomer.returns([]);
     findCNAmountsGroupedByTpp.returns([]);
     findPaymentsAmountsGroupedByClient.returns(paymentsAmountsGroupedByClient);
-    findThirdPartyPayer.returns(SinonMongoose.stubChainedQueries([tpps], ['lean']));
+    findThirdPartyPayer.returns(SinonMongoose.stubChainedQueries(tpps, ['lean']));
 
     const balances = await BalanceHelper.getBalances(credentials, null, maxDate);
 
@@ -937,7 +937,7 @@ describe('getBalances', () => {
     findCNAmountsGroupedByCustomer.returns([]);
     findCNAmountsGroupedByTpp.returns([]);
     findPaymentsAmountsGroupedByClient.returns([]);
-    findThirdPartyPayer.returns(SinonMongoose.stubChainedQueries([[]], ['lean']));
+    findThirdPartyPayer.returns(SinonMongoose.stubChainedQueries([], ['lean']));
 
     const balances = await BalanceHelper.getBalances(credentials, customerId, maxDate);
 

--- a/tests/unit/helpers/billSlips.test.js
+++ b/tests/unit/helpers/billSlips.test.js
@@ -101,7 +101,7 @@ describe('getBillSlipNumber', () => {
     const endDate = '2019-09-12T06:00:00';
     const company = { _id: new ObjectId() };
 
-    findOneAndUpdate.returns(SinonMongoose.stubChainedQueries(['1234567890'], ['lean']));
+    findOneAndUpdate.returns(SinonMongoose.stubChainedQueries('1234567890', ['lean']));
 
     const result = await BillSlipHelper.getBillSlipNumber(endDate, company._id);
 
@@ -148,7 +148,7 @@ describe('createBillSlips', () => {
     const company = { _id: new ObjectId() };
 
     findBillSlip.returns(SinonMongoose.stubChainedQueries(
-      [[{ _id: new ObjectId() }, { _id: new ObjectId() }]],
+      [{ _id: new ObjectId() }, { _id: new ObjectId() }],
       ['lean']
     ));
 
@@ -182,7 +182,7 @@ describe('createBillSlips', () => {
     const company = { _id: new ObjectId(), prefixNumber: 129 };
     const endDate = '2019-09-12T00:00:00';
 
-    findBillSlip.returns(SinonMongoose.stubChainedQueries([[]], ['lean']));
+    findBillSlip.returns(SinonMongoose.stubChainedQueries([], ['lean']));
     getBillSlipNumber.returns({ seq: 12, prefix: 'ASD' });
     formatBillSlipNumber.onCall(0).returns('BORD-129ASD00012');
     formatBillSlipNumber.onCall(1).returns('BORD-129ASD00013');
@@ -227,7 +227,7 @@ describe('createBillSlips', () => {
     const company = { _id: new ObjectId(), prefixNumber: 129 };
     const endDate = '2019-09-12T00:00:00';
 
-    findBillSlip.returns(SinonMongoose.stubChainedQueries([[]], ['lean']));
+    findBillSlip.returns(SinonMongoose.stubChainedQueries([], ['lean']));
     getBillSlipNumber.returns({ seq: 12, prefix: 'ASD' });
     formatBillSlipNumber.onCall(0).returns('BORD-129ASD00012');
     formatBillSlipNumber.onCall(1).returns('BORD-129ASD00013');
@@ -560,7 +560,7 @@ describe('generateFile', () => {
   });
 
   it('should return generated pdf and bill slip number', async () => {
-    findByIdBillSlip.returns(SinonMongoose.stubChainedQueries([billSlip]));
+    findByIdBillSlip.returns(SinonMongoose.stubChainedQueries(billSlip));
     getBillsFromBillSlip.returns(billList);
     getCreditNoteFromBillSlip.returns(creditNoteList);
     createDocxStub.returns(docx);

--- a/tests/unit/helpers/bills.test.js
+++ b/tests/unit/helpers/bills.test.js
@@ -1257,7 +1257,7 @@ describe('getBillNumber', () => {
     const prefix = '1119';
     const billNumber = { prefix, seq: 1 };
 
-    findOneAndUpdateBillNumber.returns(SinonMongoose.stubChainedQueries([billNumber], ['lean']));
+    findOneAndUpdateBillNumber.returns(SinonMongoose.stubChainedQueries(billNumber, ['lean']));
 
     const result = await BillHelper.getBillNumber(new Date('2019-11-15'), companyId);
     expect(result).toEqual(billNumber);
@@ -1848,7 +1848,7 @@ describe('list', () => {
       { _id: new ObjectId(), type: 'manual', billingItemList: [] },
     ];
 
-    findBill.returns(SinonMongoose.stubChainedQueries([bills]));
+    findBill.returns(SinonMongoose.stubChainedQueries(bills));
 
     await BillHelper.list(query, credentials);
 
@@ -1929,7 +1929,7 @@ describe('formatAndCreateBill', () => {
     getBillNumber.returns({ prefix: 'FACT-101', seq: 1 });
     formatBillNumber.returns('FACT-101092100001');
     findBillingItem.returns(
-      SinonMongoose.stubChainedQueries([[{ _id: billingItemId1, vat: 10 }, { _id: billingItemId2, vat: 25 }]], ['lean'])
+      SinonMongoose.stubChainedQueries([{ _id: billingItemId1, vat: 10 }, { _id: billingItemId2, vat: 25 }], ['lean'])
     );
     formatBillingItem.onCall(0).returns({ inclTaxes: 180 });
     formatBillingItem.onCall(1).returns({ inclTaxes: 150 });
@@ -1992,7 +1992,7 @@ describe('getBills', () => {
   });
 
   it('should return bills', async () => {
-    findBill.returns(SinonMongoose.stubChainedQueries([bills]));
+    findBill.returns(SinonMongoose.stubChainedQueries(bills));
 
     const result = await BillHelper.getBills({}, credentials);
 
@@ -2010,7 +2010,7 @@ describe('getBills', () => {
     const dateQuery = { $lte: query.startDate };
 
     getDateQueryStub.returns(dateQuery);
-    findBill.returns(SinonMongoose.stubChainedQueries([bills]));
+    findBill.returns(SinonMongoose.stubChainedQueries(bills));
 
     const result = await BillHelper.getBills(query, credentials);
 
@@ -2028,7 +2028,7 @@ describe('getBills', () => {
     const dateQuery = { $gte: query.endDate };
 
     getDateQueryStub.returns(dateQuery);
-    findBill.returns(SinonMongoose.stubChainedQueries([bills]));
+    findBill.returns(SinonMongoose.stubChainedQueries(bills));
 
     const result = await BillHelper.getBills(query, credentials);
 
@@ -2541,8 +2541,8 @@ describe('generateBillPdf', async () => {
     const companyId = new ObjectId();
     const credentials = { company: { _id: companyId } };
     const bill = { _id: new ObjectId(), number: 'number' };
-    findOneBill.returns(SinonMongoose.stubChainedQueries([bill]));
-    findOneCompany.returns(SinonMongoose.stubChainedQueries([credentials.company], ['lean']));
+    findOneBill.returns(SinonMongoose.stubChainedQueries(bill));
+    findOneCompany.returns(SinonMongoose.stubChainedQueries(credentials.company, ['lean']));
     formatPdf.returns({ data: 'data' });
     generatePdf.returns({ pdf: 'pdf' });
     getPdfContent.returns({ content: [{ text: 'data' }] });

--- a/tests/unit/helpers/categories.test.js
+++ b/tests/unit/helpers/categories.test.js
@@ -34,7 +34,7 @@ describe('list', () => {
   it('should return categories', async () => {
     const categoriesList = [{ name: 'ma première catégorie' }, { name: 'ma seconde catégorie' }];
 
-    list.returns(SinonMongoose.stubChainedQueries([categoriesList]));
+    list.returns(SinonMongoose.stubChainedQueries(categoriesList));
 
     const result = await CategoryHelper.list();
 

--- a/tests/unit/helpers/companies.test.js
+++ b/tests/unit/helpers/companies.test.js
@@ -42,7 +42,7 @@ describe('createCompany', () => {
     createFolderStub.onCall(1).returns({ id: 'qwertyuiop' });
     createFolderStub.onCall(2).returns({ id: 'asdfghj' });
     find.returns(SinonMongoose.stubChainedQueries(
-      [[{ _id: new ObjectId(), prefixNumber: 345 }]],
+      [{ _id: new ObjectId(), prefixNumber: 345 }],
       ['sort', 'limit', 'lean']
     ));
 
@@ -76,7 +76,7 @@ describe('list', () => {
 
   it('should return companies', async () => {
     const companyList = [{ _id: new ObjectId(), name: 'Alenvi' }];
-    find.returns(SinonMongoose.stubChainedQueries([companyList], ['lean']));
+    find.returns(SinonMongoose.stubChainedQueries(companyList, ['lean']));
 
     const result = await CompanyHelper.list();
 
@@ -99,7 +99,7 @@ describe('getCompany', () => {
 
   it('should return company', async () => {
     const company = { _id: new ObjectId() };
-    findOne.returns(SinonMongoose.stubChainedQueries([company], ['lean']));
+    findOne.returns(SinonMongoose.stubChainedQueries(company, ['lean']));
 
     const result = await CompanyHelper.getCompany(company._id);
 
@@ -140,7 +140,7 @@ describe('uploadFile', () => {
         },
       },
     };
-    findOneAndUpdate.returns(SinonMongoose.stubChainedQueries([], ['lean']));
+    findOneAndUpdate.returns(SinonMongoose.stubChainedQueries(null, ['lean']));
 
     await CompanyHelper.uploadFile(payload, params);
     sinon.assert.calledWithExactly(addStub, {
@@ -172,7 +172,7 @@ describe('getFirstIntervention', () => {
 
   it('should get first intervention', async () => {
     const credentials = { company: { _id: new ObjectId() } };
-    find.returns(SinonMongoose.stubChainedQueries([[{ startDate: '2019-11-12' }]], ['sort', 'limit', 'lean']));
+    find.returns(SinonMongoose.stubChainedQueries([{ startDate: '2019-11-12' }], ['sort', 'limit', 'lean']));
 
     const result = await CompanyHelper.getFirstIntervention(credentials);
 

--- a/tests/unit/helpers/companyLinkRequests.test.js
+++ b/tests/unit/helpers/companyLinkRequests.test.js
@@ -41,7 +41,7 @@ describe('list', () => {
       { user: new ObjectId(), company: companyId },
     ];
 
-    find.returns(SinonMongoose.stubChainedQueries([companyLinkRequestList]));
+    find.returns(SinonMongoose.stubChainedQueries(companyLinkRequestList));
 
     const result = await CompanyLinkRequestsHelper.list(credentials);
 

--- a/tests/unit/helpers/contracts.test.js
+++ b/tests/unit/helpers/contracts.test.js
@@ -36,7 +36,7 @@ describe('getContractList', () => {
     const credentials = { company: { _id: '1234567890' } };
     const query = { user: '1234567890' };
 
-    findContract.returns(SinonMongoose.stubChainedQueries([contracts]));
+    findContract.returns(SinonMongoose.stubChainedQueries(contracts));
 
     const result = await ContractHelper.getContractList(query, credentials);
 
@@ -62,7 +62,7 @@ describe('getContractList', () => {
     const credentials = { company: { _id: '1234567890' } };
     const query = { startDate: '2019-09-09T00:00:00', endDate: '2019-09-09T00:00:00' };
 
-    findContract.returns(SinonMongoose.stubChainedQueries([contracts]));
+    findContract.returns(SinonMongoose.stubChainedQueries(contracts));
 
     const result = await ContractHelper.getContractList(query, credentials);
 
@@ -250,8 +250,8 @@ describe('createContract', () => {
     isCreationAllowed.returns(true);
     formatSerialNumber.returns('CT1234567890');
     createContract.returns(contract);
-    findOneRole.returns(SinonMongoose.stubChainedQueries([role], ['lean']));
-    findOneUser.returns(SinonMongoose.stubChainedQueries([user]));
+    findOneRole.returns(SinonMongoose.stubChainedQueries(role, ['lean']));
+    findOneUser.returns(SinonMongoose.stubChainedQueries(user));
 
     const result = await ContractHelper.createContract(payload, credentials);
 
@@ -311,8 +311,8 @@ describe('createContract', () => {
     generateSignatureRequestStub.returns({ data: { document_hash: '1234567890' } });
 
     createContract.returns(contractWithDoc);
-    findOneRole.returns(SinonMongoose.stubChainedQueries([role], ['lean']));
-    findOneUser.returns(SinonMongoose.stubChainedQueries([user]));
+    findOneRole.returns(SinonMongoose.stubChainedQueries(role, ['lean']));
+    findOneUser.returns(SinonMongoose.stubChainedQueries(user));
 
     const result = await ContractHelper.createContract(payload, credentials);
 
@@ -365,8 +365,8 @@ describe('createContract', () => {
     isCreationAllowed.returns(true);
     formatSerialNumber.returns('CT1234567890');
     createContract.returns(contract);
-    findOneRole.returns(SinonMongoose.stubChainedQueries([role], ['lean']));
-    findOneUser.returns(SinonMongoose.stubChainedQueries([user]));
+    findOneRole.returns(SinonMongoose.stubChainedQueries(role, ['lean']));
+    findOneUser.returns(SinonMongoose.stubChainedQueries(user));
 
     const result = await ContractHelper.createContract(payload, credentials);
 
@@ -412,7 +412,7 @@ describe('createContract', () => {
     try {
       isCreationAllowed.returns(false);
 
-      findOneUser.returns(SinonMongoose.stubChainedQueries([user]));
+      findOneUser.returns(SinonMongoose.stubChainedQueries(user));
       await ContractHelper.createContract(payload, credentials);
     } catch (e) {
       expect(e.output.statusCode).toEqual(422);
@@ -500,8 +500,8 @@ describe('endContract', () => {
     };
     const credentials = { _id: new ObjectId(), company: { _id: '1234567890' } };
 
-    findOneContract.returns(SinonMongoose.stubChainedQueries([contract], ['lean']));
-    findOneAndUpdateContract.returns(SinonMongoose.stubChainedQueries([updatedContract]));
+    findOneContract.returns(SinonMongoose.stubChainedQueries(contract, ['lean']));
+    findOneAndUpdateContract.returns(SinonMongoose.stubChainedQueries(updatedContract));
     countDocumentHistories.returns(0);
     eventCountDocuments.returns(0);
 
@@ -606,8 +606,8 @@ describe('endContract', () => {
     };
 
     try {
-      findOneContract.returns(SinonMongoose.stubChainedQueries([contract], ['lean']));
-      findOneAndUpdateContract.returns(SinonMongoose.stubChainedQueries([updatedContract]));
+      findOneContract.returns(SinonMongoose.stubChainedQueries(contract, ['lean']));
+      findOneAndUpdateContract.returns(SinonMongoose.stubChainedQueries(updatedContract));
       countDocumentHistories.returns(1);
       eventCountDocuments.returns(0);
 
@@ -690,8 +690,8 @@ describe('endContract', () => {
     };
 
     try {
-      findOneContract.returns(SinonMongoose.stubChainedQueries([contract], ['lean']));
-      findOneAndUpdateContract.returns(SinonMongoose.stubChainedQueries([updatedContract]));
+      findOneContract.returns(SinonMongoose.stubChainedQueries(contract, ['lean']));
+      findOneAndUpdateContract.returns(SinonMongoose.stubChainedQueries(updatedContract));
       eventCountDocuments.returns(1);
       countDocumentHistories.returns(0);
 
@@ -746,7 +746,7 @@ describe('endContract', () => {
     };
     const credentials = { _id: new ObjectId(), company: { _id: '1234567890' } };
     try {
-      findOneContract.returns(SinonMongoose.stubChainedQueries([contract], ['lean']));
+      findOneContract.returns(SinonMongoose.stubChainedQueries(contract, ['lean']));
 
       await ContractHelper.endContract(contractId.toHexString(), payload, credentials);
       expect(true).toBe(false);
@@ -803,8 +803,8 @@ describe('createVersion', () => {
     const companyId = new ObjectId();
     const credentials = { company: { _id: companyId } };
 
-    findOneContract.returns(SinonMongoose.stubChainedQueries([contract], ['lean']));
-    findOneAndUpdateContract.returns(SinonMongoose.stubChainedQueries([], ['lean']));
+    findOneContract.returns(SinonMongoose.stubChainedQueries(contract, ['lean']));
+    findOneAndUpdateContract.returns(SinonMongoose.stubChainedQueries(null, ['lean']));
     canCreateVersion.returns(true);
 
     await ContractHelper.createVersion(contract._id.toHexString(), newVersion, credentials);
@@ -837,8 +837,8 @@ describe('createVersion', () => {
 
     generateSignatureRequest.returns({ data: { document_hash: '1234567890' } });
     canCreateVersion.returns(true);
-    findOneContract.returns(SinonMongoose.stubChainedQueries([contract], ['lean']));
-    findOneAndUpdateContract.returns(SinonMongoose.stubChainedQueries([], ['lean']));
+    findOneContract.returns(SinonMongoose.stubChainedQueries(contract, ['lean']));
+    findOneAndUpdateContract.returns(SinonMongoose.stubChainedQueries(null, ['lean']));
 
     await ContractHelper.createVersion(contract._id.toHexString(), newVersion, credentials);
 
@@ -870,7 +870,7 @@ describe('createVersion', () => {
     const credentials = { company: { _id: companyId } };
 
     try {
-      findOneContract.returns(SinonMongoose.stubChainedQueries([contract], ['lean']));
+      findOneContract.returns(SinonMongoose.stubChainedQueries(contract, ['lean']));
       generateSignatureRequest.returns({ data: { error: { type: '1234567890' } } });
       canCreateVersion.returns(true);
 
@@ -896,7 +896,7 @@ describe('createVersion', () => {
     const credentials = { company: { _id: companyId } };
 
     try {
-      findOneContract.returns(SinonMongoose.stubChainedQueries([contract], ['lean']));
+      findOneContract.returns(SinonMongoose.stubChainedQueries(contract, ['lean']));
       canCreateVersion.returns(false);
 
       await ContractHelper.createVersion(contract._id.toHexString(), newVersion, credentials);
@@ -987,7 +987,7 @@ describe('canUpdateVersion', () => {
     const versionToUpdate = { startDate: '2020-08-02T00:00:00' };
 
     countAuxiliaryEventsBetweenDates.returns(0);
-    findContract.returns(SinonMongoose.stubChainedQueries([[contract]], ['sort', 'lean']));
+    findContract.returns(SinonMongoose.stubChainedQueries([contract], ['sort', 'lean']));
 
     const result = await ContractHelper.canUpdateVersion(contract, versionToUpdate, 0, '1234567890');
 
@@ -1017,7 +1017,7 @@ describe('canUpdateVersion', () => {
 
     countAuxiliaryEventsBetweenDates.returns(0);
     findContract.returns(SinonMongoose.stubChainedQueries(
-      [[contract, { startDate: '2018-06-02T00:00:00', endDate: '2018-10-02T23:59:59' }]],
+      [contract, { startDate: '2018-06-02T00:00:00', endDate: '2018-10-02T23:59:59' }],
       ['sort', 'lean']
     ));
 
@@ -1048,7 +1048,7 @@ describe('canUpdateVersion', () => {
     const versionToUpdate = { startDate: '2020-08-02T00:00:00' };
 
     countAuxiliaryEventsBetweenDates.returns(5);
-    findContract.returns(SinonMongoose.stubChainedQueries([[contract]], ['sort', 'lean']));
+    findContract.returns(SinonMongoose.stubChainedQueries([contract], ['sort', 'lean']));
 
     const result = await ContractHelper.canUpdateVersion(contract, versionToUpdate, 0, '1234567890');
 
@@ -1187,8 +1187,8 @@ describe('updateVersion', () => {
     canUpdateVersion.returns(true);
     formatVersionEditionPayload.returns({ $set: {}, $push: {} });
 
-    findOneContract.returns(SinonMongoose.stubChainedQueries([contract], ['lean']));
-    findOneAndUpdateContract.returns(SinonMongoose.stubChainedQueries([contract], ['lean']));
+    findOneContract.returns(SinonMongoose.stubChainedQueries(contract, ['lean']));
+    findOneAndUpdateContract.returns(SinonMongoose.stubChainedQueries(contract, ['lean']));
 
     updateHistoryOnContractUpdateStub.returns();
 
@@ -1240,8 +1240,8 @@ describe('updateVersion', () => {
     canUpdateVersion.returns(true);
     formatVersionEditionPayload.returns({ $set: {}, $push: {}, $unset: { auxiliaryDoc: '' } });
 
-    findOneContract.returns(SinonMongoose.stubChainedQueries([contract], ['lean']));
-    findOneAndUpdateContract.returns(SinonMongoose.stubChainedQueries([contract], ['lean']));
+    findOneContract.returns(SinonMongoose.stubChainedQueries(contract, ['lean']));
+    findOneAndUpdateContract.returns(SinonMongoose.stubChainedQueries(contract, ['lean']));
 
     await ContractHelper.updateVersion(contractId.toHexString(), versionId.toHexString(), versionToUpdate, credentials);
 
@@ -1282,7 +1282,7 @@ describe('updateVersion', () => {
         versions: [{ _id: versionId, startDate: '2019-09-10T00:00:00' }],
       };
 
-      findOneContract.returns(SinonMongoose.stubChainedQueries([contract], ['lean']));
+      findOneContract.returns(SinonMongoose.stubChainedQueries(contract, ['lean']));
       canUpdateVersion.returns(false);
       updateHistoryOnContractUpdateStub.returns();
 

--- a/tests/unit/helpers/courseHistories.test.js
+++ b/tests/unit/helpers/courseHistories.test.js
@@ -329,7 +329,7 @@ describe('list', () => {
     }];
     const query = { course: returnedList[0].course };
 
-    find.returns(SinonMongoose.stubChainedQueries([returnedList], ['populate', 'sort', 'limit', 'lean']));
+    find.returns(SinonMongoose.stubChainedQueries(returnedList, ['populate', 'sort', 'limit', 'lean']));
 
     const result = await CourseHistoriesHelper.list(query);
 
@@ -360,7 +360,7 @@ describe('list', () => {
     }];
     const query = { course: returnedList[0].course, createdAt: '2019-02-04T10:00:00.000Z' };
 
-    find.returns(SinonMongoose.stubChainedQueries([returnedList], ['populate', 'sort', 'limit', 'lean']));
+    find.returns(SinonMongoose.stubChainedQueries(returnedList, ['populate', 'sort', 'limit', 'lean']));
 
     const result = await CourseHistoriesHelper.list(query);
 

--- a/tests/unit/helpers/courseSlots.test.js
+++ b/tests/unit/helpers/courseSlots.test.js
@@ -141,7 +141,7 @@ describe('updateCourseSlot', () => {
     const user = { _id: new ObjectId() };
     const payload = { startDate: '2020-03-03T22:00:00', step: new ObjectId(), meetingLink: 'https://github.com' };
     hasConflicts.returns(false);
-    findByIdStep.returns(SinonMongoose.stubChainedQueries([{ _id: payload.step, type: REMOTE }], ['lean']));
+    findByIdStep.returns(SinonMongoose.stubChainedQueries({ _id: payload.step, type: REMOTE }, ['lean']));
 
     await CourseSlotsHelper.updateCourseSlot(slot, payload, user);
     SinonMongoose.calledOnceWithExactly(findByIdStep, [{ query: 'findById', args: [payload.step] }, { query: 'lean' }]);
@@ -159,7 +159,7 @@ describe('updateCourseSlot', () => {
     const user = { _id: new ObjectId() };
     const payload = { startDate: '2020-03-03T22:00:00', step: new ObjectId() };
     hasConflicts.returns(false);
-    findByIdStep.returns(SinonMongoose.stubChainedQueries([{ _id: payload.step, type: REMOTE }], ['lean']));
+    findByIdStep.returns(SinonMongoose.stubChainedQueries({ _id: payload.step, type: REMOTE }, ['lean']));
 
     await CourseSlotsHelper.updateCourseSlot(slot, payload, user);
     SinonMongoose.calledOnceWithExactly(findByIdStep, [{ query: 'findById', args: [payload.step] }, { query: 'lean' }]);
@@ -181,7 +181,7 @@ describe('updateCourseSlot', () => {
       address: { fullAddress: '24 avenue Daumesnil' },
     };
     hasConflicts.returns(false);
-    findByIdStep.returns(SinonMongoose.stubChainedQueries([{ _id: payload.step, type: ON_SITE }], ['lean']));
+    findByIdStep.returns(SinonMongoose.stubChainedQueries({ _id: payload.step, type: ON_SITE }, ['lean']));
 
     await CourseSlotsHelper.updateCourseSlot(slot, payload, user);
     SinonMongoose.calledOnceWithExactly(findByIdStep, [{ query: 'findById', args: [payload.step] }, { query: 'lean' }]);
@@ -199,7 +199,7 @@ describe('updateCourseSlot', () => {
     const user = { _id: new ObjectId() };
     const payload = { startDate: '2020-03-03T22:00:00', step: new ObjectId() };
     hasConflicts.returns(false);
-    findByIdStep.returns(SinonMongoose.stubChainedQueries([{ _id: payload.step, type: ON_SITE }], ['lean']));
+    findByIdStep.returns(SinonMongoose.stubChainedQueries({ _id: payload.step, type: ON_SITE }, ['lean']));
 
     await CourseSlotsHelper.updateCourseSlot(slot, payload, user);
     SinonMongoose.calledOnceWithExactly(findByIdStep, [{ query: 'findById', args: [payload.step] }, { query: 'lean' }]);

--- a/tests/unit/helpers/courses.test.js
+++ b/tests/unit/helpers/courses.test.js
@@ -318,7 +318,7 @@ describe('listUserCourses', () => {
       },
     ];
 
-    courseFind.returns(SinonMongoose.stubChainedQueries([coursesList], ['populate', 'select', 'lean']));
+    courseFind.returns(SinonMongoose.stubChainedQueries(coursesList, ['populate', 'select', 'lean']));
 
     formatCourseWithProgress.onCall(0).returns({
       ...coursesList[0],
@@ -410,7 +410,7 @@ describe('getCourse', () => {
       type: 'inter_b2b',
       trainees: [{ _id: new ObjectId(), company: new ObjectId() }, { _id: new ObjectId(), company: new ObjectId() }],
     };
-    findOne.returns(SinonMongoose.stubChainedQueries([course]));
+    findOne.returns(SinonMongoose.stubChainedQueries(course));
 
     const result = await CourseHelper.getCourse(
       { _id: course._id },
@@ -476,7 +476,7 @@ describe('getCourse', () => {
       trainees: [{ company: authCompanyId }, { company: otherCompanyId }],
     };
     const courseWithFilteredTrainees = { type: 'inter_b2b', trainees: [{ company: authCompanyId }] };
-    findOne.returns(SinonMongoose.stubChainedQueries([courseWithAllTrainees]));
+    findOne.returns(SinonMongoose.stubChainedQueries(courseWithAllTrainees));
 
     const result = await CourseHelper.getCourse({ _id: course._id }, loggedUser);
 
@@ -650,8 +650,8 @@ describe('getCourseFollowUp', () => {
     };
     const trainees = [1, 2, 3, 4, 5];
 
-    findOne.onCall(0).returns(SinonMongoose.stubChainedQueries([{ trainees }], ['lean']));
-    findOne.onCall(1).returns(SinonMongoose.stubChainedQueries([course]));
+    findOne.onCall(0).returns(SinonMongoose.stubChainedQueries({ trainees }, ['lean']));
+    findOne.onCall(1).returns(SinonMongoose.stubChainedQueries(course));
 
     formatStep.callsFake(s => s);
     getTraineeElearningProgress.returns({ steps: { progress: 1 }, progress: 1 });
@@ -719,8 +719,8 @@ describe('getCourseFollowUp', () => {
     };
     const trainees = [1, 2, 3, 4, 5];
 
-    findOne.onCall(0).returns(SinonMongoose.stubChainedQueries([{ trainees }], ['lean']));
-    findOne.onCall(1).returns(SinonMongoose.stubChainedQueries([course]));
+    findOne.onCall(0).returns(SinonMongoose.stubChainedQueries({ trainees }, ['lean']));
+    findOne.onCall(1).returns(SinonMongoose.stubChainedQueries(course));
     formatStep.callsFake(s => s);
     getTraineeElearningProgress.returns({ steps: { progress: 1 }, elearningProgress: 1 });
 
@@ -818,7 +818,7 @@ describe('getQuestionnaireAnswers', () => {
       },
     };
 
-    findOneCourse.returns(SinonMongoose.stubChainedQueries([course]));
+    findOneCourse.returns(SinonMongoose.stubChainedQueries(course));
     formatActivity.onCall(0).returns({ followUp: [followUps[0]] });
     formatActivity.onCall(1).returns({ followUp: [followUps[1]] });
 
@@ -871,7 +871,7 @@ describe('getQuestionnaireAnswers', () => {
       },
     };
 
-    findOneCourse.returns(SinonMongoose.stubChainedQueries([course]));
+    findOneCourse.returns(SinonMongoose.stubChainedQueries(course));
     formatActivity.onCall(0).returns({ followUp: [] });
     formatActivity.onCall(1).returns({ followUp: [] });
 
@@ -918,7 +918,7 @@ describe('getQuestionnaireAnswers', () => {
       subProgram: {},
     };
 
-    findOneCourse.returns(SinonMongoose.stubChainedQueries([course]));
+    findOneCourse.returns(SinonMongoose.stubChainedQueries(course));
 
     const result = await CourseHelper.getQuestionnaireAnswers(courseId);
 
@@ -1050,7 +1050,7 @@ describe('getTraineeCourse', () => {
     };
     const credentials = { _id: new ObjectId() };
 
-    courseFindOne.returns(SinonMongoose.stubChainedQueries([course], ['populate', 'select', 'lean']));
+    courseFindOne.returns(SinonMongoose.stubChainedQueries(course, ['populate', 'select', 'lean']));
 
     formatCourseWithProgress.returns({
       ...course,
@@ -1143,7 +1143,7 @@ describe('updateCourse', () => {
     const courseId = new ObjectId();
     const payload = { misc: 'groupe 4' };
 
-    courseFindOneAndUpdate.returns(SinonMongoose.stubChainedQueries([payload], ['lean']));
+    courseFindOneAndUpdate.returns(SinonMongoose.stubChainedQueries(payload, ['lean']));
 
     const result = await CourseHelper.updateCourse(courseId, payload);
     expect(result.misc).toEqual(payload.misc);
@@ -1162,7 +1162,7 @@ describe('updateCourse', () => {
     const payload = { contact: '' };
     const updatedCourse = { _id: courseId };
 
-    courseFindOneAndUpdate.returns(SinonMongoose.stubChainedQueries([updatedCourse], ['lean']));
+    courseFindOneAndUpdate.returns(SinonMongoose.stubChainedQueries(updatedCourse, ['lean']));
 
     const result = await CourseHelper.updateCourse(courseId, payload);
     expect(result._id).toBe(courseId);
@@ -1224,7 +1224,7 @@ describe('sendSMS', () => {
   });
 
   it('should send SMS to trainees and save missing phone trainee id', async () => {
-    courseFindById.returns(SinonMongoose.stubChainedQueries([{ trainees }]));
+    courseFindById.returns(SinonMongoose.stubChainedQueries({ trainees }));
     sendStub.onCall(0).returns();
     sendStub.onCall(1).returns(new Promise(() => { throw Boom.badRequest(); }));
 
@@ -1270,7 +1270,7 @@ describe('sendSMS', () => {
 
   it('should not save coursesmshistory if no sms is sent', async () => {
     try {
-      courseFindById.returns(SinonMongoose.stubChainedQueries([{ trainees }]));
+      courseFindById.returns(SinonMongoose.stubChainedQueries({ trainees }));
       sendStub.returns(new Promise(() => { throw Boom.badRequest(); }));
 
       await CourseHelper.sendSMS(courseId, payload, credentials);
@@ -1289,7 +1289,7 @@ describe('sendSMS', () => {
       { contact: {}, identity: { firstname: 'test', lasname: 'ko' }, _id: 'poiuytrewq' },
     ];
 
-    courseFindById.returns(SinonMongoose.stubChainedQueries([{ trainees: traineesWithoutPhoneNumbers }]));
+    courseFindById.returns(SinonMongoose.stubChainedQueries({ trainees: traineesWithoutPhoneNumbers }));
 
     await CourseHelper.sendSMS(courseId, payload, credentials);
 
@@ -1310,7 +1310,7 @@ describe('getSMSHistory', () => {
   });
 
   it('should get SMS history', async () => {
-    courseSmsHistoryFind.returns(SinonMongoose.stubChainedQueries([sms]));
+    courseSmsHistoryFind.returns(SinonMongoose.stubChainedQueries(sms));
 
     const result = await CourseHelper.getSMSHistory(courseId);
 
@@ -1355,7 +1355,7 @@ describe('addCourseTrainee', () => {
     const credentials = { _id: new ObjectId(), company: { _id: new ObjectId() } };
 
     userFindOne.returns(user);
-    userFindOne.returns(SinonMongoose.stubChainedQueries([user], ['lean']));
+    userFindOne.returns(SinonMongoose.stubChainedQueries(user, ['lean']));
 
     await CourseHelper.addCourseTrainee(course._id, payload, credentials);
 
@@ -1657,7 +1657,7 @@ describe('generateAttendanceSheets', () => {
     const courseId = new ObjectId();
     const course = { misc: 'des infos en plus', type: 'inter_b2b' };
 
-    courseFindOne.returns(SinonMongoose.stubChainedQueries([course]));
+    courseFindOne.returns(SinonMongoose.stubChainedQueries(course));
 
     formatInterCourseForPdf.returns({ name: 'la formation - des infos en plus' });
     generatePdf.returns('pdf');
@@ -1691,7 +1691,7 @@ describe('generateAttendanceSheets', () => {
     const courseId = new ObjectId();
     const course = { misc: 'des infos en plus', type: 'intra' };
 
-    courseFindOne.returns(SinonMongoose.stubChainedQueries([course]));
+    courseFindOne.returns(SinonMongoose.stubChainedQueries(course));
 
     formatIntraCourseForPdf.returns({ name: 'la formation - des infos en plus' });
     generatePdf.returns('pdf');
@@ -1833,8 +1833,8 @@ describe('generateCompletionCertificate', () => {
       },
     ];
 
-    attendanceFind.returns(SinonMongoose.stubChainedQueries([attendances]));
-    courseFindOne.returns(SinonMongoose.stubChainedQueries([course]));
+    attendanceFind.returns(SinonMongoose.stubChainedQueries(attendances));
+    courseFindOne.returns(SinonMongoose.stubChainedQueries(course));
     formatCourseForDocx.returns({
       program: { learningGoals: 'Apprendre', name: 'nom du programme' },
       courseDuration: '8h',
@@ -2092,7 +2092,7 @@ describe('generateConvocationPdf', () => {
     const courseId = new ObjectId();
 
     courseFindOne.returns(SinonMongoose.stubChainedQueries(
-      [{
+      {
         _id: courseId,
         subProgram: { program: { name: 'Comment attraper des Pokemons' } },
         trainer: { identity: { firstname: 'Ash', lastname: 'Ketchum' } },
@@ -2102,7 +2102,7 @@ describe('generateConvocationPdf', () => {
           endDate: '2020-10-12T13:30:00.000+01:00',
           address: { fullAddress: '37 rue de Ponthieu 75005 Paris' },
         }],
-      }]
+      }
     ));
 
     formatCourseForConvocationPdf.returns({
@@ -2198,7 +2198,7 @@ describe('getQuestionnaires', () => {
       { name: 'test2', type: 'expectations', historiesCount: 0 },
     ];
 
-    findQuestionnaire.returns(SinonMongoose.stubChainedQueries([questionnaires], ['select', 'populate', 'lean']));
+    findQuestionnaire.returns(SinonMongoose.stubChainedQueries(questionnaires, ['select', 'populate', 'lean']));
 
     const result = await CourseHelper.getQuestionnaires(courseId);
 

--- a/tests/unit/helpers/creditNotes.test.js
+++ b/tests/unit/helpers/creditNotes.test.js
@@ -51,7 +51,7 @@ describe('getCreditNotes', () => {
     };
 
     getDateQueryStub.returns(dateQuery);
-    find.returns(SinonMongoose.stubChainedQueries([[{ customer: { _id: customerId } }]]));
+    find.returns(SinonMongoose.stubChainedQueries([{ customer: { _id: customerId } }]));
     populateSubscriptionsServicesStub.returns({ _id: customerId, firstname: 'toto' });
 
     const result = await CreditNoteHelper.getCreditNotes(payload, credentials);
@@ -82,7 +82,7 @@ describe('getCreditNotes', () => {
       customer: customerId,
     };
 
-    find.returns(SinonMongoose.stubChainedQueries([[{ customer: { _id: customerId } }]]));
+    find.returns(SinonMongoose.stubChainedQueries([{ customer: { _id: customerId } }]));
     populateSubscriptionsServicesStub.returns({ _id: customerId, firstname: 'toto' });
 
     const result = await CreditNoteHelper.getCreditNotes(payload, credentials);
@@ -120,7 +120,7 @@ describe('getCreditNotes', () => {
     };
 
     getDateQueryStub.returns(dateQuery);
-    find.returns(SinonMongoose.stubChainedQueries([[]]));
+    find.returns(SinonMongoose.stubChainedQueries([]));
 
     const result = await CreditNoteHelper.getCreditNotes(payload, credentials);
 
@@ -176,7 +176,7 @@ describe('updateEventAndFundingHistory', () => {
 
     find.returns(events);
     findOneAndUpdate.returns(null);
-    find.returns(SinonMongoose.stubChainedQueries([events], ['lean']));
+    find.returns(SinonMongoose.stubChainedQueries(events, ['lean']));
 
     await CreditNoteHelper.updateEventAndFundingHistory([], false, credentials);
 
@@ -199,7 +199,7 @@ describe('updateEventAndFundingHistory', () => {
       startDate: new Date('2019/01/19'),
     }];
 
-    find.returns(SinonMongoose.stubChainedQueries([events], ['lean']));
+    find.returns(SinonMongoose.stubChainedQueries(events, ['lean']));
     findOneAndUpdate.returns(new FundingHistory());
 
     await CreditNoteHelper.updateEventAndFundingHistory([], false, credentials);
@@ -223,7 +223,7 @@ describe('updateEventAndFundingHistory', () => {
       startDate: new Date('2019/01/19'),
     }];
 
-    find.returns(SinonMongoose.stubChainedQueries([events], ['lean']));
+    find.returns(SinonMongoose.stubChainedQueries(events, ['lean']));
     findOneAndUpdate.returns(null);
 
     await CreditNoteHelper.updateEventAndFundingHistory([], true, credentials);
@@ -249,7 +249,7 @@ describe('updateEventAndFundingHistory', () => {
       startDate: new Date('2019/01/19'),
     }];
 
-    find.returns(SinonMongoose.stubChainedQueries([events], ['lean']));
+    find.returns(SinonMongoose.stubChainedQueries(events, ['lean']));
 
     await CreditNoteHelper.updateEventAndFundingHistory(eventsToUpdate, false, credentials);
 
@@ -335,7 +335,7 @@ describe('getCreditNoteNumber', () => {
     const payload = { date: '2019-09-19T00:00:00' };
     const company = { _id: new ObjectId() };
 
-    findOneAndUpdate.returns(SinonMongoose.stubChainedQueries([], ['lean']));
+    findOneAndUpdate.returns(SinonMongoose.stubChainedQueries(null, ['lean']));
 
     await CreditNoteHelper.getCreditNoteNumber(payload, company._id);
 
@@ -970,8 +970,8 @@ describe('generateCreditNotePdf', () => {
   });
 
   it('should generate a pdf', async () => {
-    creditNoteFindOne.returns(SinonMongoose.stubChainedQueries([{ origin: COMPANI, number: '12345' }]));
-    companyNoteFindOne.returns(SinonMongoose.stubChainedQueries([{ _id: credentials.company._id }], ['lean']));
+    creditNoteFindOne.returns(SinonMongoose.stubChainedQueries({ origin: COMPANI, number: '12345' }));
+    companyNoteFindOne.returns(SinonMongoose.stubChainedQueries({ _id: credentials.company._id }, ['lean']));
     formatPdf.returns({ name: 'creditNotePdf' });
     getPdfContent.returns({ content: ['creditNotePdf'] });
     generatePdf.returns({ title: 'creditNote' });
@@ -1011,7 +1011,7 @@ describe('generateCreditNotePdf', () => {
 
   it('should return a 404 if creditnote is not found', async () => {
     try {
-      creditNoteFindOne.returns(SinonMongoose.stubChainedQueries([]));
+      creditNoteFindOne.returns(SinonMongoose.stubChainedQueries(null));
 
       await CreditNoteHelper.generateCreditNotePdf(params, credentials);
     } catch (e) {
@@ -1042,7 +1042,7 @@ describe('generateCreditNotePdf', () => {
 
   it('should return a 400 if creditnote origin is not compani', async () => {
     try {
-      creditNoteFindOne.returns(SinonMongoose.stubChainedQueries([{ origin: OGUST }]));
+      creditNoteFindOne.returns(SinonMongoose.stubChainedQueries({ origin: OGUST }));
 
       await CreditNoteHelper.generateCreditNotePdf(params, credentials);
     } catch (e) {

--- a/tests/unit/helpers/customerAbsences.test.js
+++ b/tests/unit/helpers/customerAbsences.test.js
@@ -66,7 +66,7 @@ describe('list', () => {
     ];
 
     formatIdsArray.returns([customerId]);
-    findCustomerAbsence.returns(SinonMongoose.stubChainedQueries([[customerAbsences]]));
+    findCustomerAbsence.returns(SinonMongoose.stubChainedQueries([customerAbsences]));
 
     await CustomerAbsencesHelper.list(query, credentials);
 
@@ -112,7 +112,7 @@ describe('list', () => {
     ];
 
     formatIdsArray.returns(customers);
-    findCustomerAbsence.returns(SinonMongoose.stubChainedQueries([[customerAbsences]]));
+    findCustomerAbsence.returns(SinonMongoose.stubChainedQueries([customerAbsences]));
 
     await CustomerAbsencesHelper.list(query, credentials);
 
@@ -197,7 +197,7 @@ describe('updateCustomerAbsence', () => {
     const customerAbsence = { _id: customerAbsenceId, customer };
     const payload = { absenceType: 'hospitalization', startDate, endDate };
 
-    findOne.returns(SinonMongoose.stubChainedQueries([customerAbsence], ['lean']));
+    findOne.returns(SinonMongoose.stubChainedQueries(customerAbsence, ['lean']));
 
     await CustomerAbsencesHelper.updateCustomerAbsence(customerAbsenceId, payload, credentials);
 

--- a/tests/unit/helpers/customerNotes.test.js
+++ b/tests/unit/helpers/customerNotes.test.js
@@ -60,7 +60,7 @@ describe('list', () => {
       { _id: new ObjectId(), title: 'test 2' },
     ];
 
-    find.returns(SinonMongoose.stubChainedQueries([customerNotes], ['populate', 'sort', 'lean']));
+    find.returns(SinonMongoose.stubChainedQueries(customerNotes, ['populate', 'sort', 'lean']));
 
     const result = await CustomerNotesHelper.list(customer, credentials);
 
@@ -106,7 +106,7 @@ describe('update', () => {
     const customerNote = { _id: new ObjectId(), title: 'test', description: 'description', customer: credentials._id };
     const payload = { title: 'titre mis a jour', description: 'description mise a jour' };
 
-    findOne.returns(SinonMongoose.stubChainedQueries([customerNote], ['lean']));
+    findOne.returns(SinonMongoose.stubChainedQueries(customerNote, ['lean']));
     customerNoteHistoryCreate.returns(customerNote);
 
     await CustomerNotesHelper.update(customerNote._id, payload, credentials);
@@ -156,7 +156,7 @@ describe('update', () => {
     };
     const payload = { title: '  test', description: 'description' };
 
-    findOne.returns(SinonMongoose.stubChainedQueries([customerNote], ['lean']));
+    findOne.returns(SinonMongoose.stubChainedQueries(customerNote, ['lean']));
 
     await CustomerNotesHelper.update(customerNote._id, payload, credentials);
 

--- a/tests/unit/helpers/customerPartners.test.js
+++ b/tests/unit/helpers/customerPartners.test.js
@@ -40,7 +40,7 @@ describe('list', () => {
       { _id: new ObjectId(), partner: { _id: new ObjectId() } },
     ];
 
-    find.returns(SinonMongoose.stubChainedQueries([customerPartners]));
+    find.returns(SinonMongoose.stubChainedQueries(customerPartners));
 
     const result = await CustomerPartnersHelper.list(customer, credentials);
 
@@ -79,7 +79,7 @@ describe('update', () => {
     const customerPartnerId = new ObjectId();
     const customerPartner = { _id: customerPartnerId, customer: new ObjectId() };
 
-    findOneAndUpdate.returns(SinonMongoose.stubChainedQueries([customerPartner], ['lean']));
+    findOneAndUpdate.returns(SinonMongoose.stubChainedQueries(customerPartner, ['lean']));
 
     await CustomerPartnersHelper.update(customerPartnerId, { prescriber: true });
 
@@ -103,7 +103,7 @@ describe('update', () => {
     const customerPartnerId = new ObjectId();
     const customerPartner = { _id: customerPartnerId, customer: new ObjectId() };
 
-    findOneAndUpdate.returns(SinonMongoose.stubChainedQueries([customerPartner], ['lean']));
+    findOneAndUpdate.returns(SinonMongoose.stubChainedQueries(customerPartner, ['lean']));
 
     await CustomerPartnersHelper.update(customerPartnerId, { prescriber: false });
 

--- a/tests/unit/helpers/customers.test.js
+++ b/tests/unit/helpers/customers.test.js
@@ -53,15 +53,15 @@ describe('getCustomersBySector', () => {
     const customerIds = [new ObjectId(), new ObjectId()];
 
     findSectorHistories.returns(SinonMongoose.stubChainedQueries(
-      [[{ auxiliary: auxiliaryIds[1] }, { auxiliary: auxiliaryIds[0] }]],
+      [{ auxiliary: auxiliaryIds[1] }, { auxiliary: auxiliaryIds[0] }],
       ['lean']
     ));
     findEvents.returns(SinonMongoose.stubChainedQueries(
-      [[
+      [
         { customer: { _id: customerIds[0] } },
         { customer: { _id: customerIds[0] } },
         { customer: { _id: customerIds[1] } },
-      ]],
+      ],
       ['populate', 'lean']
     ));
     populateSubscriptionsServices.onCall(0).returns({ _id: customerIds[0], identity: {} });
@@ -165,7 +165,7 @@ describe('getCustomers', () => {
     const companyId = new ObjectId();
     const credentials = { company: { _id: companyId } };
 
-    findCustomer.returns(SinonMongoose.stubChainedQueries([[]]));
+    findCustomer.returns(SinonMongoose.stubChainedQueries([]));
 
     const result = await CustomerHelper.getCustomers(credentials);
 
@@ -187,7 +187,7 @@ describe('getCustomers', () => {
     const credentials = { company: { _id: companyId } };
     const customers = [{ identity: { firstname: 'Emmanuel' }, company: companyId }, { company: companyId }];
 
-    findCustomer.returns(SinonMongoose.stubChainedQueries([customers]));
+    findCustomer.returns(SinonMongoose.stubChainedQueries(customers));
     populateSubscriptionsServices.onCall(0).returns({
       identity: { firstname: 'Emmanuel' },
       company: companyId,
@@ -245,7 +245,7 @@ describe('getCustomers', () => {
       { identity: { firstname: 'Jean-Paul', lastname: 'Belmondot' }, company: companyId },
     ];
 
-    findCustomer.returns(SinonMongoose.stubChainedQueries([[customers[0]]]));
+    findCustomer.returns(SinonMongoose.stubChainedQueries([customers[0]]));
     populateSubscriptionsServices.returns({
       identity: { firstname: 'Emmanuel' },
       company: companyId,
@@ -299,7 +299,7 @@ describe('getCustomers', () => {
       { identity: { firstname: 'Jean-Paul', lastname: 'Belmondot' }, company: companyId },
     ];
 
-    findCustomer.returns(SinonMongoose.stubChainedQueries([[customers[1]]]));
+    findCustomer.returns(SinonMongoose.stubChainedQueries([customers[1]]));
     populateSubscriptionsServices.returns({
       identity: { firstname: 'Jean-Paul', lastname: 'Belmondot' },
       company: companyId,
@@ -362,7 +362,7 @@ describe('getCustomersFirstIntervention', () => {
     const credentials = { company: { _id: companyId } };
     const query = { company: companyId };
 
-    findCustomer.returns(SinonMongoose.stubChainedQueries([customers]));
+    findCustomer.returns(SinonMongoose.stubChainedQueries(customers));
 
     const result = await CustomerHelper.getCustomersFirstIntervention(query, credentials);
 
@@ -436,10 +436,7 @@ describe('getCustomersWithSubscriptions', () => {
   it('should return customers with subscriptions', async () => {
     const companyId = new ObjectId();
     const customersWithSubscriptions = [{ identity: { lastname: 'Fred' }, subscriptions: [{ _id: new ObjectId() }] }];
-    findCustomer.returns(SinonMongoose.stubChainedQueries(
-      [customersWithSubscriptions],
-      ['populate', 'select', 'lean']
-    ));
+    findCustomer.returns(SinonMongoose.stubChainedQueries(customersWithSubscriptions, ['populate', 'select', 'lean']));
 
     const rep = await CustomerHelper.getCustomersWithSubscriptions({ company: { _id: companyId } });
 
@@ -492,7 +489,7 @@ describe('getCustomer', () => {
     const customerId = 'qwertyuiop';
     const credentials = { company: { _id: new ObjectId() } };
 
-    findOneCustomer.returns(SinonMongoose.stubChainedQueries([null]));
+    findOneCustomer.returns(SinonMongoose.stubChainedQueries(null));
 
     const result = await CustomerHelper.getCustomer(customerId, credentials);
 
@@ -518,7 +515,7 @@ describe('getCustomer', () => {
     const credentials = { company: { _id: new ObjectId() } };
     const customer = { identity: { firstname: 'Emmanuel' } };
 
-    findOneCustomer.returns(SinonMongoose.stubChainedQueries([customer]));
+    findOneCustomer.returns(SinonMongoose.stubChainedQueries(customer));
     populateSubscriptionsServices.callsFake(cus => ({ ...cus, subscriptions: 2 }));
     subscriptionsAccepted.callsFake(cus => ({ ...cus, subscriptionsAccepted: true }));
 
@@ -548,7 +545,7 @@ describe('getCustomer', () => {
     const credentials = { company: { _id: new ObjectId() } };
     const customer = { identity: { firstname: 'Emmanuel' }, fundings: [{ _id: '1234' }, { _id: '09876' }] };
 
-    findOneCustomer.returns(SinonMongoose.stubChainedQueries([customer]));
+    findOneCustomer.returns(SinonMongoose.stubChainedQueries(customer));
     populateSubscriptionsServices.callsFake(cus => ({ ...cus, subscriptions: 2 }));
     subscriptionsAccepted.callsFake(cus => ({ ...cus, subscriptionsAccepted: true }));
     populateFundingsList.returnsArg(0);
@@ -597,7 +594,7 @@ describe('getRumNumber', () => {
   it('should get RUM number', async () => {
     const companyId = new ObjectId();
 
-    findOneAndUpdateRum.returns(SinonMongoose.stubChainedQueries([], ['lean']));
+    findOneAndUpdateRum.returns(SinonMongoose.stubChainedQueries(null, ['lean']));
 
     await CustomerHelper.getRumNumber(companyId);
 
@@ -672,7 +669,7 @@ describe('formatPaymentPayload', () => {
     const customer = { payment: { bankAccountNumber: '', iban: 'FR4717569000303461796573B36', bic: '', mandates: [] } };
     const payload = { payment: { iban: 'FR8312739000501844178231W37' } };
 
-    findByIdCustomer.returns(SinonMongoose.stubChainedQueries([customer], ['lean']));
+    findByIdCustomer.returns(SinonMongoose.stubChainedQueries(customer, ['lean']));
     getRumNumber.returns(rumNumber);
     formatRumNumber.returns(formattedRumNumber);
 
@@ -698,7 +695,7 @@ describe('formatPaymentPayload', () => {
     const customer = { payment: { bankAccountNumber: '', iban: '', bic: '', mandates: [] } };
     const payload = { payment: { iban: 'FR4717569000303461796573B36' } };
 
-    findByIdCustomer.returns(SinonMongoose.stubChainedQueries([customer], ['lean']));
+    findByIdCustomer.returns(SinonMongoose.stubChainedQueries(customer, ['lean']));
 
     const result = await CustomerHelper.formatPaymentPayload(customerId, payload, company);
 
@@ -730,7 +727,7 @@ describe('updateCustomerEvents', () => {
     const payload = { contact: { primaryAddress: { fullAddress: '27 rue des renaudes 75017 Paris' } } };
 
     findByIdCustomer.returns(SinonMongoose.stubChainedQueries(
-      [{ contact: { primaryAddress: { fullAddress: '37 rue Ponthieu 75008 Paris' } } }],
+      { contact: { primaryAddress: { fullAddress: '37 rue Ponthieu 75008 Paris' } } },
       ['lean']
     ));
 
@@ -755,7 +752,7 @@ describe('updateCustomerEvents', () => {
     const payload = { contact: { secondaryAddress: { fullAddress: '27 rue des renaudes 75017 Paris' } } };
 
     findByIdCustomer.returns(SinonMongoose.stubChainedQueries(
-      [{ contact: { secondaryAddress: { fullAddress: '37 rue Ponthieu 75008 Paris' } } }],
+      { contact: { secondaryAddress: { fullAddress: '37 rue Ponthieu 75008 Paris' } } },
       ['lean']
     ));
 
@@ -780,7 +777,7 @@ describe('updateCustomerEvents', () => {
     const payload = { contact: { secondaryAddress: { fullAddress: '27 rue des renaudes 75017 Paris' } } };
 
     findByIdCustomer.returns(SinonMongoose.stubChainedQueries(
-      [{ contact: { primaryAddress: { fullAddress: '37 rue Ponthieu 75008 Paris' } } }],
+      { contact: { primaryAddress: { fullAddress: '37 rue Ponthieu 75008 Paris' } } },
       ['lean']
     ));
 
@@ -802,7 +799,7 @@ describe('updateCustomerEvents', () => {
       },
     };
 
-    findByIdCustomer.returns(SinonMongoose.stubChainedQueries([customer], ['lean']));
+    findByIdCustomer.returns(SinonMongoose.stubChainedQueries(customer, ['lean']));
 
     await CustomerHelper.updateCustomerEvents(customerId, payload);
 
@@ -853,7 +850,7 @@ describe('updateCustomer', () => {
 
     const customerResult = { _id: customer._id };
 
-    findOneAndUpdateCustomer.returns(SinonMongoose.stubChainedQueries([customerResult], ['lean']));
+    findOneAndUpdateCustomer.returns(SinonMongoose.stubChainedQueries(customerResult, ['lean']));
 
     const result = await CustomerHelper.updateCustomer(customer._id, payload, credentials);
 
@@ -879,7 +876,7 @@ describe('updateCustomer', () => {
       payment: { bankAccountNumber: '', iban: 'FR8312739000501844178231W37', bic: '', mandates: [formattedRumNumber] },
     };
 
-    findOneAndUpdateCustomer.returns(SinonMongoose.stubChainedQueries([customerResult], ['lean']));
+    findOneAndUpdateCustomer.returns(SinonMongoose.stubChainedQueries(customerResult, ['lean']));
 
     formatPaymentPayload.returns({
       $set: flat(payload, { safe: true }),
@@ -923,7 +920,7 @@ describe('updateCustomer', () => {
 
     formatPaymentPayload.returns(payload);
 
-    findOneAndUpdateCustomer.returns(SinonMongoose.stubChainedQueries([customerResult], ['lean']));
+    findOneAndUpdateCustomer.returns(SinonMongoose.stubChainedQueries(customerResult, ['lean']));
 
     const result = await CustomerHelper.updateCustomer(customerId, payload, credentials);
 
@@ -943,7 +940,7 @@ describe('updateCustomer', () => {
     const payload = { contact: { primaryAddress: { fullAddress: '27 rue des renaudes 75017 Paris' } } };
     const customerResult = { contact: { primaryAddress: { fullAddress: '27 rue des renaudes 75017 Paris' } } };
 
-    findOneAndUpdateCustomer.returns(SinonMongoose.stubChainedQueries([customerResult], ['lean']));
+    findOneAndUpdateCustomer.returns(SinonMongoose.stubChainedQueries(customerResult, ['lean']));
 
     const result = await CustomerHelper.updateCustomer(customerId, payload, credentials);
 
@@ -969,7 +966,7 @@ describe('updateCustomer', () => {
     const payload = { contact: { secondaryAddress: { fullAddress: '27 rue des renaudes 75017 Paris' } } };
     const customerResult = { contact: { secondaryAddress: { fullAddress: '27 rue des renaudes 75017 Paris' } } };
 
-    findOneAndUpdateCustomer.returns(SinonMongoose.stubChainedQueries([customerResult], ['lean']));
+    findOneAndUpdateCustomer.returns(SinonMongoose.stubChainedQueries(customerResult, ['lean']));
 
     const result = await CustomerHelper.updateCustomer(customerId, payload, credentials);
 
@@ -995,7 +992,7 @@ describe('updateCustomer', () => {
     const payload = { contact: { secondaryAddress: { fullAddress: '27 rue des renaudes 75017 Paris' } } };
     const customerResult = { contact: { primaryAddress: { fullAddress: '27 rue des renaudes 75017 Paris' } } };
 
-    findOneAndUpdateCustomer.returns(SinonMongoose.stubChainedQueries([customerResult], ['lean']));
+    findOneAndUpdateCustomer.returns(SinonMongoose.stubChainedQueries(customerResult, ['lean']));
 
     const result = await CustomerHelper.updateCustomer(customerId, payload, credentials);
 
@@ -1026,7 +1023,7 @@ describe('updateCustomer', () => {
       },
     };
 
-    findOneAndUpdateCustomer.returns(SinonMongoose.stubChainedQueries([customerResult], ['lean']));
+    findOneAndUpdateCustomer.returns(SinonMongoose.stubChainedQueries(customerResult, ['lean']));
 
     const result = await CustomerHelper.updateCustomer(customerId, payload, credentials);
 
@@ -1052,7 +1049,7 @@ describe('updateCustomer', () => {
     const customerResult = { identity: { firstname: 'Molly', lastname: 'LeGrosChat' } };
     const payload = { stoppedAt: '2019-06-25T16:34:04.144Z', stopReason: 'hospitalization' };
 
-    findOneAndUpdateCustomer.returns(SinonMongoose.stubChainedQueries([customerResult], ['lean']));
+    findOneAndUpdateCustomer.returns(SinonMongoose.stubChainedQueries(customerResult, ['lean']));
 
     const result = await CustomerHelper.updateCustomer(customerId, payload, credentials);
 
@@ -1086,7 +1083,7 @@ describe('updateCustomer', () => {
     const payload = { identity: { firstname: 'Raymond', lastname: 'Holt' } };
     const customerResult = { identity: { firstname: 'Raymond', lastname: 'Holt' } };
 
-    findOneAndUpdateCustomer.returns(SinonMongoose.stubChainedQueries([customerResult], ['lean']));
+    findOneAndUpdateCustomer.returns(SinonMongoose.stubChainedQueries(customerResult, ['lean']));
 
     const result = await CustomerHelper.updateCustomer(customerId, payload, credentials);
 
@@ -1207,8 +1204,8 @@ describe('removeCustomer', () => {
       { customer: customerId, user: helper2Id, company: companyId },
     ];
 
-    findOne.returns(SinonMongoose.stubChainedQueries([customer], ['lean']));
-    findHelper.returns(SinonMongoose.stubChainedQueries([helpers], ['lean']));
+    findOne.returns(SinonMongoose.stubChainedQueries(customer, ['lean']));
+    findHelper.returns(SinonMongoose.stubChainedQueries(helpers, ['lean']));
 
     await CustomerHelper.removeCustomer(customerId);
 
@@ -1241,8 +1238,8 @@ describe('removeCustomer', () => {
     const helperId = new ObjectId();
     const helper = { customer: customerId, user: helperId, company: companyId };
 
-    findOne.returns(SinonMongoose.stubChainedQueries([customer], ['lean']));
-    findHelper.returns(SinonMongoose.stubChainedQueries([[helper]], ['lean']));
+    findOne.returns(SinonMongoose.stubChainedQueries(customer, ['lean']));
+    findHelper.returns(SinonMongoose.stubChainedQueries([helper], ['lean']));
 
     await CustomerHelper.removeCustomer(customerId);
 
@@ -1270,8 +1267,8 @@ describe('removeCustomer', () => {
     const customerId = new ObjectId();
     const customer = { _id: customerId, company: companyId };
 
-    findOne.returns(SinonMongoose.stubChainedQueries([customer], ['lean']));
-    findHelper.returns(SinonMongoose.stubChainedQueries([[]], ['lean']));
+    findOne.returns(SinonMongoose.stubChainedQueries(customer, ['lean']));
+    findHelper.returns(SinonMongoose.stubChainedQueries([], ['lean']));
 
     await CustomerHelper.removeCustomer(customerId);
 
@@ -1340,7 +1337,7 @@ describe('generateQRCode', () => {
     const customer = { _id: customerId, identity: { firstname: 'N\'Golo', lastname: 'Compté' } };
 
     toDataURL.returns('my_pic_in_base_64');
-    findOneCustomer.returns(SinonMongoose.stubChainedQueries([customer], ['lean']));
+    findOneCustomer.returns(SinonMongoose.stubChainedQueries(customer, ['lean']));
     getPdfContent.returns('template');
     generatePdf.returns('pdf');
 

--- a/tests/unit/helpers/dataExport.test.js
+++ b/tests/unit/helpers/dataExport.test.js
@@ -32,7 +32,7 @@ describe('exportCustomers', () => {
     const customers = [];
     const companyId = new ObjectId();
 
-    findCustomer.returns(SinonMongoose.stubChainedQueries([customers]));
+    findCustomer.returns(SinonMongoose.stubChainedQueries(customers));
 
     const credentials = { company: { _id: companyId } };
     const result = await ExportHelper.exportCustomers(credentials);
@@ -111,7 +111,7 @@ describe('exportCustomers', () => {
     ];
     const companyId = new ObjectId();
 
-    findCustomer.returns(SinonMongoose.stubChainedQueries([customers]));
+    findCustomer.returns(SinonMongoose.stubChainedQueries(customers));
 
     const credentials = { company: { _id: companyId } };
     const result = await ExportHelper.exportCustomers(credentials);
@@ -163,7 +163,7 @@ describe('exportCustomers', () => {
     const customers = [{}];
     const companyId = new ObjectId();
 
-    findCustomer.returns(SinonMongoose.stubChainedQueries([customers]));
+    findCustomer.returns(SinonMongoose.stubChainedQueries(customers));
 
     const credentials = { company: { _id: companyId } };
     const result = await ExportHelper.exportCustomers(credentials);
@@ -210,7 +210,7 @@ describe('exportAuxiliaries', () => {
 
   it('should return csv header', async () => {
     const credentials = { company: { _id: new ObjectId() } };
-    findUserCompany.returns(SinonMongoose.stubChainedQueries([[]], ['lean']));
+    findUserCompany.returns(SinonMongoose.stubChainedQueries([], ['lean']));
 
     const result = await ExportHelper.exportAuxiliaries(credentials);
 
@@ -256,9 +256,9 @@ describe('exportAuxiliaries', () => {
         establishment: { name: 'Test' },
       },
     ];
-    findUserCompany.returns(SinonMongoose.stubChainedQueries([userCompanies], ['lean']));
-    findRole.returns(SinonMongoose.stubChainedQueries([[{ _id: roleIds[0] }, { _id: roleIds[1] }]], ['lean']));
-    findUser.returns(SinonMongoose.stubChainedQueries([auxiliaries]));
+    findUserCompany.returns(SinonMongoose.stubChainedQueries(userCompanies, ['lean']));
+    findRole.returns(SinonMongoose.stubChainedQueries([{ _id: roleIds[0] }, { _id: roleIds[1] }], ['lean']));
+    findUser.returns(SinonMongoose.stubChainedQueries(auxiliaries));
 
     const result = await ExportHelper.exportAuxiliaries(credentials);
 
@@ -334,9 +334,9 @@ describe('exportAuxiliaries', () => {
       },
     ];
 
-    findUserCompany.returns(SinonMongoose.stubChainedQueries([userCompanies], ['lean']));
-    findRole.returns(SinonMongoose.stubChainedQueries([[{ _id: roleIds[0] }, { _id: roleIds[1] }]], ['lean']));
-    findUser.returns(SinonMongoose.stubChainedQueries([auxiliaries]));
+    findUserCompany.returns(SinonMongoose.stubChainedQueries(userCompanies, ['lean']));
+    findRole.returns(SinonMongoose.stubChainedQueries([{ _id: roleIds[0] }, { _id: roleIds[1] }], ['lean']));
+    findUser.returns(SinonMongoose.stubChainedQueries(auxiliaries));
 
     const result = await ExportHelper.exportAuxiliaries(credentials);
 
@@ -409,7 +409,7 @@ describe('exportHelpers', () => {
 
   it('should return csv header', async () => {
     const credentials = { company: { _id: new ObjectId() } };
-    findUserCompany.returns(SinonMongoose.stubChainedQueries([[]], ['lean']));
+    findUserCompany.returns(SinonMongoose.stubChainedQueries([], ['lean']));
 
     const result = await ExportHelper.exportHelpers(credentials);
 
@@ -464,9 +464,9 @@ describe('exportHelpers', () => {
       },
     }];
 
-    findUserCompany.returns(SinonMongoose.stubChainedQueries([userCompanies], ['lean']));
-    findOneRole.returns(SinonMongoose.stubChainedQueries([{ _id: roleId }], ['lean']));
-    findUser.returns(SinonMongoose.stubChainedQueries([helpers]));
+    findUserCompany.returns(SinonMongoose.stubChainedQueries(userCompanies, ['lean']));
+    findOneRole.returns(SinonMongoose.stubChainedQueries({ _id: roleId }, ['lean']));
+    findUser.returns(SinonMongoose.stubChainedQueries(helpers));
 
     const result = await ExportHelper.exportHelpers(credentials);
 
@@ -531,7 +531,7 @@ describe('exportSectors', () => {
   it('should return csv header', async () => {
     const credentials = { company: { _id: new ObjectId() } };
 
-    findSectorHistory.returns(SinonMongoose.stubChainedQueries([[]]));
+    findSectorHistory.returns(SinonMongoose.stubChainedQueries([]));
 
     const result = await ExportHelper.exportSectors(credentials);
 
@@ -569,7 +569,7 @@ describe('exportSectors', () => {
       endDate: '2019-12-10',
     }];
 
-    findSectorHistory.returns(SinonMongoose.stubChainedQueries([sectorHistories]));
+    findSectorHistory.returns(SinonMongoose.stubChainedQueries(sectorHistories));
 
     const result = await ExportHelper.exportSectors(credentials);
 
@@ -615,7 +615,7 @@ describe('exportReferents', () => {
   it('should return csv header', async () => {
     const credentials = { company: { _id: new ObjectId() } };
 
-    findReferentHistory.returns(SinonMongoose.stubChainedQueries([[]]));
+    findReferentHistory.returns(SinonMongoose.stubChainedQueries([]));
 
     const result = await ExportHelper.exportReferents(credentials);
 
@@ -660,7 +660,7 @@ describe('exportReferents', () => {
       },
     ];
 
-    findReferentHistory.returns(SinonMongoose.stubChainedQueries([referentHistories]));
+    findReferentHistory.returns(SinonMongoose.stubChainedQueries(referentHistories));
 
     const result = await ExportHelper.exportReferents(credentials);
 
@@ -815,7 +815,7 @@ describe('exportServices', () => {
     const services = [];
     const credentials = { company: { _id: new ObjectId() } };
 
-    findService.returns(SinonMongoose.stubChainedQueries([services]));
+    findService.returns(SinonMongoose.stubChainedQueries(services));
 
     const result = await ExportHelper.exportServices(credentials);
 
@@ -870,7 +870,7 @@ describe('exportServices', () => {
     ];
     const credentials = { company: { _id: new ObjectId() } };
 
-    findService.returns(SinonMongoose.stubChainedQueries([services]));
+    findService.returns(SinonMongoose.stubChainedQueries(services));
 
     const result = await ExportHelper.exportServices(credentials);
 
@@ -917,7 +917,7 @@ describe('exportSubscriptions', () => {
     const customers = [];
     const companyId = new ObjectId();
 
-    findCustomer.returns(SinonMongoose.stubChainedQueries([customers]));
+    findCustomer.returns(SinonMongoose.stubChainedQueries(customers));
 
     const credentials = { company: { _id: companyId } };
     const result = await ExportHelper.exportSubscriptions(credentials);
@@ -957,7 +957,7 @@ describe('exportSubscriptions', () => {
     ];
     const companyId = new ObjectId();
 
-    findCustomer.returns(SinonMongoose.stubChainedQueries([customers]));
+    findCustomer.returns(SinonMongoose.stubChainedQueries(customers));
 
     const credentials = { company: { _id: companyId } };
     const result = await ExportHelper.exportSubscriptions(credentials);

--- a/tests/unit/helpers/delivery.test.js
+++ b/tests/unit/helpers/delivery.test.js
@@ -41,10 +41,10 @@ describe('formatEvents', () => {
       { auxiliary: auxiliary1, customer: customer2, _id: event2 },
       { auxiliary: auxiliary2, customer: customer1, _id: event3 },
     ];
-    findUsers.returns(SinonMongoose.stubChainedQueries([[{ _id: auxiliary1 }, { _id: auxiliary2 }]]));
-    findCustomers.returns(SinonMongoose.stubChainedQueries([[{ _id: customer1 }, { _id: customer2 }]]));
+    findUsers.returns(SinonMongoose.stubChainedQueries([{ _id: auxiliary1 }, { _id: auxiliary2 }]));
+    findCustomers.returns(SinonMongoose.stubChainedQueries([{ _id: customer1 }, { _id: customer2 }]));
     findEventHistories.returns(SinonMongoose.stubChainedQueries(
-      [[{ event: { eventId: event1 } }, { event: { eventId: event2 } }, { event: { eventId: event3 } }]],
+      [{ event: { eventId: event1 } }, { event: { eventId: event2 } }, { event: { eventId: event3 } }],
       ['lean']
     ));
 
@@ -256,8 +256,8 @@ describe('getEvents', () => {
       { isBilled: false, _id: 'not_billed' },
       { isBilled: true, _id: 'billedbutwrongtpp', bills: { thirdPartyPayer: new ObjectId() } },
     ];
-    findCustomers.returns(SinonMongoose.stubChainedQueries([customers], ['lean']));
-    findEvents.returns(SinonMongoose.stubChainedQueries([events], ['lean']));
+    findCustomers.returns(SinonMongoose.stubChainedQueries(customers, ['lean']));
+    findEvents.returns(SinonMongoose.stubChainedQueries(events, ['lean']));
     formatNonBilledEvents.returns([{ isBilled: false, _id: 'not_billed', auxiliary: 'auxiliary' }]);
     formatBilledEvents.returns([{ isBilled: true, _id: 'billed', auxiliary: 'aux' }]);
 
@@ -322,7 +322,7 @@ describe('getFileName', () => {
     const tppId = new ObjectId();
     const query = { thirdPartyPayers: [tppId], month: '09-2021' };
     const thirdPartyPayer = { teletransmissionType: 'APA', companyCode: '440' };
-    findOne.returns(SinonMongoose.stubChainedQueries([thirdPartyPayer], ['lean']));
+    findOne.returns(SinonMongoose.stubChainedQueries(thirdPartyPayer, ['lean']));
 
     const result = await DeliveryHelper.getFileName(query);
 

--- a/tests/unit/helpers/distanceMatrix.test.js
+++ b/tests/unit/helpers/distanceMatrix.test.js
@@ -25,7 +25,7 @@ describe('getDistanceMatrices', () => {
   });
 
   it('should return a distance matrix', async () => {
-    find.returns(SinonMongoose.stubChainedQueries([distanceMatrix], ['lean']));
+    find.returns(SinonMongoose.stubChainedQueries(distanceMatrix, ['lean']));
 
     const credentials = { company: { _id: companyId } };
     const result = await DistanceMatrixHelper.getDistanceMatrices(credentials);

--- a/tests/unit/helpers/draftFinalPay.test.js
+++ b/tests/unit/helpers/draftFinalPay.test.js
@@ -247,9 +247,9 @@ describe('computeDraftFinalPay', () => {
     const existingPay = [{ auxiliary: new ObjectId() }];
 
     getEventsToPay.returns(payData);
-    surchargeFind.returns(SinonMongoose.stubChainedQueries([[{ _id: 'surcharge' }]], ['lean']));
-    companyFindOne.returns(SinonMongoose.stubChainedQueries([{}], ['lean']));
-    distanceMatrixFind.returns(SinonMongoose.stubChainedQueries([[{ _id: 'dm' }]], ['lean']));
+    surchargeFind.returns(SinonMongoose.stubChainedQueries([{ _id: 'surcharge' }], ['lean']));
+    companyFindOne.returns(SinonMongoose.stubChainedQueries({}, ['lean']));
+    distanceMatrixFind.returns(SinonMongoose.stubChainedQueries([{ _id: 'dm' }], ['lean']));
     findPay.returns(existingPay);
     getPreviousMonthPay.returns(prevPay);
     computeAuxiliaryDraftFinalPay.returns({ hoursBalance: 120 });
@@ -319,9 +319,9 @@ describe('computeDraftFinalPay', () => {
     const existingPay = [{ auxiliary: new ObjectId() }];
 
     getEventsToPay.returns(payData);
-    surchargeFind.returns(SinonMongoose.stubChainedQueries([[{ _id: 'surcharge' }]], ['lean']));
-    companyFindOne.returns(SinonMongoose.stubChainedQueries([{}], ['lean']));
-    distanceMatrixFind.returns(SinonMongoose.stubChainedQueries([[{ _id: 'dm' }]], ['lean']));
+    surchargeFind.returns(SinonMongoose.stubChainedQueries([{ _id: 'surcharge' }], ['lean']));
+    companyFindOne.returns(SinonMongoose.stubChainedQueries({}, ['lean']));
+    distanceMatrixFind.returns(SinonMongoose.stubChainedQueries([{ _id: 'dm' }], ['lean']));
     findPay.returns(existingPay);
     getPreviousMonthPay.returns(prevPay);
     computeAuxiliaryDraftFinalPay.returns({ hoursBalance: 120 });

--- a/tests/unit/helpers/draftPay.test.js
+++ b/tests/unit/helpers/draftPay.test.js
@@ -2060,9 +2060,9 @@ describe('computeDraftPay', () => {
     const companyId = new ObjectId();
     const credentials = { company: { _id: companyId } };
     const query = { startDate: '2019-05-01T00:00:00', endDate: '2019-05-31T23:59:59' };
-    companyFindOne.returns(SinonMongoose.stubChainedQueries([{ _id: companyId }], ['lean']));
-    surchargeFind.returns(SinonMongoose.stubChainedQueries([[{ _id: 'sur' }]], ['lean']));
-    distanceMatrixFind.returns(SinonMongoose.stubChainedQueries([[{ _id: 'dm' }]], ['lean']));
+    companyFindOne.returns(SinonMongoose.stubChainedQueries({ _id: companyId }, ['lean']));
+    surchargeFind.returns(SinonMongoose.stubChainedQueries([{ _id: 'sur' }], ['lean']));
+    distanceMatrixFind.returns(SinonMongoose.stubChainedQueries([{ _id: 'dm' }], ['lean']));
 
     const result = await DraftPayHelper.computeDraftPay([], query, credentials);
 
@@ -2104,9 +2104,9 @@ describe('computeDraftPay', () => {
 
     getEventsToPay.returns(payData);
     getPreviousMonthPay.returns(prevPay);
-    companyFindOne.returns(SinonMongoose.stubChainedQueries([{ _id: companyId }], ['lean']));
-    surchargeFind.returns(SinonMongoose.stubChainedQueries([[{ _id: 'sur' }]], ['lean']));
-    distanceMatrixFind.returns(SinonMongoose.stubChainedQueries([[{ _id: 'dm' }]], ['lean']));
+    companyFindOne.returns(SinonMongoose.stubChainedQueries({ _id: companyId }, ['lean']));
+    surchargeFind.returns(SinonMongoose.stubChainedQueries([{ _id: 'sur' }], ['lean']));
+    distanceMatrixFind.returns(SinonMongoose.stubChainedQueries([{ _id: 'dm' }], ['lean']));
     computeAuxiliaryDraftPay.returns({ hoursBalance: 120 });
     getContract.returns(null);
 
@@ -2149,9 +2149,9 @@ describe('computeDraftPay', () => {
 
     getEventsToPay.returns(payData);
     getPreviousMonthPay.returns(prevPay);
-    companyFindOne.returns(SinonMongoose.stubChainedQueries([{ _id: companyId }], ['lean']));
-    surchargeFind.returns(SinonMongoose.stubChainedQueries([[{ _id: 'sur' }]], ['lean']));
-    distanceMatrixFind.returns(SinonMongoose.stubChainedQueries([[{ _id: 'dm' }]], ['lean']));
+    companyFindOne.returns(SinonMongoose.stubChainedQueries({ _id: companyId }, ['lean']));
+    surchargeFind.returns(SinonMongoose.stubChainedQueries([{ _id: 'sur' }], ['lean']));
+    distanceMatrixFind.returns(SinonMongoose.stubChainedQueries([{ _id: 'dm' }], ['lean']));
     computeAuxiliaryDraftPay.returns({ hoursBalance: 120 });
     getContract.returns({ _id: '1234567890' });
 
@@ -2197,9 +2197,9 @@ describe('computeDraftPay', () => {
     }];
 
     getEventsToPay.returns(payData);
-    companyFindOne.returns(SinonMongoose.stubChainedQueries([{ _id: companyId }], ['lean']));
-    surchargeFind.returns(SinonMongoose.stubChainedQueries([[{ _id: 'sur' }]], ['lean']));
-    distanceMatrixFind.returns(SinonMongoose.stubChainedQueries([[{ _id: 'dm' }]], ['lean']));
+    companyFindOne.returns(SinonMongoose.stubChainedQueries({ _id: companyId }, ['lean']));
+    surchargeFind.returns(SinonMongoose.stubChainedQueries([{ _id: 'sur' }], ['lean']));
+    distanceMatrixFind.returns(SinonMongoose.stubChainedQueries([{ _id: 'dm' }], ['lean']));
     computeAuxiliaryDraftPay.returns({ hoursBalance: 120 });
     getContract.returns({ _id: '1234567890' });
 

--- a/tests/unit/helpers/draftbills.test.js
+++ b/tests/unit/helpers/draftbills.test.js
@@ -113,7 +113,7 @@ describe('populateFundings', () => {
     const tpps = [{ _id: tppId, billingMode: BILLING_DIRECT }];
     const funding = { ...omit(fundings[0], ['versions']) };
     mergeLastVersionWithBaseObjectStub.returns(funding);
-    findOneFundingHistory.returns(SinonMongoose.stubChainedQueries([null], ['lean']));
+    findOneFundingHistory.returns(SinonMongoose.stubChainedQueries(null, ['lean']));
 
     const result = await DraftBillsHelper.populateFundings(fundings, new Date(), tpps, companyId);
 
@@ -139,7 +139,7 @@ describe('populateFundings', () => {
     const funding = { ...fundings[0].versions[0], ...omit(fundings[0], ['versions']) };
     const returnedHistory = { careHours: 4, fundingId };
     mergeLastVersionWithBaseObjectStub.returns(funding);
-    findOneFundingHistory.returns(SinonMongoose.stubChainedQueries([returnedHistory], ['lean']));
+    findOneFundingHistory.returns(SinonMongoose.stubChainedQueries(returnedHistory, ['lean']));
 
     const result = await DraftBillsHelper.populateFundings(fundings, new Date(), tpps, companyId);
 
@@ -164,7 +164,7 @@ describe('populateFundings', () => {
     const tpps = [{ _id: tppId, billingMode: BILLING_DIRECT }];
     const funding = { ...fundings[0].versions[0], ...omit(fundings[0], ['versions']) };
     mergeLastVersionWithBaseObjectStub.returns(funding);
-    findOneFundingHistory.returns(SinonMongoose.stubChainedQueries([null], ['lean']));
+    findOneFundingHistory.returns(SinonMongoose.stubChainedQueries(null, ['lean']));
 
     const result = await DraftBillsHelper.populateFundings(fundings, new Date(), tpps, companyId);
 
@@ -193,7 +193,7 @@ describe('populateFundings', () => {
     ];
     const funding = { ...fundings[0].versions[0], ...omit(fundings[0], ['versions']) };
     mergeLastVersionWithBaseObjectStub.returns(funding);
-    findFundingHistory.returns(SinonMongoose.stubChainedQueries([returnedHistories], ['lean']));
+    findFundingHistory.returns(SinonMongoose.stubChainedQueries(returnedHistories, ['lean']));
 
     const result = await DraftBillsHelper.populateFundings(fundings, new Date('2019/03/10'), tpps, companyId);
 
@@ -1298,9 +1298,9 @@ describe('getDraftBillsList', () => {
     const query = { endDate: '2019-12-25T07:00:00', billingStartDate: '2019-12-31T07:00:00' };
 
     getEventsToBill.returns([]);
-    findThirdPartyPayer.returns(SinonMongoose.stubChainedQueries([null], ['lean']));
-    findSurcharge.returns(SinonMongoose.stubChainedQueries([bddSurcharges], ['lean']));
-    findBillingItem.returns(SinonMongoose.stubChainedQueries([bddBillingItems], ['lean']));
+    findThirdPartyPayer.returns(SinonMongoose.stubChainedQueries(null, ['lean']));
+    findSurcharge.returns(SinonMongoose.stubChainedQueries(bddSurcharges, ['lean']));
+    findBillingItem.returns(SinonMongoose.stubChainedQueries(bddBillingItems, ['lean']));
     formatBillingItems.returns([]);
 
     const result = await DraftBillsHelper.getDraftBillsList(query, credentials);
@@ -1333,9 +1333,9 @@ describe('getDraftBillsList', () => {
     const bddBillingItems = [{ _id: new ObjectId(), defaultUnitAmount: 2 }];
     const query = { endDate: '2019-12-25T07:00:00', billingStartDate: '2019-12-31T07:00:00' };
 
-    findThirdPartyPayer.returns(SinonMongoose.stubChainedQueries([thirdPartyPayersList], ['lean']));
-    findSurcharge.returns(SinonMongoose.stubChainedQueries([bddSurcharges], ['lean']));
-    findBillingItem.returns(SinonMongoose.stubChainedQueries([bddBillingItems], ['lean']));
+    findThirdPartyPayer.returns(SinonMongoose.stubChainedQueries(thirdPartyPayersList, ['lean']));
+    findSurcharge.returns(SinonMongoose.stubChainedQueries(bddSurcharges, ['lean']));
+    findBillingItem.returns(SinonMongoose.stubChainedQueries(bddBillingItems, ['lean']));
     getEventsToBill.returns([
       {
         customer: { _id: 'ghjk', identity: { firstname: 'Toto' } },
@@ -1466,9 +1466,9 @@ describe('getDraftBillsList', () => {
     const bddBillingItems = [{ _id: new ObjectId(), defaultUnitAmount: 2 }];
     const query = { endDate: '2019-12-25T07:00:00', billingStartDate: '2019-12-31T07:00:00' };
 
-    findThirdPartyPayer.returns(SinonMongoose.stubChainedQueries([null], ['lean']));
-    findSurcharge.returns(SinonMongoose.stubChainedQueries([bddSurcharges], ['lean']));
-    findBillingItem.returns(SinonMongoose.stubChainedQueries([bddBillingItems], ['lean']));
+    findThirdPartyPayer.returns(SinonMongoose.stubChainedQueries(null, ['lean']));
+    findSurcharge.returns(SinonMongoose.stubChainedQueries(bddSurcharges, ['lean']));
+    findBillingItem.returns(SinonMongoose.stubChainedQueries(bddBillingItems, ['lean']));
     getEventsToBill.returns([
       {
         customer: { _id: 'ghjk', identity: { firstname: 'Toto' } },

--- a/tests/unit/helpers/establishments.test.js
+++ b/tests/unit/helpers/establishments.test.js
@@ -36,7 +36,7 @@ describe('create', () => {
     const credentials = { company: { _id: new ObjectId() } };
     const payloadWithCompany = { ...payload, company: credentials.company._id };
 
-    create.returns(SinonMongoose.stubChainedQueries([payloadWithCompany], ['toObject']));
+    create.returns(SinonMongoose.stubChainedQueries(payloadWithCompany, ['toObject']));
 
     const result = await EstablishmentsHelper.create(payload, credentials);
 
@@ -61,7 +61,7 @@ describe('update', () => {
     const payload = { siret: '13605658901234' };
     const establishmentId = new ObjectId();
 
-    findOneAndUpdate.returns(SinonMongoose.stubChainedQueries([{ _id: establishmentId }], ['lean']));
+    findOneAndUpdate.returns(SinonMongoose.stubChainedQueries({ _id: establishmentId }, ['lean']));
 
     const result = await EstablishmentsHelper.update(establishmentId, payload);
 
@@ -89,7 +89,7 @@ describe('list', () => {
     const credentials = { company: { _id: new ObjectId() } };
     const establishments = [{ _id: new ObjectId() }, { _id: new ObjectId() }];
 
-    find.returns(SinonMongoose.stubChainedQueries([establishments]));
+    find.returns(SinonMongoose.stubChainedQueries(establishments));
 
     await EstablishmentsHelper.list(credentials);
 

--- a/tests/unit/helpers/eventHistories.test.js
+++ b/tests/unit/helpers/eventHistories.test.js
@@ -155,7 +155,7 @@ describe('createEventHistory', () => {
     const companyId = new ObjectId();
     const payload = { _id: new ObjectId(), auxiliary: auxiliaryId.toHexString() };
     const credentials = { _id: new ObjectId(), company: { _id: companyId } };
-    findOne.returns(SinonMongoose.stubChainedQueries([{ sector: sectorId }]));
+    findOne.returns(SinonMongoose.stubChainedQueries({ sector: sectorId }));
 
     await EventHistoryHelper.createEventHistory(payload, credentials, 'event_creation');
 
@@ -650,7 +650,7 @@ describe('formatHistoryForAuxiliaryUpdate', () => {
     const mainInfo = { createdBy: 'james bond', action: 'event_update', event: { type: 'intervention' } };
     const payload = { auxiliary: 'qwertyuiop' };
     const event = { auxiliary: auxiliaryId };
-    find.returns(SinonMongoose.stubChainedQueries([[{ _id: auxiliaryId, sector: sectorId }]]));
+    find.returns(SinonMongoose.stubChainedQueries([{ _id: auxiliaryId, sector: sectorId }]));
 
     const result = await EventHistoryHelper.formatHistoryForAuxiliaryUpdate(mainInfo, payload, event, companyId);
 
@@ -680,7 +680,7 @@ describe('formatHistoryForAuxiliaryUpdate', () => {
     const mainInfo = { createdBy: 'james bond', action: 'event_update', event: { type: 'intervention' } };
     const payload = { sector: sectorId };
     const event = { auxiliary: auxiliaryId };
-    findOne.returns(SinonMongoose.stubChainedQueries([{ _id: auxiliaryId, sector: sectorId }]));
+    findOne.returns(SinonMongoose.stubChainedQueries({ _id: auxiliaryId, sector: sectorId }));
 
     const result = await EventHistoryHelper.formatHistoryForAuxiliaryUpdate(mainInfo, payload, event, companyId);
 
@@ -711,7 +711,7 @@ describe('formatHistoryForAuxiliaryUpdate', () => {
     const mainInfo = { createdBy: 'james bond', action: 'event_update', event: { type: 'intervention' } };
     const payload = { auxiliary: auxiliaryId };
     const event = { sector: eventSectorId };
-    findOne.returns(SinonMongoose.stubChainedQueries([{ _id: auxiliaryId, sector: sectorId }]));
+    findOne.returns(SinonMongoose.stubChainedQueries({ _id: auxiliaryId, sector: sectorId }));
 
     const result = await EventHistoryHelper.formatHistoryForAuxiliaryUpdate(mainInfo, payload, event, companyId);
 
@@ -757,7 +757,7 @@ describe('formatHistoryForCancelUpdate', () => {
       cancel: { reason: 'toto', condition: 'tata' },
       auxiliary: auxiliaryId.toHexString(),
     };
-    findOne.returns(SinonMongoose.stubChainedQueries([{ _id: auxiliaryId, sector: sectorId }]));
+    findOne.returns(SinonMongoose.stubChainedQueries({ _id: auxiliaryId, sector: sectorId }));
 
     const result = await EventHistoryHelper.formatHistoryForCancelUpdate(mainInfo, payload, companyId);
 
@@ -837,7 +837,7 @@ describe('formatHistoryForDatesUpdate', () => {
       auxiliary: auxiliaryId.toHexString(),
     };
     const event = { startDate: '2019-01-21T09:38:18', endDate: '2019-01-21T10:38:18' };
-    findOne.returns(SinonMongoose.stubChainedQueries([{ _id: auxiliaryId, sector: sectorId }]));
+    findOne.returns(SinonMongoose.stubChainedQueries({ _id: auxiliaryId, sector: sectorId }));
 
     const result = await EventHistoryHelper.formatHistoryForDatesUpdate(mainInfo, payload, event, companyId);
 
@@ -924,7 +924,7 @@ describe('formatHistoryForHoursUpdate', () => {
       auxiliary: auxiliaryId.toHexString(),
     };
     const event = { startDate: '2019-01-21T09:38:18', endDate: '2019-01-21T10:38:18' };
-    findOne.returns(SinonMongoose.stubChainedQueries([{ _id: auxiliaryId, sector: sectorId }]));
+    findOne.returns(SinonMongoose.stubChainedQueries({ _id: auxiliaryId, sector: sectorId }));
 
     const result = await EventHistoryHelper.formatHistoryForHoursUpdate(mainInfo, payload, event, companyId);
 
@@ -1100,9 +1100,9 @@ describe('createTimeStampCancellationHistory', () => {
     const auxiliaryId = new ObjectId();
     const sectorId = new ObjectId();
 
-    findOne.returns(SinonMongoose.stubChainedQueries([{ _id: eventHistoryId, event: { eventId } }], ['lean']));
-    findOneEvent.returns(SinonMongoose.stubChainedQueries([{ _id: eventId, auxiliary: auxiliaryId }], ['lean']));
-    findOneUser.returns(SinonMongoose.stubChainedQueries([{ _id: auxiliaryId, sector: sectorId }]));
+    findOne.returns(SinonMongoose.stubChainedQueries({ _id: eventHistoryId, event: { eventId } }, ['lean']));
+    findOneEvent.returns(SinonMongoose.stubChainedQueries({ _id: eventId, auxiliary: auxiliaryId }, ['lean']));
+    findOneUser.returns(SinonMongoose.stubChainedQueries({ _id: auxiliaryId, sector: sectorId }));
 
     await EventHistoryHelper.createTimeStampCancellationHistory(eventHistoryId, payload, credentials);
 
@@ -1147,8 +1147,8 @@ describe('createTimeStampCancellationHistory', () => {
     const eventId = new ObjectId();
     const sectorId = new ObjectId();
 
-    findOne.returns(SinonMongoose.stubChainedQueries([{ _id: eventHistoryId, event: { eventId } }], ['lean']));
-    findOneEvent.returns(SinonMongoose.stubChainedQueries([{ _id: eventId, sector: sectorId }], ['lean']));
+    findOne.returns(SinonMongoose.stubChainedQueries({ _id: eventHistoryId, event: { eventId } }, ['lean']));
+    findOneEvent.returns(SinonMongoose.stubChainedQueries({ _id: eventId, sector: sectorId }, ['lean']));
 
     await EventHistoryHelper.createTimeStampCancellationHistory(eventHistoryId, payload, credentials);
 

--- a/tests/unit/helpers/events.test.js
+++ b/tests/unit/helpers/events.test.js
@@ -337,7 +337,7 @@ describe('updateEvent', () => {
 
     isRepetitionValid.returns(true);
     isUpdateAllowed.returns(true);
-    findOne.returns(SinonMongoose.stubChainedQueries([event]));
+    findOne.returns(SinonMongoose.stubChainedQueries(event));
 
     await EventHelper.updateEvent(event, payload, credentials);
 
@@ -425,7 +425,7 @@ describe('updateEvent', () => {
     shouldDetachFromRepetition.returns(true);
     isUpdateAllowed.returns(true);
     formatEditionPayload.returns({ $set: { _id: eventId }, $unset: {} });
-    findOne.returns(SinonMongoose.stubChainedQueries([{ ...event, updated: 1 }]));
+    findOne.returns(SinonMongoose.stubChainedQueries({ ...event, updated: 1 }));
 
     await EventHelper.updateEvent(event, payload, credentials);
 
@@ -480,7 +480,7 @@ describe('updateEvent', () => {
     isRepetition.returns(false);
     isUpdateAllowed.returns(true);
     formatEditionPayload.returns({ $set: { _id: eventId }, $unset: {} });
-    findOne.returns(SinonMongoose.stubChainedQueries([{ ...event, updated: 1 }]));
+    findOne.returns(SinonMongoose.stubChainedQueries({ ...event, updated: 1 }));
 
     await EventHelper.updateEvent(event, payload, credentials);
 
@@ -549,7 +549,7 @@ describe('listForCreditNotes', () => {
       'bills.inclTaxesTpp': { $exists: false },
     };
 
-    findEvent.returns(SinonMongoose.stubChainedQueries([events], ['sort', 'lean']));
+    findEvent.returns(SinonMongoose.stubChainedQueries(events, ['sort', 'lean']));
 
     const result = await EventHelper.listForCreditNotes(payload, { company: { _id: companyId } });
 
@@ -580,7 +580,7 @@ describe('listForCreditNotes', () => {
       'bills.thirdPartyPayer': payload.thirdPartyPayer,
     };
 
-    findEvent.returns(SinonMongoose.stubChainedQueries([[{ type: 'intervention' }]], ['sort', 'lean']));
+    findEvent.returns(SinonMongoose.stubChainedQueries([{ type: 'intervention' }], ['sort', 'lean']));
 
     const result = await EventHelper.listForCreditNotes(payload, { company: { _id: companyId } });
 
@@ -614,7 +614,7 @@ describe('listForCreditNotes', () => {
       $or: [{ isBilled: true }, { _id: { $in: creditNote.events.map(event => event.eventId) } }],
     };
 
-    findEvent.returns(SinonMongoose.stubChainedQueries([events], ['sort', 'lean']));
+    findEvent.returns(SinonMongoose.stubChainedQueries(events, ['sort', 'lean']));
 
     const result = await EventHelper.listForCreditNotes(payload, { company: { _id: companyId } }, creditNote);
 
@@ -1165,7 +1165,7 @@ describe('detachAuxiliaryFromEvent', () => {
     const companyId = new ObjectId();
 
     const auxiliary = { sector: 'sector' };
-    findOneUser.returns(SinonMongoose.stubChainedQueries([auxiliary]));
+    findOneUser.returns(SinonMongoose.stubChainedQueries(auxiliary));
 
     const result = await EventHelper.detachAuxiliaryFromEvent(event, companyId);
 
@@ -1248,7 +1248,7 @@ describe('createEvent', () => {
     isCreationAllowed.returns(true);
     isRepetition.returns(false);
     getEvent.returns(event);
-    createEvent.returns(SinonMongoose.stubChainedQueries([event], ['toObject']));
+    createEvent.returns(SinonMongoose.stubChainedQueries(event, ['toObject']));
 
     await EventHelper.createEvent(payload, credentials);
 
@@ -1280,7 +1280,7 @@ describe('createEvent', () => {
     isRepetition.returns(true);
     detachAuxiliaryFromEvent.returns(detachedEvent);
     getEvent.returns(detachedEvent);
-    createEvent.returns(SinonMongoose.stubChainedQueries([detachedEvent], ['toObject']));
+    createEvent.returns(SinonMongoose.stubChainedQueries(detachedEvent, ['toObject']));
 
     await EventHelper.createEvent(newEvent, credentials);
 
@@ -1309,7 +1309,7 @@ describe('createEvent', () => {
 
     isCreationAllowed.returns(true);
     hasConflicts.returns(false);
-    createEvent.returns(SinonMongoose.stubChainedQueries([event], ['toObject']));
+    createEvent.returns(SinonMongoose.stubChainedQueries(event, ['toObject']));
     getEvent.returns(event);
     isRepetition.returns(true);
 
@@ -1349,9 +1349,9 @@ describe('createEvent', () => {
 
     isCreationAllowed.returns(true);
     isRepetition.returns(false);
-    createEvent.returns(SinonMongoose.stubChainedQueries([event], ['toObject']));
+    createEvent.returns(SinonMongoose.stubChainedQueries(event, ['toObject']));
     getEvent.returns(payload);
-    findOneUser.returns(SinonMongoose.stubChainedQueries([auxiliary]));
+    findOneUser.returns(SinonMongoose.stubChainedQueries(auxiliary));
 
     await EventHelper.createEvent(payload, credentials);
 
@@ -1457,7 +1457,7 @@ describe('unassignConflictInterventions', () => {
     const events = [new Event({ _id: new ObjectId() }), new Event({ _id: new ObjectId() })];
 
     formatEventsInConflictQuery.returns(query);
-    findEvent.returns(SinonMongoose.stubChainedQueries([events], ['lean']));
+    findEvent.returns(SinonMongoose.stubChainedQueries(events, ['lean']));
 
     await EventHelper.unassignConflictInterventions(dates, auxiliaryId, credentials);
 
@@ -1562,7 +1562,7 @@ describe('deleteEventsAndRepetition', () => {
     };
     const events = [{ _id: '1234567890' }, { _id: 'qwertyuiop' }, { _id: 'asdfghjkl' }];
 
-    find.returns(SinonMongoose.stubChainedQueries([events], ['lean']));
+    find.returns(SinonMongoose.stubChainedQueries(events, ['lean']));
 
     await EventHelper.deleteEventsAndRepetition(query, false, credentials);
 
@@ -1625,7 +1625,7 @@ describe('deleteEventsAndRepetition', () => {
       [parentId]: [events[1], events[2]],
     };
 
-    find.returns(SinonMongoose.stubChainedQueries([events], ['lean']));
+    find.returns(SinonMongoose.stubChainedQueries(events, ['lean']));
 
     await EventHelper.deleteEventsAndRepetition(query, true, credentials);
 
@@ -1649,7 +1649,7 @@ describe('deleteEventsAndRepetition', () => {
       { _id: 'asdfghjkl', type: INTERVENTION, isBilled: true },
     ];
 
-    find.returns(SinonMongoose.stubChainedQueries([events], ['lean']));
+    find.returns(SinonMongoose.stubChainedQueries(events, ['lean']));
     checkDeletionIsAllowed.throws(Boom.conflict('Vous ne pouvez pas supprimer un évènement facturé.'));
 
     try {
@@ -1678,7 +1678,7 @@ describe('deleteEventsAndRepetition', () => {
       { _id: 'asdfghjkl', type: INTERVENTION },
     ];
 
-    find.returns(SinonMongoose.stubChainedQueries([events], ['lean']));
+    find.returns(SinonMongoose.stubChainedQueries(events, ['lean']));
     checkDeletionIsAllowed.throws(Boom.conflict('Vous ne pouvez pas supprimer un évènement horodaté.'));
 
     try {
@@ -1896,8 +1896,8 @@ describe('workingStats', () => {
     getContractWeekInfoStub.returns(contractInfo);
     getPayFromEventsStub.returns(hours);
     getPayFromAbsencesStub.returns(absencesHours);
-    findUser.returns(SinonMongoose.stubChainedQueries([auxiliaries]));
-    findDistanceMatrix.returns(SinonMongoose.stubChainedQueries([distanceMatrix], ['lean']));
+    findUser.returns(SinonMongoose.stubChainedQueries(auxiliaries));
+    findDistanceMatrix.returns(SinonMongoose.stubChainedQueries(distanceMatrix, ['lean']));
 
     const result = await EventHelper.workingStats(query, credentials);
 
@@ -1944,9 +1944,9 @@ describe('workingStats', () => {
     getContractWeekInfoStub.returns(contractInfo);
     getPayFromEventsStub.returns(hours);
     getPayFromAbsencesStub.returns(absencesHours);
-    findUser.returns(SinonMongoose.stubChainedQueries([auxiliaries]));
-    findUserCompany.returns(SinonMongoose.stubChainedQueries([users], ['lean']));
-    findDistanceMatrix.returns(SinonMongoose.stubChainedQueries([distanceMatrix], ['lean']));
+    findUser.returns(SinonMongoose.stubChainedQueries(auxiliaries));
+    findUserCompany.returns(SinonMongoose.stubChainedQueries(users, ['lean']));
+    findDistanceMatrix.returns(SinonMongoose.stubChainedQueries(distanceMatrix, ['lean']));
 
     const result = await EventHelper.workingStats(queryWithoutAuxiliary, credentials);
     const expectedResult = {};
@@ -1988,8 +1988,8 @@ describe('workingStats', () => {
 
   it('should return {} if no contract in auxiliaries', async () => {
     getEventsToPayStub.returns([{ auxiliary: { _id: auxiliaryId } }]);
-    findUser.returns(SinonMongoose.stubChainedQueries([[{ _id: auxiliaryId, firstname: 'toto' }]]));
-    findDistanceMatrix.returns(SinonMongoose.stubChainedQueries([distanceMatrix], ['lean']));
+    findUser.returns(SinonMongoose.stubChainedQueries([{ _id: auxiliaryId, firstname: 'toto' }]));
+    findDistanceMatrix.returns(SinonMongoose.stubChainedQueries(distanceMatrix, ['lean']));
 
     const result = await EventHelper.workingStats(query, credentials);
     expect(result).toEqual({});
@@ -2019,8 +2019,8 @@ describe('workingStats', () => {
 
     getEventsToPayStub.returns([{ auxiliary: { _id: auxiliaryId } }]);
     getContractStub.returns();
-    findUser.returns(SinonMongoose.stubChainedQueries([[{ _id: auxiliaryId, firstname: 'toto', contracts }]]));
-    findDistanceMatrix.returns(SinonMongoose.stubChainedQueries([distanceMatrix], ['lean']));
+    findUser.returns(SinonMongoose.stubChainedQueries([{ _id: auxiliaryId, firstname: 'toto', contracts }]));
+    findDistanceMatrix.returns(SinonMongoose.stubChainedQueries(distanceMatrix, ['lean']));
 
     const result = await EventHelper.workingStats(query, credentials);
     expect(result).toEqual({});

--- a/tests/unit/helpers/eventsRepetition.test.js
+++ b/tests/unit/helpers/eventsRepetition.test.js
@@ -278,7 +278,7 @@ describe('createRepeatedEvents', () => {
     formatRepeatedPayload.onCall(0).returns(repeatedEvents[0]);
     formatRepeatedPayload.onCall(1).returns(repeatedEvents[1]);
     formatRepeatedPayload.onCall(2).returns(repeatedEvents[2]);
-    customerFindOne.returns(SinonMongoose.stubChainedQueries([null], ['lean']));
+    customerFindOne.returns(SinonMongoose.stubChainedQueries(null, ['lean']));
 
     await EventsRepetitionHelper.createRepeatedEvents(event, range, sector, false);
 
@@ -314,7 +314,7 @@ describe('createRepeatedEvents', () => {
 
     formatRepeatedPayload.onCall(0).returns(fridayEvent);
     formatRepeatedPayload.onCall(1).returns(mondayEvent);
-    customerFindOne.returns(SinonMongoose.stubChainedQueries([null], ['lean']));
+    customerFindOne.returns(SinonMongoose.stubChainedQueries(null, ['lean']));
 
     await EventsRepetitionHelper.createRepeatedEvents(event, range, sector, true);
 
@@ -349,7 +349,7 @@ describe('createRepeatedEvents', () => {
     formatRepeatedPayload.onCall(0).returns(repeatedEvents[0]);
     formatRepeatedPayload.onCall(1).returns(repeatedEvents[1]);
     formatRepeatedPayload.onCall(2).returns(repeatedEvents[2]);
-    customerFindOne.returns(SinonMongoose.stubChainedQueries([customer], ['lean']));
+    customerFindOne.returns(SinonMongoose.stubChainedQueries(customer, ['lean']));
 
     await EventsRepetitionHelper.createRepeatedEvents(event, range, sector, false);
 
@@ -622,7 +622,7 @@ describe('createRepetitions', () => {
     const payload = { _id: '1234567890', repetition: { frequency: 'every_day', parentId: '0987654321' } };
     const event = new Event({ repetition: { frequency: EVERY_WEEK }, company: new ObjectId(), auxiliary: auxiliaryId });
 
-    findOne.returns(SinonMongoose.stubChainedQueries([{ _id: auxiliaryId, sector: sectorId }]));
+    findOne.returns(SinonMongoose.stubChainedQueries({ _id: auxiliaryId, sector: sectorId }));
 
     await EventsRepetitionHelper.createRepetitions(event, payload, credentials);
 
@@ -646,7 +646,7 @@ describe('createRepetitions', () => {
     const payload = { _id: '1234567890', repetition: { frequency: 'every_day', parentId: '0987654321' } };
     const event = new Event({ company: new ObjectId(), auxiliary: auxiliaryId });
 
-    findOne.returns(SinonMongoose.stubChainedQueries([{ _id: auxiliaryId, sector: sectorId }]));
+    findOne.returns(SinonMongoose.stubChainedQueries({ _id: auxiliaryId, sector: sectorId }));
 
     await EventsRepetitionHelper.createRepetitions(event, payload, credentials);
 
@@ -780,7 +780,7 @@ describe('updateRepetition', () => {
       },
     ];
 
-    find.returns(SinonMongoose.stubChainedQueries([events], ['lean']));
+    find.returns(SinonMongoose.stubChainedQueries(events, ['lean']));
     hasConflicts.returns(false);
     isAbsent.returns(false);
 
@@ -858,9 +858,9 @@ describe('updateRepetition', () => {
       },
       $unset: { auxiliary: '' },
     });
-    findOneUser.returns(SinonMongoose.stubChainedQueries([{ _id: auxiliaryId, sector: sectorId }]));
+    findOneUser.returns(SinonMongoose.stubChainedQueries({ _id: auxiliaryId, sector: sectorId }));
     hasConflicts.returns(true);
-    find.returns(SinonMongoose.stubChainedQueries([events], ['lean']));
+    find.returns(SinonMongoose.stubChainedQueries(events, ['lean']));
 
     await EventsRepetitionHelper.updateRepetition(event, payload, credentials);
 
@@ -965,8 +965,8 @@ describe('updateRepetition', () => {
       $unset: { auxiliary: '' },
     });
     hasConflicts.returns(true);
-    findOneUser.returns(SinonMongoose.stubChainedQueries([{ _id: auxiliaryId, sector: sectorId }]));
-    find.returns(SinonMongoose.stubChainedQueries([events], ['lean']));
+    findOneUser.returns(SinonMongoose.stubChainedQueries({ _id: auxiliaryId, sector: sectorId }));
+    find.returns(SinonMongoose.stubChainedQueries(events, ['lean']));
 
     await EventsRepetitionHelper.updateRepetition(event, payload, credentials);
 
@@ -1060,8 +1060,8 @@ describe('updateRepetition', () => {
     ];
 
     hasConflicts.returns(true);
-    findOneUser.returns(SinonMongoose.stubChainedQueries([{ _id: auxiliaryId, sector: sectorId }]));
-    find.returns(SinonMongoose.stubChainedQueries([events], ['lean']));
+    findOneUser.returns(SinonMongoose.stubChainedQueries({ _id: auxiliaryId, sector: sectorId }));
+    find.returns(SinonMongoose.stubChainedQueries(events, ['lean']));
 
     await EventsRepetitionHelper.updateRepetition(event, payload, credentials);
 
@@ -1154,7 +1154,7 @@ describe('updateRepetition', () => {
       },
     ];
 
-    find.returns(SinonMongoose.stubChainedQueries([events], ['lean']));
+    find.returns(SinonMongoose.stubChainedQueries(events, ['lean']));
     hasConflicts.returns(false);
     isAbsent.onCall(0).returns(false);
     isAbsent.onCall(1).returns(false);

--- a/tests/unit/helpers/eventsValidation.test.js
+++ b/tests/unit/helpers/eventsValidation.test.js
@@ -84,7 +84,7 @@ describe('isUserContractValidOnEventDates', () => {
     const event = { auxiliary: new ObjectId() };
     const user = { _id: event.auxiliary };
 
-    findOne.returns(SinonMongoose.stubChainedQueries([user]));
+    findOne.returns(SinonMongoose.stubChainedQueries(user));
 
     const result = await EventsValidationHelper.isUserContractValidOnEventDates(event);
 
@@ -103,7 +103,7 @@ describe('isUserContractValidOnEventDates', () => {
     const event = { auxiliary: new ObjectId() };
     const user = { _id: event.auxiliary, contracts: [] };
 
-    findOne.returns(SinonMongoose.stubChainedQueries([user]));
+    findOne.returns(SinonMongoose.stubChainedQueries(user));
 
     const result = await EventsValidationHelper.isUserContractValidOnEventDates(event);
 
@@ -123,7 +123,7 @@ describe('isUserContractValidOnEventDates', () => {
     const contract = { user: event.auxiliary, startDate: '2020-12-05T00:00:00' };
     const user = { _id: event.auxiliary, contracts: [contract] };
 
-    findOne.returns(SinonMongoose.stubChainedQueries([user]));
+    findOne.returns(SinonMongoose.stubChainedQueries(user));
 
     const result = await EventsValidationHelper.isUserContractValidOnEventDates(event);
 
@@ -143,7 +143,7 @@ describe('isUserContractValidOnEventDates', () => {
     const contract = { user: event.auxiliary, startDate: '2020-01-04T00:00:00' };
     const user = { _id: event.auxiliary, contracts: [contract] };
 
-    findOne.returns(SinonMongoose.stubChainedQueries([user]));
+    findOne.returns(SinonMongoose.stubChainedQueries(user));
 
     const result = await EventsValidationHelper.isUserContractValidOnEventDates(event);
 
@@ -168,7 +168,7 @@ describe('isUserContractValidOnEventDates', () => {
     const contract = { user: event.auxiliary, startDate: '2020-05-04T00:00:00' };
     const user = { _id: event.auxiliary, contracts: [contract] };
 
-    findOne.returns(SinonMongoose.stubChainedQueries([user]));
+    findOne.returns(SinonMongoose.stubChainedQueries(user));
 
     const result = await EventsValidationHelper.isUserContractValidOnEventDates(event);
 
@@ -193,7 +193,7 @@ describe('isUserContractValidOnEventDates', () => {
     const contract = { user: event.auxiliary, startDate: '2020-01-04T00:00:00' };
     const user = { _id: event.auxiliary, contracts: [contract] };
 
-    findOne.returns(SinonMongoose.stubChainedQueries([user]));
+    findOne.returns(SinonMongoose.stubChainedQueries(user));
 
     const result = await EventsValidationHelper.isUserContractValidOnEventDates(event);
 

--- a/tests/unit/helpers/fundings.test.js
+++ b/tests/unit/helpers/fundings.test.js
@@ -28,7 +28,7 @@ describe('checkSubscriptionFunding', () => {
   it('should return an error if customer does not exists', async () => {
     const customerId = new ObjectId();
     try {
-      findOneCustomer.returns(SinonMongoose.stubChainedQueries([null], ['lean']));
+      findOneCustomer.returns(SinonMongoose.stubChainedQueries(null, ['lean']));
 
       await FundingsHelper.checkSubscriptionFunding(customerId, checkedFunding);
     } catch (e) {
@@ -44,7 +44,7 @@ describe('checkSubscriptionFunding', () => {
   it('should return true if customer does not have fundings', async () => {
     const customerId = new ObjectId();
 
-    findOneCustomer.returns(SinonMongoose.stubChainedQueries([{}], ['lean']));
+    findOneCustomer.returns(SinonMongoose.stubChainedQueries({}, ['lean']));
 
     const res = await FundingsHelper.checkSubscriptionFunding(customerId, checkedFunding);
 
@@ -58,7 +58,7 @@ describe('checkSubscriptionFunding', () => {
   it('should return true if customer does not have fundings', async () => {
     const customerId = new ObjectId();
 
-    findOneCustomer.returns(SinonMongoose.stubChainedQueries([{ fundings: [] }], ['lean']));
+    findOneCustomer.returns(SinonMongoose.stubChainedQueries({ fundings: [] }, ['lean']));
 
     const res = await FundingsHelper.checkSubscriptionFunding(customerId, checkedFunding);
 
@@ -73,13 +73,13 @@ describe('checkSubscriptionFunding', () => {
     const customerId = new ObjectId();
 
     findOneCustomer.returns(SinonMongoose.stubChainedQueries(
-      [{
+      {
         fundings: [{
           _id: fundingId,
           subscription: checkedFundingSubscriptionId,
           versions: [{ careDays: [0, 1, 2], startDate: '2019-10-01', endDate: '2019-11-02' }],
         }],
-      }],
+      },
       ['lean']
     ));
 
@@ -102,7 +102,7 @@ describe('checkSubscriptionFunding', () => {
       },
     ];
 
-    findOneCustomer.returns(SinonMongoose.stubChainedQueries([{ fundings }], ['lean']));
+    findOneCustomer.returns(SinonMongoose.stubChainedQueries({ fundings }, ['lean']));
 
     const res = await FundingsHelper.checkSubscriptionFunding(customerId, checkedFunding);
 
@@ -123,7 +123,7 @@ describe('checkSubscriptionFunding', () => {
       },
     ];
 
-    findOneCustomer.returns(SinonMongoose.stubChainedQueries([{ fundings }], ['lean']));
+    findOneCustomer.returns(SinonMongoose.stubChainedQueries({ fundings }, ['lean']));
 
     const res = await FundingsHelper.checkSubscriptionFunding(customerId, checkedFunding);
 
@@ -144,7 +144,7 @@ describe('checkSubscriptionFunding', () => {
       },
     ];
 
-    findOneCustomer.returns(SinonMongoose.stubChainedQueries([{ fundings }], ['lean']));
+    findOneCustomer.returns(SinonMongoose.stubChainedQueries({ fundings }, ['lean']));
 
     const res = await FundingsHelper.checkSubscriptionFunding(customerId, checkedFunding);
 
@@ -165,7 +165,7 @@ describe('checkSubscriptionFunding', () => {
       },
     ];
 
-    findOneCustomer.returns(SinonMongoose.stubChainedQueries([{ fundings }], ['lean']));
+    findOneCustomer.returns(SinonMongoose.stubChainedQueries({ fundings }, ['lean']));
 
     const res = await FundingsHelper.checkSubscriptionFunding(customerId, checkedFunding);
 
@@ -186,7 +186,7 @@ describe('checkSubscriptionFunding', () => {
       },
     ];
 
-    findOneCustomer.returns(SinonMongoose.stubChainedQueries([{ fundings }], ['lean']));
+    findOneCustomer.returns(SinonMongoose.stubChainedQueries({ fundings }, ['lean']));
 
     const res = await FundingsHelper.checkSubscriptionFunding(customerId, checkedFunding);
 
@@ -212,7 +212,7 @@ describe('checkSubscriptionFunding', () => {
       },
     ];
 
-    findOneCustomer.returns(SinonMongoose.stubChainedQueries([{ fundings }], ['lean']));
+    findOneCustomer.returns(SinonMongoose.stubChainedQueries({ fundings }, ['lean']));
 
     const res = await FundingsHelper.checkSubscriptionFunding(customerId, checkedFunding);
 
@@ -298,7 +298,7 @@ describe('createFunding', () => {
     const customer = { _id: customerId };
 
     checkSubscriptionFunding.returns(true);
-    findOneAndUpdateCustomer.returns(SinonMongoose.stubChainedQueries([customer]));
+    findOneAndUpdateCustomer.returns(SinonMongoose.stubChainedQueries(customer));
 
     await FundingsHelper.createFunding(customerId, payload);
 
@@ -366,7 +366,7 @@ describe('updateFunding', () => {
     };
 
     checkSubscriptionFunding.returns(true);
-    findOneAndUpdateCustomer.returns(SinonMongoose.stubChainedQueries([customer]));
+    findOneAndUpdateCustomer.returns(SinonMongoose.stubChainedQueries(customer));
 
     await FundingsHelper.updateFunding(customerId, fundingId, payload);
 

--- a/tests/unit/helpers/helpers.test.js
+++ b/tests/unit/helpers/helpers.test.js
@@ -23,7 +23,7 @@ describe('list', () => {
       { _id: new ObjectId(), user: { local: { email: 'helper2@test.fr' } }, customer: query.customer, referent: false },
     ];
 
-    find.returns(SinonMongoose.stubChainedQueries([helpers]));
+    find.returns(SinonMongoose.stubChainedQueries(helpers));
 
     const result = await HelpersHelper.list(query, credentials);
 
@@ -69,7 +69,7 @@ describe('update', () => {
     const customerId = new ObjectId();
     const helper = { _id: helperId, customer: customerId };
 
-    findOneAndUpdate.returns(SinonMongoose.stubChainedQueries([helper], ['lean']));
+    findOneAndUpdate.returns(SinonMongoose.stubChainedQueries(helper, ['lean']));
 
     await HelpersHelper.update(helperId, { referent: true });
 

--- a/tests/unit/helpers/historyExport.test.js
+++ b/tests/unit/helpers/historyExport.test.js
@@ -1887,7 +1887,7 @@ describe('exportCourseSlotHistory', () => {
   });
 
   it('should return an array with the header and 2 rows', async () => {
-    findCourseSlot.returns(SinonMongoose.stubChainedQueries([courseSlotList]));
+    findCourseSlot.returns(SinonMongoose.stubChainedQueries(courseSlotList));
 
     const result = await ExportHelper.exportCourseSlotHistory('2021-01-14T23:00:00.000Z', '2022-01-20T22:59:59.000Z');
 

--- a/tests/unit/helpers/historyExport.test.js
+++ b/tests/unit/helpers/historyExport.test.js
@@ -155,7 +155,7 @@ describe('getWorkingEventsForExport', () => {
   });
 
   it('should return events for history export', async () => {
-    find.returns(SinonMongoose.stubChainedQueries([events], ['populate', 'sort', 'lean']));
+    find.returns(SinonMongoose.stubChainedQueries(events, ['populate', 'sort', 'lean']));
 
     const result = await ExportHelper.getWorkingEventsForExport(startDate, endDate, companyId);
     expect(result).toStrictEqual(eventsWithSubscription);
@@ -722,8 +722,8 @@ describe('exportBillsAndCreditNotesHistory', () => {
   });
 
   it('should return an array containing just the header', async () => {
-    findBill.returns(SinonMongoose.stubChainedQueries([[]], ['populate', 'sort', 'lean']));
-    findCreditNote.returns(SinonMongoose.stubChainedQueries([[]], ['populate', 'sort', 'lean']));
+    findBill.returns(SinonMongoose.stubChainedQueries([], ['populate', 'sort', 'lean']));
+    findCreditNote.returns(SinonMongoose.stubChainedQueries([], ['populate', 'sort', 'lean']));
 
     const exportArray = await ExportHelper.exportBillsAndCreditNotesHistory(null, null, credentials);
 
@@ -751,8 +751,8 @@ describe('exportBillsAndCreditNotesHistory', () => {
   });
 
   it('should return an array with the header and a row of empty cells', async () => {
-    findBill.returns(SinonMongoose.stubChainedQueries([[{}]], ['populate', 'sort', 'lean']));
-    findCreditNote.returns(SinonMongoose.stubChainedQueries([[{}]], ['populate', 'sort', 'lean']));
+    findBill.returns(SinonMongoose.stubChainedQueries([{}], ['populate', 'sort', 'lean']));
+    findCreditNote.returns(SinonMongoose.stubChainedQueries([{}], ['populate', 'sort', 'lean']));
 
     formatPriceStub.callsFake(price => (price ? `P-${price}` : ''));
     formatHourStub.callsFake(hour => (hour ? `${hour}h` : ''));
@@ -791,8 +791,8 @@ describe('exportBillsAndCreditNotesHistory', () => {
   });
 
   it('should return an array with the header and 2 rows', async () => {
-    findBill.returns(SinonMongoose.stubChainedQueries([bills], ['populate', 'sort', 'lean']));
-    findCreditNote.returns(SinonMongoose.stubChainedQueries([creditNotes], ['populate', 'sort', 'lean']));
+    findBill.returns(SinonMongoose.stubChainedQueries(bills, ['populate', 'sort', 'lean']));
+    findCreditNote.returns(SinonMongoose.stubChainedQueries(creditNotes, ['populate', 'sort', 'lean']));
 
     formatPriceStub.callsFake(price => (price ? `P-${price}` : ''));
     formatHourStub.callsFake(hour => (hour ? `${hour}h` : ''));
@@ -907,7 +907,7 @@ describe('exportContractHistory', () => {
 
   it('should return an array containing just the header', async () => {
     const credentials = { company: { _id: new ObjectId() } };
-    find.returns(SinonMongoose.stubChainedQueries([[]]));
+    find.returns(SinonMongoose.stubChainedQueries([]));
 
     const result = await ExportHelper.exportContractHistory(startDate, endDate, credentials);
 
@@ -936,7 +936,7 @@ describe('exportContractHistory', () => {
     const credentials = { company: { _id: new ObjectId() } };
     const contracts = [{ versions: [{ startDate: '2019-10-10T00:00:00' }], user: { _id: new ObjectId() } }];
 
-    find.returns(SinonMongoose.stubChainedQueries([contracts]));
+    find.returns(SinonMongoose.stubChainedQueries(contracts));
 
     const result = await ExportHelper.exportContractHistory(startDate, endDate, credentials);
 
@@ -971,7 +971,7 @@ describe('exportContractHistory', () => {
       },
     ];
 
-    find.returns(SinonMongoose.stubChainedQueries([contracts]));
+    find.returns(SinonMongoose.stubChainedQueries(contracts));
 
     const result = await ExportHelper.exportContractHistory(startDate, endDate, credentials);
     expect(result).toEqual([
@@ -1338,8 +1338,8 @@ describe('exportPayAndFinalPayHistory', () => {
       company: credentials.company._id,
     };
 
-    findPay.returns(SinonMongoose.stubChainedQueries([[]], ['sort', 'populate', 'lean']));
-    findFinalPay.returns(SinonMongoose.stubChainedQueries([[]], ['sort', 'populate', 'lean']));
+    findPay.returns(SinonMongoose.stubChainedQueries([], ['sort', 'populate', 'lean']));
+    findFinalPay.returns(SinonMongoose.stubChainedQueries([], ['sort', 'populate', 'lean']));
 
     const exportArray = await ExportHelper.exportPayAndFinalPayHistory(startDate, endDate, credentials);
 
@@ -1394,8 +1394,8 @@ describe('exportPayAndFinalPayHistory', () => {
       company: credentials.company._id,
     };
 
-    findPay.returns(SinonMongoose.stubChainedQueries([pays], ['sort', 'populate', 'lean']));
-    findFinalPay.returns(SinonMongoose.stubChainedQueries([finalPays], ['sort', 'populate', 'lean']));
+    findPay.returns(SinonMongoose.stubChainedQueries(pays, ['sort', 'populate', 'lean']));
+    findFinalPay.returns(SinonMongoose.stubChainedQueries(finalPays, ['sort', 'populate', 'lean']));
 
     formatFloatForExportStub.callsFake(nb => Number(nb).toFixed(2).replace('.', ','));
     formatSurchargedDetailsForExport.returnsArg(1);
@@ -1524,7 +1524,7 @@ describe('exportPaymentsHistory', () => {
   });
 
   it('should return an array containing just the header', async () => {
-    find.returns(SinonMongoose.stubChainedQueries([[]], ['sort', 'populate', 'lean']));
+    find.returns(SinonMongoose.stubChainedQueries([], ['sort', 'populate', 'lean']));
 
     const credentials = { company: new ObjectId() };
     const exportArray = await ExportHelper.exportPaymentsHistory(null, null, credentials);
@@ -1543,7 +1543,7 @@ describe('exportPaymentsHistory', () => {
   });
 
   it('should return an array with the header and 2 rows', async () => {
-    find.returns(SinonMongoose.stubChainedQueries([paymentsList], ['sort', 'populate', 'lean']));
+    find.returns(SinonMongoose.stubChainedQueries(paymentsList, ['sort', 'populate', 'lean']));
 
     const credentials = { company: new ObjectId() };
     const exportArray = await ExportHelper.exportPaymentsHistory(null, null, credentials);
@@ -1697,8 +1697,8 @@ describe('exportCourseHistory', () => {
   });
 
   it('should return an array with the header and 2 rows', async () => {
-    findCourseSlot.returns(SinonMongoose.stubChainedQueries([courseSlotList], ['lean']));
-    findCourse.returns(SinonMongoose.stubChainedQueries([courseList]));
+    findCourseSlot.returns(SinonMongoose.stubChainedQueries(courseSlotList, ['lean']));
+    findCourse.returns(SinonMongoose.stubChainedQueries(courseList));
     groupSlotsByDate.onCall(0).returns([[courseSlotList[0], courseSlotList[1]]]);
     groupSlotsByDate.onCall(1).returns([[courseSlotList[2]], [courseSlotList[3]]]);
     getTotalDuration.onCall(0).returns('4h');

--- a/tests/unit/helpers/internalHours.test.js
+++ b/tests/unit/helpers/internalHours.test.js
@@ -38,7 +38,7 @@ describe('list', () => {
     const credentials = { company: { _id: new ObjectId() } };
     const internalHours = [{ _id: new ObjectId(), name: 'skusku' }];
 
-    find.returns(SinonMongoose.stubChainedQueries([internalHours], ['lean']));
+    find.returns(SinonMongoose.stubChainedQueries(internalHours, ['lean']));
 
     const result = await InternalHoursHelper.list(credentials);
 

--- a/tests/unit/helpers/mandates.test.js
+++ b/tests/unit/helpers/mandates.test.js
@@ -25,7 +25,7 @@ describe('getMandates', () => {
     const customerId = (new ObjectId()).toHexString();
     const mandate = { _id: new ObjectId() };
 
-    findOneCustomer.returns(SinonMongoose.stubChainedQueries([mandate], ['lean']));
+    findOneCustomer.returns(SinonMongoose.stubChainedQueries(mandate, ['lean']));
 
     const result = await MandatesHelper.getMandates(customerId);
 
@@ -61,7 +61,7 @@ describe('updateMandate', () => {
     const mandateId = '1234567890';
     const payload = { startDate: '2019-12-12T00:00:00' };
 
-    findOneAndUpdateCustomer.returns(SinonMongoose.stubChainedQueries([{ ...payload, _id: mandateId }], ['lean']));
+    findOneAndUpdateCustomer.returns(SinonMongoose.stubChainedQueries({ ...payload, _id: mandateId }, ['lean']));
 
     const result = await MandatesHelper.updateMandate(customerId, mandateId, payload);
 
@@ -113,7 +113,7 @@ describe('getSignatureRequest', () => {
       _id: customerId,
       payment: { mandates: [{ _id: new ObjectId() }, { _id: mandateId, rum: 'rum' }] },
     };
-    findOneCustomer.returns(SinonMongoose.stubChainedQueries([customer], ['lean']));
+    findOneCustomer.returns(SinonMongoose.stubChainedQueries(customer, ['lean']));
     generateSignatureRequest.returns({
       data: { document_hash: 'document_hash', signers: [{ embedded_signing_url: 'embedded_signing_url' }] },
     });
@@ -155,7 +155,7 @@ describe('getSignatureRequest', () => {
         payment: { mandates: [{ _id: new ObjectId() }, { _id: mandateId, rum: 'rum' }] },
       };
 
-      findOneCustomer.returns(SinonMongoose.stubChainedQueries([customer], ['lean']));
+      findOneCustomer.returns(SinonMongoose.stubChainedQueries(customer, ['lean']));
       generateSignatureRequest.returns({ data: { error: 'error' } });
 
       await MandatesHelper.getSignatureRequest(customerId, mandateId.toHexString(), payload);
@@ -217,8 +217,8 @@ describe('saveSignedMandate', () => {
     };
     const drive = { driveId: 'fileId', link: 'webViewLink' };
 
-    findOneCustomer.returns(SinonMongoose.stubChainedQueries([customer], ['lean']));
-    findOneAndUpdateCustomer.returns(SinonMongoose.stubChainedQueries([], ['lean']));
+    findOneCustomer.returns(SinonMongoose.stubChainedQueries(customer, ['lean']));
+    findOneAndUpdateCustomer.returns(SinonMongoose.stubChainedQueries(null, ['lean']));
     getDocument.returns({ data: { log: [{ event: 'document_signed' }] } });
     downloadFinalDocument.returns({ data: 'data' });
     createAndReadFile.returns('file');
@@ -265,7 +265,7 @@ describe('saveSignedMandate', () => {
         driveFolder: { driveId: 'driveFolder' },
       };
 
-      findOneCustomer.returns(SinonMongoose.stubChainedQueries([customer], ['lean']));
+      findOneCustomer.returns(SinonMongoose.stubChainedQueries(customer, ['lean']));
       getDocument.returns({ data: { error: 'error', log: [{ event: 'document_signed' }] } });
 
       await MandatesHelper.saveSignedMandate(customerId, mandateId.toHexString());
@@ -295,7 +295,7 @@ describe('saveSignedMandate', () => {
         driveFolder: { driveId: 'driveFolder' },
       };
 
-      findOneCustomer.returns(SinonMongoose.stubChainedQueries([customer], ['lean']));
+      findOneCustomer.returns(SinonMongoose.stubChainedQueries(customer, ['lean']));
       getDocument.returns({ data: { log: [{ event: 'document_not_signed' }] } });
 
       await MandatesHelper.saveSignedMandate(customerId, mandateId.toHexString());

--- a/tests/unit/helpers/notifications.test.js
+++ b/tests/unit/helpers/notifications.test.js
@@ -97,7 +97,7 @@ describe('sendBlendedCourseRegistrationNotification', () => {
       slots: [{ startDate: '2020-01-02' }],
     };
 
-    findOne.returns(SinonMongoose.stubChainedQueries([course]));
+    findOne.returns(SinonMongoose.stubChainedQueries(course));
 
     await NotificationHelper.sendBlendedCourseRegistrationNotification(trainee, courseId);
 
@@ -174,8 +174,8 @@ describe('sendNewElearningCourseNotification', () => {
       slots: [{ startDate: '2020-01-02' }],
     };
 
-    courseFindOne.returns(SinonMongoose.stubChainedQueries([course]));
-    userFind.returns(SinonMongoose.stubChainedQueries([trainees], ['lean']));
+    courseFindOne.returns(SinonMongoose.stubChainedQueries(course));
+    userFind.returns(SinonMongoose.stubChainedQueries(trainees, ['lean']));
 
     await NotificationHelper.sendNewElearningCourseNotification(courseId);
 
@@ -232,8 +232,8 @@ describe('sendNewElearningCourseNotification', () => {
       slots: [{ startDate: '2020-01-02' }],
     };
 
-    courseFindOne.returns(SinonMongoose.stubChainedQueries([course]));
-    userFind.returns(SinonMongoose.stubChainedQueries([[]], ['lean']));
+    courseFindOne.returns(SinonMongoose.stubChainedQueries(course));
+    userFind.returns(SinonMongoose.stubChainedQueries([], ['lean']));
 
     await NotificationHelper.sendNewElearningCourseNotification(courseId);
 

--- a/tests/unit/helpers/partnerOrganizations.test.js
+++ b/tests/unit/helpers/partnerOrganizations.test.js
@@ -64,7 +64,7 @@ describe('list', () => {
     const credentials = { company: { _id: new ObjectId() } };
     const partnerOrganizationId = new ObjectId();
 
-    find.returns(SinonMongoose.stubChainedQueries([[{ _id: partnerOrganizationId, name: 'skusku', partners: [] }]]));
+    find.returns(SinonMongoose.stubChainedQueries([{ _id: partnerOrganizationId, name: 'skusku', partners: [] }]));
 
     const result = await PartnerOrganizationsHelper.list(credentials);
 
@@ -102,7 +102,7 @@ describe('list', () => {
       },
     ];
 
-    find.returns(SinonMongoose.stubChainedQueries([partnerOrganizations]));
+    find.returns(SinonMongoose.stubChainedQueries(partnerOrganizations));
 
     const result = await PartnerOrganizationsHelper.list(credentials);
 
@@ -149,7 +149,7 @@ describe('getPartnerOrganization', () => {
     const partnerOrganizationId = new ObjectId();
     const credentials = { company: { _id: new ObjectId() } };
 
-    findOne.returns(SinonMongoose.stubChainedQueries([[{ _id: partnerOrganizationId, name: 'skusku' }]]));
+    findOne.returns(SinonMongoose.stubChainedQueries([{ _id: partnerOrganizationId, name: 'skusku' }]));
 
     await PartnerOrganizationsHelper.getPartnerOrganization(partnerOrganizationId, credentials);
 

--- a/tests/unit/helpers/partners.test.js
+++ b/tests/unit/helpers/partners.test.js
@@ -16,7 +16,7 @@ describe('list', () => {
   it('should list partner from my company', async () => {
     const credentials = { company: { _id: new ObjectId() } };
 
-    find.returns(SinonMongoose.stubChainedQueries([[{ _id: new ObjectId() }]], ['lean']));
+    find.returns(SinonMongoose.stubChainedQueries([{ _id: new ObjectId() }], ['lean']));
 
     await PartnersHelper.list(credentials);
 

--- a/tests/unit/helpers/payDocuments.test.js
+++ b/tests/unit/helpers/payDocuments.test.js
@@ -34,7 +34,7 @@ describe('create', () => {
     const payload = { file: 'stream', mimeType: 'pdf', date: '2020-12-31T00:00:00', nature: 'payslip', user: userId };
     const credentials = { company: { _id: new ObjectId() } };
     findOne.returns(SinonMongoose.stubChainedQueries(
-      [{ _id: userId, administrative: { driveFolder: { driveId: 'driveId' } }, identity: { lastname: 'lastname' } }],
+      { _id: userId, administrative: { driveFolder: { driveId: 'driveId' } }, identity: { lastname: 'lastname' } },
       ['lean']
     ));
     formatIdentity.returns('bonjour');
@@ -69,7 +69,7 @@ describe('create', () => {
     const payload = { file: 'stream', mimeType: 'pdf', date: '2020-12-31T00:00:00', nature: 'payslip', user: userId };
     const credentials = { company: { _id: companyId } };
     findOne.returns(SinonMongoose.stubChainedQueries(
-      [{ _id: userId, administrative: { driveFolder: { driveId: 'driveId' } }, identity: { lastname: 'lastname' } }],
+      { _id: userId, administrative: { driveFolder: { driveId: 'driveId' } }, identity: { lastname: 'lastname' } },
       ['lean']
     ));
     formatIdentity.returns('bonjour');

--- a/tests/unit/helpers/payments.test.js
+++ b/tests/unit/helpers/payments.test.js
@@ -28,7 +28,7 @@ describe('getPayments', () => {
     const credentials = { company: { _id: new ObjectId() } };
     const query = {};
     const payment = { _id: new ObjectId() };
-    find.returns(SinonMongoose.stubChainedQueries([[payment]]));
+    find.returns(SinonMongoose.stubChainedQueries([payment]));
 
     const result = await PaymentsHelper.getPayments(query, credentials);
 
@@ -51,7 +51,7 @@ describe('getPayments', () => {
     const payment = { _id: new ObjectId() };
 
     getDateQueryStub.returns({ $lte: '2019-11-01' });
-    find.returns(SinonMongoose.stubChainedQueries([[payment]]));
+    find.returns(SinonMongoose.stubChainedQueries([payment]));
 
     const result = await PaymentsHelper.getPayments(query, credentials);
 
@@ -74,7 +74,7 @@ describe('getPayments', () => {
     const payment = { _id: new ObjectId() };
 
     getDateQueryStub.returns({ $gte: '2019-11-01' });
-    find.returns(SinonMongoose.stubChainedQueries([[payment]]));
+    find.returns(SinonMongoose.stubChainedQueries([payment]));
 
     const result = await PaymentsHelper.getPayments(query, credentials);
 
@@ -374,7 +374,7 @@ describe('getPaymentNumber', () => {
     const payment = { nature: 'payment', date: new Date('2019-12-01') };
     const companyId = new ObjectId();
 
-    findOneAndUpdate.returns(SinonMongoose.stubChainedQueries([], ['lean']));
+    findOneAndUpdate.returns(SinonMongoose.stubChainedQueries(null, ['lean']));
 
     await PaymentsHelper.getPaymentNumber(payment, companyId);
 

--- a/tests/unit/helpers/programs.test.js
+++ b/tests/unit/helpers/programs.test.js
@@ -39,7 +39,7 @@ describe('list', () => {
   it('should return programs', async () => {
     const programsList = [{ name: 'name' }, { name: 'program' }];
 
-    find.returns(SinonMongoose.stubChainedQueries([programsList]));
+    find.returns(SinonMongoose.stubChainedQueries(programsList));
 
     const result = await ProgramHelper.list();
     expect(result).toMatchObject(programsList);
@@ -72,8 +72,8 @@ describe('listELearning', () => {
     const companyId = new ObjectId();
     const credentials = { _id: new ObjectId(), company: { _id: companyId } };
 
-    courseFind.returns(SinonMongoose.stubChainedQueries([[{ subProgram: subPrograms[0] }]], ['lean']));
-    programFind.returns(SinonMongoose.stubChainedQueries([programsList]));
+    courseFind.returns(SinonMongoose.stubChainedQueries([{ subProgram: subPrograms[0] }], ['lean']));
+    programFind.returns(SinonMongoose.stubChainedQueries(programsList));
 
     const result = await ProgramHelper.listELearning(credentials);
     expect(result).toMatchObject([{ name: 'name' }, { name: 'program' }]);
@@ -128,8 +128,8 @@ describe('listELearning', () => {
     const companyId = new ObjectId();
     const credentials = { _id: new ObjectId(), company: { _id: companyId } };
 
-    courseFind.returns(SinonMongoose.stubChainedQueries([[{ subProgram: subPrograms[0] }]], ['lean']));
-    programFind.returns(SinonMongoose.stubChainedQueries([programsList]));
+    courseFind.returns(SinonMongoose.stubChainedQueries([{ subProgram: subPrograms[0] }], ['lean']));
+    programFind.returns(SinonMongoose.stubChainedQueries(programsList));
 
     const result = await ProgramHelper.listELearning(credentials, { _id: programId });
     expect(result).toMatchObject([{ _id: programId, name: 'name' }]);
@@ -214,7 +214,7 @@ describe('getProgram', () => {
       }],
     };
 
-    programFindOne.returns(SinonMongoose.stubChainedQueries([program]));
+    programFindOne.returns(SinonMongoose.stubChainedQueries(program));
 
     const result = await ProgramHelper.getProgram(program._id);
 
@@ -413,8 +413,8 @@ describe('addTester', () => {
   it('should add existing user to program as tester', async () => {
     const programId = new ObjectId();
     const user = { _id: new ObjectId(), local: { email: 'test@test.fr' } };
-    findOne.returns(SinonMongoose.stubChainedQueries([user], ['lean']));
-    findOneAndUpdate.returns(SinonMongoose.stubChainedQueries([{ _id: programId }], ['lean']));
+    findOne.returns(SinonMongoose.stubChainedQueries(user, ['lean']));
+    findOneAndUpdate.returns(SinonMongoose.stubChainedQueries({ _id: programId }, ['lean']));
 
     await ProgramHelper.addTester(programId, user);
 
@@ -437,9 +437,9 @@ describe('addTester', () => {
     const userId = new ObjectId();
     const payload = { local: { email: 'test@test.fr' } };
 
-    findOne.returns(SinonMongoose.stubChainedQueries([], ['lean']));
+    findOne.returns(SinonMongoose.stubChainedQueries(null, ['lean']));
     createUser.returns({ ...payload, _id: userId });
-    findOneAndUpdate.returns(SinonMongoose.stubChainedQueries([{ _id: programId }], ['lean']));
+    findOneAndUpdate.returns(SinonMongoose.stubChainedQueries({ _id: programId }, ['lean']));
 
     await ProgramHelper.addTester(programId, payload);
 

--- a/tests/unit/helpers/questionnaires.test.js
+++ b/tests/unit/helpers/questionnaires.test.js
@@ -38,7 +38,7 @@ describe('list', () => {
   it('should return questionnaires', async () => {
     const questionnairesList = [{ name: 'test' }, { name: 'test2' }];
 
-    find.returns(SinonMongoose.stubChainedQueries([questionnairesList]));
+    find.returns(SinonMongoose.stubChainedQueries(questionnairesList));
 
     const result = await QuestionnaireHelper.list();
 
@@ -63,7 +63,7 @@ describe('getQuestionnaire', () => {
     const questionnaireId = new ObjectId();
     const questionnaire = { _id: questionnaireId, name: 'test' };
 
-    findOne.returns(SinonMongoose.stubChainedQueries([questionnaire]));
+    findOne.returns(SinonMongoose.stubChainedQueries(questionnaire));
 
     const result = await QuestionnaireHelper.getQuestionnaire(questionnaireId);
 
@@ -93,7 +93,7 @@ describe('editQuestionnaire', () => {
     const cards = [new ObjectId(), new ObjectId()];
     const questionnaire = { _id: questionnaireId, name: 'test2', cards };
 
-    findOneAndUpdate.returns(SinonMongoose.stubChainedQueries([questionnaire], ['lean']));
+    findOneAndUpdate.returns(SinonMongoose.stubChainedQueries(questionnaire, ['lean']));
 
     const result = await QuestionnaireHelper.update(questionnaireId, { name: 'test2', cards });
 
@@ -152,7 +152,7 @@ describe('removeCard', () => {
   it('should remove card without media from questionnaire', async () => {
     const cardId = new ObjectId();
 
-    findOneAndRemoveCard.returns(SinonMongoose.stubChainedQueries([null], ['lean']));
+    findOneAndRemoveCard.returns(SinonMongoose.stubChainedQueries(null, ['lean']));
 
     await QuestionnaireHelper.removeCard(cardId);
 
@@ -171,7 +171,7 @@ describe('removeCard', () => {
     const cardId = new ObjectId();
     const card = { _id: cardId, media: { publicId: 'publicId' } };
 
-    findOneAndRemoveCard.returns(SinonMongoose.stubChainedQueries([card], ['lean']));
+    findOneAndRemoveCard.returns(SinonMongoose.stubChainedQueries(card, ['lean']));
 
     await QuestionnaireHelper.removeCard(cardId);
 
@@ -207,7 +207,7 @@ describe('getUserQuestionnaires', () => {
     const credentials = { _id: new ObjectId() };
     const course = { _id: courseId, format: 'strictly_e_learning' };
 
-    findOneCourse.returns(SinonMongoose.stubChainedQueries([course]));
+    findOneCourse.returns(SinonMongoose.stubChainedQueries(course));
     nowStub.returns(new Date('2021-04-13T15:00:00'));
 
     const result = await QuestionnaireHelper.getUserQuestionnaires(courseId, credentials);
@@ -233,9 +233,9 @@ describe('getUserQuestionnaires', () => {
       slots: [{ startDate: new Date('2021-04-20T09:00:00'), endDate: new Date('2021-04-20T11:00:00') }],
     };
 
-    findOneCourse.returns(SinonMongoose.stubChainedQueries([course]));
+    findOneCourse.returns(SinonMongoose.stubChainedQueries(course));
     nowStub.returns(new Date('2021-04-13T15:00:00'));
-    findOneQuestionnaire.returns(SinonMongoose.stubChainedQueries([null]));
+    findOneQuestionnaire.returns(SinonMongoose.stubChainedQueries(null));
 
     const result = await QuestionnaireHelper.getUserQuestionnaires(courseId, credentials);
 
@@ -272,9 +272,9 @@ describe('getUserQuestionnaires', () => {
       histories: [{ _id: new ObjectId(), course: course._id, user: credentials._id }],
     };
 
-    findOneCourse.returns(SinonMongoose.stubChainedQueries([course]));
+    findOneCourse.returns(SinonMongoose.stubChainedQueries(course));
     nowStub.returns(new Date('2021-04-13T15:00:00'));
-    findOneQuestionnaire.returns(SinonMongoose.stubChainedQueries([questionnaire]));
+    findOneQuestionnaire.returns(SinonMongoose.stubChainedQueries(questionnaire));
 
     const result = await QuestionnaireHelper.getUserQuestionnaires(courseId, credentials);
 
@@ -307,9 +307,9 @@ describe('getUserQuestionnaires', () => {
     };
     const questionnaire = { _id: new ObjectId(), name: 'test', type: 'expectations', histories: [] };
 
-    findOneCourse.returns(SinonMongoose.stubChainedQueries([course]));
+    findOneCourse.returns(SinonMongoose.stubChainedQueries(course));
     nowStub.returns(new Date('2021-04-13T15:00:00'));
-    findOneQuestionnaire.returns(SinonMongoose.stubChainedQueries([questionnaire]));
+    findOneQuestionnaire.returns(SinonMongoose.stubChainedQueries(questionnaire));
 
     const result = await QuestionnaireHelper.getUserQuestionnaires(courseId, credentials);
 
@@ -339,9 +339,9 @@ describe('getUserQuestionnaires', () => {
     const course = { _id: courseId, slots: [] };
     const questionnaire = { _id: new ObjectId(), name: 'test', histories: [] };
 
-    findOneCourse.returns(SinonMongoose.stubChainedQueries([course]));
+    findOneCourse.returns(SinonMongoose.stubChainedQueries(course));
     nowStub.returns(new Date('2021-04-13T15:00:00'));
-    findOneQuestionnaire.returns(SinonMongoose.stubChainedQueries([questionnaire]));
+    findOneQuestionnaire.returns(SinonMongoose.stubChainedQueries(questionnaire));
 
     const result = await QuestionnaireHelper.getUserQuestionnaires(courseId, credentials);
 
@@ -374,7 +374,7 @@ describe('getUserQuestionnaires', () => {
       slotsToPlan: [{ _id: new ObjectId() }],
     };
 
-    findOneCourse.returns(SinonMongoose.stubChainedQueries([course]));
+    findOneCourse.returns(SinonMongoose.stubChainedQueries(course));
     nowStub.returns(new Date('2021-04-23T15:00:00'));
 
     const result = await QuestionnaireHelper.getUserQuestionnaires(courseId, credentials);
@@ -400,9 +400,9 @@ describe('getUserQuestionnaires', () => {
       slots: [{ startDate: new Date('2021-04-20T09:00:00'), endDate: new Date('2021-04-20T11:00:00') }],
     };
 
-    findOneCourse.returns(SinonMongoose.stubChainedQueries([course]));
+    findOneCourse.returns(SinonMongoose.stubChainedQueries(course));
     nowStub.returns(new Date('2021-04-23T15:00:00'));
-    findOneQuestionnaire.returns(SinonMongoose.stubChainedQueries([null]));
+    findOneQuestionnaire.returns(SinonMongoose.stubChainedQueries(null));
 
     const result = await QuestionnaireHelper.getUserQuestionnaires(courseId, credentials);
 
@@ -439,9 +439,9 @@ describe('getUserQuestionnaires', () => {
       histories: [{ _id: new ObjectId(), course: course._id, user: credentials._id }],
     };
 
-    findOneCourse.returns(SinonMongoose.stubChainedQueries([course]));
+    findOneCourse.returns(SinonMongoose.stubChainedQueries(course));
     nowStub.returns(new Date('2021-04-23T15:00:00'));
-    findOneQuestionnaire.returns(SinonMongoose.stubChainedQueries([questionnaire]));
+    findOneQuestionnaire.returns(SinonMongoose.stubChainedQueries(questionnaire));
 
     const result = await QuestionnaireHelper.getUserQuestionnaires(courseId, credentials);
 
@@ -474,9 +474,9 @@ describe('getUserQuestionnaires', () => {
     };
     const questionnaire = { _id: new ObjectId(), name: 'test', type: 'end_of_course', histories: [] };
 
-    findOneCourse.returns(SinonMongoose.stubChainedQueries([course]));
+    findOneCourse.returns(SinonMongoose.stubChainedQueries(course));
     nowStub.returns(new Date('2021-04-23T10:00:00'));
-    findOneQuestionnaire.returns(SinonMongoose.stubChainedQueries([questionnaire]));
+    findOneQuestionnaire.returns(SinonMongoose.stubChainedQueries(questionnaire));
 
     const result = await QuestionnaireHelper.getUserQuestionnaires(courseId, credentials);
 
@@ -512,7 +512,7 @@ describe('getUserQuestionnaires', () => {
       ],
     };
 
-    findOneCourse.returns(SinonMongoose.stubChainedQueries([course]));
+    findOneCourse.returns(SinonMongoose.stubChainedQueries(course));
     nowStub.returns(new Date('2021-04-23T15:00:00'));
 
     const result = await QuestionnaireHelper.getUserQuestionnaires(courseId, credentials);
@@ -614,8 +614,8 @@ describe('getFollowUp', () => {
       ],
     };
 
-    courseFindOne.returns(SinonMongoose.stubChainedQueries([course], ['select', 'populate', 'lean']));
-    questionnaireFindOne.returns(SinonMongoose.stubChainedQueries([questionnaire], ['select', 'populate', 'lean']));
+    courseFindOne.returns(SinonMongoose.stubChainedQueries(course, ['select', 'populate', 'lean']));
+    questionnaireFindOne.returns(SinonMongoose.stubChainedQueries(questionnaire, ['select', 'populate', 'lean']));
 
     const result = await QuestionnaireHelper.getFollowUp(questionnaireId, courseId);
 
@@ -761,8 +761,8 @@ describe('getFollowUp', () => {
       ],
     };
 
-    courseFindOne.returns(SinonMongoose.stubChainedQueries([course], ['select', 'populate', 'lean']));
-    questionnaireFindOne.returns(SinonMongoose.stubChainedQueries([questionnaire], ['select', 'populate', 'lean']));
+    courseFindOne.returns(SinonMongoose.stubChainedQueries(course, ['select', 'populate', 'lean']));
+    questionnaireFindOne.returns(SinonMongoose.stubChainedQueries(questionnaire, ['select', 'populate', 'lean']));
 
     const result = await QuestionnaireHelper.getFollowUp(questionnaireId, courseId);
 
@@ -901,7 +901,7 @@ describe('getFollowUp', () => {
       ],
     };
 
-    questionnaireFindOne.returns(SinonMongoose.stubChainedQueries([questionnaire], ['select', 'populate', 'lean']));
+    questionnaireFindOne.returns(SinonMongoose.stubChainedQueries(questionnaire, ['select', 'populate', 'lean']));
 
     const result = await QuestionnaireHelper.getFollowUp(questionnaireId);
 
@@ -983,8 +983,8 @@ describe('getFollowUp', () => {
       }],
     };
 
-    courseFindOne.returns(SinonMongoose.stubChainedQueries([course], ['select', 'populate', 'lean']));
-    questionnaireFindOne.returns(SinonMongoose.stubChainedQueries([questionnaire], ['select', 'populate', 'lean']));
+    courseFindOne.returns(SinonMongoose.stubChainedQueries(course, ['select', 'populate', 'lean']));
+    questionnaireFindOne.returns(SinonMongoose.stubChainedQueries(questionnaire, ['select', 'populate', 'lean']));
 
     const result = await QuestionnaireHelper.getFollowUp(questionnaireId, courseId);
 
@@ -1055,8 +1055,8 @@ describe('getFollowUp', () => {
       histories: [],
     };
 
-    courseFindOne.returns(SinonMongoose.stubChainedQueries([course], ['select', 'populate', 'lean']));
-    questionnaireFindOne.returns(SinonMongoose.stubChainedQueries([questionnaire], ['select', 'populate', 'lean']));
+    courseFindOne.returns(SinonMongoose.stubChainedQueries(course, ['select', 'populate', 'lean']));
+    questionnaireFindOne.returns(SinonMongoose.stubChainedQueries(questionnaire, ['select', 'populate', 'lean']));
 
     const result = await QuestionnaireHelper.getFollowUp(questionnaireId, courseId);
 
@@ -1133,8 +1133,8 @@ describe('getFollowUp', () => {
       }],
     };
 
-    courseFindOne.returns(SinonMongoose.stubChainedQueries([course], ['select', 'populate', 'lean']));
-    questionnaireFindOne.returns(SinonMongoose.stubChainedQueries([questionnaire], ['select', 'populate', 'lean']));
+    courseFindOne.returns(SinonMongoose.stubChainedQueries(course, ['select', 'populate', 'lean']));
+    questionnaireFindOne.returns(SinonMongoose.stubChainedQueries(questionnaire, ['select', 'populate', 'lean']));
 
     const result = await QuestionnaireHelper.getFollowUp(questionnaireId, courseId);
 

--- a/tests/unit/helpers/quotes.test.js
+++ b/tests/unit/helpers/quotes.test.js
@@ -20,7 +20,7 @@ describe('getQuotes', () => {
   it('should get customer quotes', async () => {
     const customerId = '12345678io0';
 
-    findOne.returns(SinonMongoose.stubChainedQueries([], ['lean']));
+    findOne.returns(SinonMongoose.stubChainedQueries(null, ['lean']));
 
     await QuoteHelper.getQuotes(customerId);
 
@@ -51,7 +51,7 @@ describe('getQuoteNumber', () => {
   it('should return quote number', async () => {
     const company = { _id: new ObjectId() };
 
-    findOneAndUpdate.returns(SinonMongoose.stubChainedQueries([], ['lean']));
+    findOneAndUpdate.returns(SinonMongoose.stubChainedQueries(null, ['lean']));
 
     await QuoteHelper.getQuoteNumber(company._id);
 
@@ -110,7 +110,7 @@ describe('createQuote', () => {
 
     getQuoteNumberStub.returns({ prefix: 'pre', seq: 2 });
     formatQuoteNumberStub.returns('pre-002');
-    findOneAndUpdate.returns(SinonMongoose.stubChainedQueries([], ['lean']));
+    findOneAndUpdate.returns(SinonMongoose.stubChainedQueries(null, ['lean']));
 
     await QuoteHelper.createQuote(customerId, payload, credentials);
 

--- a/tests/unit/helpers/referentHistories.test.js
+++ b/tests/unit/helpers/referentHistories.test.js
@@ -31,7 +31,7 @@ describe('updateCustomerReferent', () => {
 
   describe('no previous history', () => {
     it('Case 1 : no referent in payload', async () => {
-      findReferentHistory.returns(SinonMongoose.stubChainedQueries([[]], ['sort', 'limit', 'lean']));
+      findReferentHistory.returns(SinonMongoose.stubChainedQueries([], ['sort', 'limit', 'lean']));
 
       await ReferentHistoriesHelper.updateCustomerReferent(customerId, null, company);
       sinon.assert.notCalled(updateLastHistory);
@@ -51,7 +51,7 @@ describe('updateCustomerReferent', () => {
     it('Case 2 : referent in payload', async () => {
       const referent = new ObjectId();
 
-      findReferentHistory.returns(SinonMongoose.stubChainedQueries([[]], ['sort', 'limit', 'lean']));
+      findReferentHistory.returns(SinonMongoose.stubChainedQueries([], ['sort', 'limit', 'lean']));
 
       await ReferentHistoriesHelper.updateCustomerReferent(customerId, referent.toHexString(), company);
       sinon.assert.notCalled(updateLastHistory);
@@ -73,7 +73,7 @@ describe('updateCustomerReferent', () => {
     it('Case 1 : no referent in payload', async () => {
       const lastHistory = { endDate: moment().subtract(1, 'month').toDate() };
 
-      findReferentHistory.returns(SinonMongoose.stubChainedQueries([[lastHistory]], ['sort', 'limit', 'lean']));
+      findReferentHistory.returns(SinonMongoose.stubChainedQueries([lastHistory], ['sort', 'limit', 'lean']));
 
       await ReferentHistoriesHelper.updateCustomerReferent(customerId, null, company);
       sinon.assert.notCalled(updateLastHistory);
@@ -94,7 +94,7 @@ describe('updateCustomerReferent', () => {
       const referent = new ObjectId();
       const lastHistory = { endDate: moment().subtract(1, 'month').toDate() };
 
-      findReferentHistory.returns(SinonMongoose.stubChainedQueries([[lastHistory]], ['sort', 'limit', 'lean']));
+      findReferentHistory.returns(SinonMongoose.stubChainedQueries([lastHistory], ['sort', 'limit', 'lean']));
 
       await ReferentHistoriesHelper.updateCustomerReferent(customerId, referent.toHexString(), company);
       sinon.assert.notCalled(updateLastHistory);
@@ -116,7 +116,7 @@ describe('updateCustomerReferent', () => {
     it('Case 1 : no referent in payload', async () => {
       const lastHistory = { endDate: moment().subtract(1, 'd').endOf('d').toDate() };
 
-      findReferentHistory.returns(SinonMongoose.stubChainedQueries([[lastHistory]], ['sort', 'limit', 'lean']));
+      findReferentHistory.returns(SinonMongoose.stubChainedQueries([lastHistory], ['sort', 'limit', 'lean']));
 
       await ReferentHistoriesHelper.updateCustomerReferent(customerId, null, company);
       sinon.assert.notCalled(updateLastHistory);
@@ -137,7 +137,7 @@ describe('updateCustomerReferent', () => {
       const referent = new ObjectId();
       const lastHistory = { endDate: moment().subtract(1, 'd').endOf('d').toDate(), auxiliary: { _id: referent } };
 
-      findReferentHistory.returns(SinonMongoose.stubChainedQueries([[lastHistory]], ['sort', 'limit', 'lean']));
+      findReferentHistory.returns(SinonMongoose.stubChainedQueries([lastHistory], ['sort', 'limit', 'lean']));
 
       await ReferentHistoriesHelper.updateCustomerReferent(customerId, referent.toHexString(), company);
       sinon.assert.calledOnceWithExactly(updateLastHistory, lastHistory, { $unset: { endDate: '' } });
@@ -161,7 +161,7 @@ describe('updateCustomerReferent', () => {
         auxiliary: { _id: new ObjectId() },
       };
 
-      findReferentHistory.returns(SinonMongoose.stubChainedQueries([[lastHistory]], ['sort', 'limit', 'lean']));
+      findReferentHistory.returns(SinonMongoose.stubChainedQueries([lastHistory], ['sort', 'limit', 'lean']));
 
       await ReferentHistoriesHelper.updateCustomerReferent(customerId, referent.toHexString(), company);
       sinon.assert.notCalled(updateLastHistory);
@@ -183,9 +183,9 @@ describe('updateCustomerReferent', () => {
     it('Case 1 : no referent and previous history starts today', async () => {
       const lastHistory = { startDate: moment().startOf('d').toDate(), _id: new ObjectId() };
 
-      findReferentHistory.returns(SinonMongoose.stubChainedQueries([[lastHistory]], ['sort', 'limit', 'lean']));
+      findReferentHistory.returns(SinonMongoose.stubChainedQueries([lastHistory], ['sort', 'limit', 'lean']));
       findOneCustomer.returns(
-        SinonMongoose.stubChainedQueries([{ firstIntervention: { startDate: moment().toDate() } }])
+        SinonMongoose.stubChainedQueries({ firstIntervention: { startDate: moment().toDate() } })
       );
 
       await ReferentHistoriesHelper.updateCustomerReferent(customerId, null, company);
@@ -216,8 +216,8 @@ describe('updateCustomerReferent', () => {
     it('Case 2 : no referent and customer doesn\'t have first intervention', async () => {
       const lastHistory = { startDate: moment().subtract(1, 'month').startOf('d').toDate(), _id: new ObjectId() };
 
-      findReferentHistory.returns(SinonMongoose.stubChainedQueries([[lastHistory]], ['sort', 'limit', 'lean']));
-      findOneCustomer.returns(SinonMongoose.stubChainedQueries([{}]));
+      findReferentHistory.returns(SinonMongoose.stubChainedQueries([lastHistory], ['sort', 'limit', 'lean']));
+      findOneCustomer.returns(SinonMongoose.stubChainedQueries({}));
 
       await ReferentHistoriesHelper.updateCustomerReferent(customerId, null, company);
       sinon.assert.notCalled(updateLastHistory);
@@ -247,9 +247,9 @@ describe('updateCustomerReferent', () => {
     it('Case 3 : no referent', async () => {
       const lastHistory = { startDate: moment().subtract(1, 'month').startOf('d').toDate(), _id: new ObjectId() };
 
-      findReferentHistory.returns(SinonMongoose.stubChainedQueries([[lastHistory]], ['sort', 'limit', 'lean']));
+      findReferentHistory.returns(SinonMongoose.stubChainedQueries([lastHistory], ['sort', 'limit', 'lean']));
       findOneCustomer.returns(
-        SinonMongoose.stubChainedQueries([{ firstIntervention: { startDate: moment().toDate() } }])
+        SinonMongoose.stubChainedQueries({ firstIntervention: { startDate: moment().toDate() } })
       );
 
       await ReferentHistoriesHelper.updateCustomerReferent(customerId, null, company);
@@ -285,9 +285,9 @@ describe('updateCustomerReferent', () => {
       const referent = new ObjectId();
       const lastHistory = { auxiliary: { _id: referent }, _id: new ObjectId() };
 
-      findReferentHistory.returns(SinonMongoose.stubChainedQueries([[lastHistory]], ['sort', 'limit', 'lean']));
+      findReferentHistory.returns(SinonMongoose.stubChainedQueries([lastHistory], ['sort', 'limit', 'lean']));
       findOneCustomer.returns(
-        SinonMongoose.stubChainedQueries([{ firstIntervention: { startDate: moment().toDate() } }])
+        SinonMongoose.stubChainedQueries({ firstIntervention: { startDate: moment().toDate() } })
       );
 
       await ReferentHistoriesHelper.updateCustomerReferent(customerId, referent.toHexString(), company);
@@ -319,8 +319,8 @@ describe('updateCustomerReferent', () => {
       const referent = new ObjectId();
       const lastHistory = { auxiliary: { _id: new ObjectId() }, _id: new ObjectId() };
 
-      findReferentHistory.returns(SinonMongoose.stubChainedQueries([[lastHistory]], ['sort', 'limit', 'lean']));
-      findOneCustomer.returns(SinonMongoose.stubChainedQueries([{}]));
+      findReferentHistory.returns(SinonMongoose.stubChainedQueries([lastHistory], ['sort', 'limit', 'lean']));
+      findOneCustomer.returns(SinonMongoose.stubChainedQueries({}));
 
       await ReferentHistoriesHelper.updateCustomerReferent(customerId, referent.toHexString(), company);
       sinon.assert.calledOnceWithExactly(
@@ -359,9 +359,9 @@ describe('updateCustomerReferent', () => {
         auxiliary: { _id: new ObjectId() },
       };
 
-      findReferentHistory.returns(SinonMongoose.stubChainedQueries([[lastHistory]], ['sort', 'limit', 'lean']));
+      findReferentHistory.returns(SinonMongoose.stubChainedQueries([lastHistory], ['sort', 'limit', 'lean']));
       findOneCustomer.returns(
-        SinonMongoose.stubChainedQueries([{ firstIntervention: { startDate: moment().toDate() } }])
+        SinonMongoose.stubChainedQueries({ firstIntervention: { startDate: moment().toDate() } })
       );
 
       await ReferentHistoriesHelper.updateCustomerReferent(customerId, referent.toHexString(), company);
@@ -393,9 +393,9 @@ describe('updateCustomerReferent', () => {
       const referent = new ObjectId();
       const lastHistory = { auxiliary: { _id: new ObjectId() }, _id: new ObjectId() };
 
-      findReferentHistory.returns(SinonMongoose.stubChainedQueries([[lastHistory]], ['sort', 'limit', 'lean']));
+      findReferentHistory.returns(SinonMongoose.stubChainedQueries([lastHistory], ['sort', 'limit', 'lean']));
       findOneCustomer.returns(
-        SinonMongoose.stubChainedQueries([{ firstIntervention: { startDate: moment().toDate() } }])
+        SinonMongoose.stubChainedQueries({ firstIntervention: { startDate: moment().toDate() } })
       );
 
       await ReferentHistoriesHelper.updateCustomerReferent(customerId, referent.toHexString(), company);

--- a/tests/unit/helpers/repetitions.test.js
+++ b/tests/unit/helpers/repetitions.test.js
@@ -30,7 +30,7 @@ describe('updateRepetitions', () => {
       _id: new ObjectId(),
       test: 's',
     };
-    findOneRepetition.returns(SinonMongoose.stubChainedQueries([repetition], ['lean']));
+    findOneRepetition.returns(SinonMongoose.stubChainedQueries(repetition, ['lean']));
     formatEditionPayloadStub.returns({ payload: 'payload' });
 
     const result = await RepetitionHelper.updateRepetitions(eventPayload, parentId);
@@ -51,7 +51,7 @@ describe('updateRepetitions', () => {
 
   it('should do nothing if repetition does not exist', async () => {
     const parentId = new ObjectId();
-    findOneRepetition.returns(SinonMongoose.stubChainedQueries([], ['lean']));
+    findOneRepetition.returns(SinonMongoose.stubChainedQueries(null, ['lean']));
 
     const result = await RepetitionHelper.updateRepetitions({}, parentId);
 

--- a/tests/unit/helpers/sectorHistories.test.js
+++ b/tests/unit/helpers/sectorHistories.test.js
@@ -33,8 +33,8 @@ describe('updateHistoryOnSectorUpdate', () => {
   });
 
   it('should create sector history if no previous one', async () => {
-    findOne.returns(SinonMongoose.stubChainedQueries([], ['lean']));
-    find.returns(SinonMongoose.stubChainedQueries([[]], ['sort', 'lean']));
+    findOne.returns(SinonMongoose.stubChainedQueries(null, ['lean']));
+    find.returns(SinonMongoose.stubChainedQueries([], ['sort', 'lean']));
 
     const result = await SectorHistoryHelper.updateHistoryOnSectorUpdate(auxiliaryId, sector.toHexString(), companyId);
 
@@ -53,8 +53,8 @@ describe('updateHistoryOnSectorUpdate', () => {
   it('should return nothing if last sector history sector is same than new one', async () => {
     const sectorHistory = { _id: new ObjectId(), sector, startDate: '2019-09-10T00:00:00' };
 
-    findOne.returns(SinonMongoose.stubChainedQueries([sectorHistory], ['lean']));
-    find.returns(SinonMongoose.stubChainedQueries([[{ _id: new ObjectId() }]], ['sort', 'lean']));
+    findOne.returns(SinonMongoose.stubChainedQueries(sectorHistory, ['lean']));
+    find.returns(SinonMongoose.stubChainedQueries([{ _id: new ObjectId() }], ['sort', 'lean']));
 
     const result = await SectorHistoryHelper.updateHistoryOnSectorUpdate(auxiliaryId, sector.toHexString(), companyId);
 
@@ -68,9 +68,9 @@ describe('updateHistoryOnSectorUpdate', () => {
 
   it('should return an error if no last sector history and has an ongoing contract', async () => {
     try {
-      findOne.returns(SinonMongoose.stubChainedQueries([], ['lean']));
+      findOne.returns(SinonMongoose.stubChainedQueries(null, ['lean']));
       find.returns(SinonMongoose.stubChainedQueries(
-        [[{ _id: new ObjectId(), startDate: '2020-01-01T23:59:59' }]],
+        [{ _id: new ObjectId(), startDate: '2020-01-01T23:59:59' }],
         ['sort', 'lean']
       ));
 
@@ -90,8 +90,8 @@ describe('updateHistoryOnSectorUpdate', () => {
   it('should update sector history if auxiliary does not have contract', async () => {
     const sectorHistory = { _id: new ObjectId(), sector: new ObjectId(), startDate: '2019-09-10T00:00:00' };
 
-    findOne.returns(SinonMongoose.stubChainedQueries([sectorHistory], ['lean']));
-    find.returns(SinonMongoose.stubChainedQueries([[]], ['sort', 'lean']));
+    findOne.returns(SinonMongoose.stubChainedQueries(sectorHistory, ['lean']));
+    find.returns(SinonMongoose.stubChainedQueries([], ['sort', 'lean']));
     updateOne.returns({ sector });
 
     const result = await SectorHistoryHelper.updateHistoryOnSectorUpdate(auxiliaryId, sector.toHexString(), companyId);
@@ -118,9 +118,9 @@ describe('updateHistoryOnSectorUpdate', () => {
   });
 
   it('should update sector history if auxiliary is between contracts', async () => {
-    findOne.returns(SinonMongoose.stubChainedQueries([], ['lean']));
+    findOne.returns(SinonMongoose.stubChainedQueries(null, ['lean']));
     find.returns(SinonMongoose.stubChainedQueries(
-      [[{ startDate: '2020-01-01T00:00:00', endDate: '2020-08-01T23:59:59' }, { startDate: moment().add(1, 'd') }]],
+      [{ startDate: '2020-01-01T00:00:00', endDate: '2020-08-01T23:59:59' }, { startDate: moment().add(1, 'd') }],
       ['sort', 'lean']
     ));
     createHistoryStub.returns({ sector });
@@ -150,8 +150,8 @@ describe('updateHistoryOnSectorUpdate', () => {
   it('should update sector history if many changes made on the same day', async () => {
     const sectorHistory = { _id: new ObjectId(), sector: new ObjectId(), startDate: moment().startOf('day') };
 
-    findOne.returns(SinonMongoose.stubChainedQueries([sectorHistory], ['lean']));
-    find.returns(SinonMongoose.stubChainedQueries([[{ _id: new ObjectId() }]], ['sort', 'lean']));
+    findOne.returns(SinonMongoose.stubChainedQueries(sectorHistory, ['lean']));
+    find.returns(SinonMongoose.stubChainedQueries([{ _id: new ObjectId() }], ['sort', 'lean']));
     updateOne.returns({ sector });
 
     const result = await SectorHistoryHelper.updateHistoryOnSectorUpdate(auxiliaryId, sector.toHexString(), companyId);
@@ -180,9 +180,9 @@ describe('updateHistoryOnSectorUpdate', () => {
   it('should update sector history and create new one', async () => {
     const sectorHistory = { _id: new ObjectId(), sector: new ObjectId(), startDate: '2019-10-10' };
 
-    findOne.returns(SinonMongoose.stubChainedQueries([sectorHistory], ['lean']));
+    findOne.returns(SinonMongoose.stubChainedQueries(sectorHistory, ['lean']));
     find.returns(SinonMongoose.stubChainedQueries(
-      [[{ _id: new ObjectId(), startDate: moment('2019-10-12').toDate() }]],
+      [{ _id: new ObjectId(), startDate: moment('2019-10-12').toDate() }],
       ['sort', 'lean']
     ));
     updateOne.returns({ sector });
@@ -246,8 +246,8 @@ describe('createHistoryOnContractCreation', () => {
     const user = { _id: auxiliaryId, sector };
     const existingHistory = { _id: new ObjectId(), sector };
 
-    countDocuments.returns(SinonMongoose.stubChainedQueries([], ['lean']));
-    findOne.returns(SinonMongoose.stubChainedQueries([existingHistory], ['lean']));
+    countDocuments.returns(SinonMongoose.stubChainedQueries(null, ['lean']));
+    findOne.returns(SinonMongoose.stubChainedQueries(existingHistory, ['lean']));
 
     await SectorHistoryHelper.createHistoryOnContractCreation(user, newContract, companyId);
 
@@ -279,8 +279,8 @@ describe('createHistoryOnContractCreation', () => {
   it('should create sector history if does not exist without start date', async () => {
     const user = { _id: auxiliaryId, sector };
 
-    countDocuments.returns(SinonMongoose.stubChainedQueries([], ['lean']));
-    findOne.returns(SinonMongoose.stubChainedQueries([], ['lean']));
+    countDocuments.returns(SinonMongoose.stubChainedQueries(null, ['lean']));
+    findOne.returns(SinonMongoose.stubChainedQueries(null, ['lean']));
 
     await SectorHistoryHelper.createHistoryOnContractCreation(user, newContract, companyId);
 
@@ -315,7 +315,7 @@ describe('createHistoryOnContractCreation', () => {
     try {
       const existingWrongHistory = { _id: new ObjectId(), sector };
 
-      countDocuments.returns(SinonMongoose.stubChainedQueries([existingWrongHistory], ['lean']));
+      countDocuments.returns(SinonMongoose.stubChainedQueries(existingWrongHistory, ['lean']));
 
       await SectorHistoryHelper.createHistoryOnContractCreation(user, newContract, companyId);
 
@@ -367,7 +367,7 @@ describe('updateHistoryOnContractUpdate', () => {
 
   it('should update sector history if contract has not started yet', async () => {
     findOne.returns(
-      SinonMongoose.stubChainedQueries([{ user: auxiliaryId, startDate: moment().add(2, 'month') }], ['lean'])
+      SinonMongoose.stubChainedQueries({ user: auxiliaryId, startDate: moment().add(2, 'month') }, ['lean'])
     );
 
     await SectorHistoryHelper.updateHistoryOnContractUpdate(contractId, newContract, companyId);
@@ -386,8 +386,8 @@ describe('updateHistoryOnContractUpdate', () => {
   it('should update and remove sector history if contract has started', async () => {
     const sectorHistory = [{ _id: new ObjectId() }];
 
-    findOne.returns(SinonMongoose.stubChainedQueries([{ user: auxiliaryId, startDate: '2019-01-01' }], ['lean']));
-    find.returns(SinonMongoose.stubChainedQueries([sectorHistory], ['sort', 'limit', 'lean']));
+    findOne.returns(SinonMongoose.stubChainedQueries({ user: auxiliaryId, startDate: '2019-01-01' }, ['lean']));
+    find.returns(SinonMongoose.stubChainedQueries(sectorHistory, ['sort', 'limit', 'lean']));
 
     await SectorHistoryHelper.updateHistoryOnContractUpdate(contractId, newContract, companyId);
 
@@ -440,7 +440,7 @@ describe('updateHistoryOnContractDeletion', () => {
   });
 
   it('should remove sector histories and update last one', async () => {
-    findOne.returns(SinonMongoose.stubChainedQueries([{ startDate: '2020-10-10' }], ['lean']));
+    findOne.returns(SinonMongoose.stubChainedQueries({ startDate: '2020-10-10' }, ['lean']));
 
     await SectorHistoryHelper.updateHistoryOnContractDeletion(contract, companyId);
 
@@ -478,7 +478,7 @@ describe('createHistory', () => {
   it('should create SectorHistory without startDate', async () => {
     const sectorHistory = { auxiliary: auxiliaryId, sector, company: companyId };
 
-    create.returns(SinonMongoose.stubChainedQueries([sectorHistory], ['toObject']));
+    create.returns(SinonMongoose.stubChainedQueries(sectorHistory, ['toObject']));
 
     const result = await SectorHistoryHelper.createHistory({ _id: auxiliaryId, sector }, companyId);
 
@@ -495,7 +495,7 @@ describe('createHistory', () => {
   it('should create SectorHistory with startDate', async () => {
     const sectorHistory = { auxiliary: auxiliaryId, sector, company: companyId, startDate: '2020-01-01' };
 
-    create.returns(SinonMongoose.stubChainedQueries([sectorHistory], ['toObject']));
+    create.returns(SinonMongoose.stubChainedQueries(sectorHistory, ['toObject']));
 
     const result = await SectorHistoryHelper.createHistory({ _id: auxiliaryId, sector }, companyId, '2020-01-01');
 
@@ -551,7 +551,7 @@ describe('getAuxiliarySectors', () => {
     const sectorId1 = new ObjectId();
     const sectorId2 = new ObjectId();
     sectorHistoryFind.returns(SinonMongoose.stubChainedQueries(
-      [[{ sector: sectorId1 }, { sector: sectorId1 }, { sector: sectorId2 }]],
+      [{ sector: sectorId1 }, { sector: sectorId1 }, { sector: sectorId2 }],
       ['lean']
     ));
 
@@ -581,7 +581,7 @@ describe('getAuxiliarySectors', () => {
   it('should return an empty array if no sector on the time range', async () => {
     const auxiliaryId = new ObjectId();
     const companyId = new ObjectId();
-    sectorHistoryFind.returns(SinonMongoose.stubChainedQueries([[]], ['lean']));
+    sectorHistoryFind.returns(SinonMongoose.stubChainedQueries([], ['lean']));
 
     const result = await SectorHistoryHelper.getAuxiliarySectors(auxiliaryId, companyId, '2020-01-01', '2020-02-02');
 

--- a/tests/unit/helpers/sectors.test.js
+++ b/tests/unit/helpers/sectors.test.js
@@ -19,7 +19,7 @@ describe('create', () => {
     const companyId = new ObjectId();
     const credentials = { company: { _id: companyId } };
 
-    create.returns(SinonMongoose.stubChainedQueries([{ name: 'toto', company: companyId }], ['toObject']));
+    create.returns(SinonMongoose.stubChainedQueries({ name: 'toto', company: companyId }, ['toObject']));
 
     const result = await SectorsHelper.create(payload, credentials);
 
@@ -48,7 +48,7 @@ describe('list', () => {
     const credentials = { company: { _id: new ObjectId() } };
     const companyId = credentials.company._id;
 
-    find.returns(SinonMongoose.stubChainedQueries([{ name: 'toto', company: companyId }], ['lean']));
+    find.returns(SinonMongoose.stubChainedQueries({ name: 'toto', company: companyId }, ['lean']));
 
     await SectorsHelper.list(credentials);
 
@@ -77,7 +77,7 @@ describe('update', () => {
     const companyId = new ObjectId();
     const credentials = { company: { _id: companyId } };
 
-    findOneAndUpdate.returns(SinonMongoose.stubChainedQueries([], ['lean']));
+    findOneAndUpdate.returns(SinonMongoose.stubChainedQueries(null, ['lean']));
 
     await SectorsHelper.update(sectorId, payload, credentials);
 

--- a/tests/unit/helpers/services.test.js
+++ b/tests/unit/helpers/services.test.js
@@ -18,7 +18,7 @@ describe('list', () => {
   });
 
   it('should find services', async () => {
-    find.returns(SinonMongoose.stubChainedQueries([[{ name: 'test' }]]));
+    find.returns(SinonMongoose.stubChainedQueries([{ name: 'test' }]));
 
     const result = await ServiceHelper.list({ company: { _id: companyId } }, { isArchived: true });
 

--- a/tests/unit/helpers/steps.test.js
+++ b/tests/unit/helpers/steps.test.js
@@ -270,7 +270,7 @@ describe('list', () => {
       },
     ];
 
-    stepFind.returns(SinonMongoose.stubChainedQueries([steps], ['populate', 'lean']));
+    stepFind.returns(SinonMongoose.stubChainedQueries(steps, ['populate', 'lean']));
 
     const result = await StepHelper.list(programId);
 

--- a/tests/unit/helpers/subPrograms.test.js
+++ b/tests/unit/helpers/subPrograms.test.js
@@ -97,7 +97,7 @@ describe('updatedSubProgram', () => {
         ],
       };
 
-      findOneAndUpdate.returns(SinonMongoose.stubChainedQueries([updatedSubProgram]));
+      findOneAndUpdate.returns(SinonMongoose.stubChainedQueries(updatedSubProgram));
       stepUpdateManyStub.returns({ activities });
 
       await SubProgramHelper.updateSubProgram(subProgram._id, payload);
@@ -146,7 +146,7 @@ describe('updatedSubProgram', () => {
         accessRules: [],
       };
 
-      findOneAndUpdate.returns(SinonMongoose.stubChainedQueries([updatedSubProgram]));
+      findOneAndUpdate.returns(SinonMongoose.stubChainedQueries(updatedSubProgram));
       stepUpdateManyStub.returns({ activities });
       courseCreateStub.returns(course);
 
@@ -200,7 +200,7 @@ describe('updatedSubProgram', () => {
           accessRules: [payload.accessCompany],
         };
 
-        findOneAndUpdate.returns(SinonMongoose.stubChainedQueries([updatedSubProgram]));
+        findOneAndUpdate.returns(SinonMongoose.stubChainedQueries(updatedSubProgram));
         stepUpdateManyStub.returns({ activities });
         courseCreateStub.returns(course);
 
@@ -264,7 +264,7 @@ describe('listELearningDraft', () => {
       },
     ];
 
-    find.returns(SinonMongoose.stubChainedQueries([subProgramsList]));
+    find.returns(SinonMongoose.stubChainedQueries(subProgramsList));
 
     const result = await SubProgramHelper.listELearningDraft();
 
@@ -303,7 +303,7 @@ describe('listELearningDraft', () => {
       },
     ];
 
-    find.returns(SinonMongoose.stubChainedQueries([subProgramsList]));
+    find.returns(SinonMongoose.stubChainedQueries(subProgramsList));
 
     const result = await SubProgramHelper.listELearningDraft(testerRestrictedPrograms);
 
@@ -346,7 +346,7 @@ describe('getSubProgram', () => {
       }],
     };
 
-    findOne.returns(SinonMongoose.stubChainedQueries([subProgram]));
+    findOne.returns(SinonMongoose.stubChainedQueries(subProgram));
 
     const result = await SubProgramHelper.getSubProgram(subProgram._id);
 

--- a/tests/unit/helpers/subscriptions.test.js
+++ b/tests/unit/helpers/subscriptions.test.js
@@ -234,7 +234,7 @@ describe('updateSubscription', () => {
       subscriptions: [{ _id: subscriptionId, evenings: 2, service: new ObjectId() }],
     };
 
-    findOneAndUpdate.returns(SinonMongoose.stubChainedQueries([customer]));
+    findOneAndUpdate.returns(SinonMongoose.stubChainedQueries(customer));
     populateSubscriptionsServices.returns(customer);
 
     const result = await SubscriptionsHelper.updateSubscription(params, payload);
@@ -279,8 +279,8 @@ describe('addSubscription', () => {
     const customer = { _id: customerId };
     const payload = { service: new ObjectId(), estimatedWeeklyVolume: 10 };
 
-    findById.returns(SinonMongoose.stubChainedQueries([customer], ['lean']));
-    findOneAndUpdate.returns(SinonMongoose.stubChainedQueries([customer]));
+    findById.returns(SinonMongoose.stubChainedQueries(customer, ['lean']));
+    findOneAndUpdate.returns(SinonMongoose.stubChainedQueries(customer));
     populateSubscriptionsServices.returns(customer);
 
     const result = await SubscriptionsHelper.addSubscription(customerId, payload);
@@ -310,8 +310,8 @@ describe('addSubscription', () => {
     const customer = { _id: customerId, subscriptions: [{ service: new ObjectId() }] };
     const payload = { service: (new ObjectId()).toHexString(), estimatedWeeklyVolume: 10 };
 
-    findById.returns(SinonMongoose.stubChainedQueries([customer], ['lean']));
-    findOneAndUpdate.returns(SinonMongoose.stubChainedQueries([customer]));
+    findById.returns(SinonMongoose.stubChainedQueries(customer, ['lean']));
+    findOneAndUpdate.returns(SinonMongoose.stubChainedQueries(customer));
     populateSubscriptionsServices.returns(customer);
 
     const result = await SubscriptionsHelper.addSubscription(customerId, payload);
@@ -343,7 +343,7 @@ describe('addSubscription', () => {
       const customer = { _id: customerId, subscriptions: [{ service: serviceId }] };
       const payload = { service: serviceId.toHexString(), estimatedWeeklyVolume: 10 };
 
-      findById.returns(SinonMongoose.stubChainedQueries([customer], ['lean']));
+      findById.returns(SinonMongoose.stubChainedQueries(customer, ['lean']));
 
       await SubscriptionsHelper.addSubscription(customerId, payload);
     } catch (e) {
@@ -374,12 +374,12 @@ describe('deleteSubscription', () => {
 
   it('should delete subscription and the subscriptionhistory associated', async () => {
     findByIdCustomer.returns(SinonMongoose.stubChainedQueries(
-      [{
+      {
         subscriptionsHistory: [
           { subscriptions: [{ subscriptionId }] },
           { subscriptions: [{ subscriptionId }, { subscriptionId: secondSubId }] },
         ],
-      }],
+      },
       ['lean']
     ));
 
@@ -414,7 +414,7 @@ describe('createSubscriptionHistory', () => {
     const payload = { evenings: 2 };
     const customer = { _id: customerId };
 
-    findOneAndUpdateCustomer.returns(SinonMongoose.stubChainedQueries([customer], ['lean']));
+    findOneAndUpdateCustomer.returns(SinonMongoose.stubChainedQueries(customer, ['lean']));
 
     const result = await SubscriptionsHelper.createSubscriptionHistory(customerId.toHexString(), payload);
 

--- a/tests/unit/helpers/surcharges.test.js
+++ b/tests/unit/helpers/surcharges.test.js
@@ -19,7 +19,7 @@ describe('list', () => {
     const companyId = new ObjectId();
     const credentials = { company: { _id: companyId } };
 
-    find.returns(SinonMongoose.stubChainedQueries([[{ company: companyId, name: 'Coucou' }]], ['lean']));
+    find.returns(SinonMongoose.stubChainedQueries([{ company: companyId, name: 'Coucou' }], ['lean']));
 
     const result = await SurchargesHelper.list(credentials);
     expect(result).toEqual([{ company: companyId, name: 'Coucou' }]);

--- a/tests/unit/helpers/taxCertificates.test.js
+++ b/tests/unit/helpers/taxCertificates.test.js
@@ -28,7 +28,7 @@ describe('list', () => {
     const companyId = new ObjectId();
     const customer = new ObjectId();
 
-    find.returns(SinonMongoose.stubChainedQueries([taxCertificates], ['lean']));
+    find.returns(SinonMongoose.stubChainedQueries(taxCertificates, ['lean']));
 
     const result = await TaxCertificateHelper.list(customer, { company: { _id: companyId } });
 
@@ -218,7 +218,7 @@ describe('generateTaxCertificatePdf', () => {
     const credentials = { company: { _id: companyId } };
     const taxCertificate = { _id: taxCertificateId, year: '2019' };
 
-    findOne.returns(SinonMongoose.stubChainedQueries([taxCertificate]));
+    findOne.returns(SinonMongoose.stubChainedQueries(taxCertificate));
     getTaxCertificateInterventions.returns(['interventions']);
     getTaxCertificatesPayments.returns({ paid: 1200, cesu: 500 });
     formatPdf.returns('data');
@@ -342,7 +342,7 @@ describe('remove', () => {
   it('should delete tax certificate', async () => {
     const taxCertificateId = new ObjectId();
 
-    findOneAndDelete.returns(SinonMongoose.stubChainedQueries([{ _id: new ObjectId() }], ['lean']));
+    findOneAndDelete.returns(SinonMongoose.stubChainedQueries({ _id: new ObjectId() }, ['lean']));
 
     await TaxCertificateHelper.remove(taxCertificateId);
 
@@ -357,7 +357,7 @@ describe('remove', () => {
     const taxCertificateId = new ObjectId();
     const taxCertificate = { _id: new ObjectId(), driveFile: { driveId: new ObjectId() } };
 
-    findOneAndDelete.returns(SinonMongoose.stubChainedQueries([taxCertificate], ['lean']));
+    findOneAndDelete.returns(SinonMongoose.stubChainedQueries(taxCertificate, ['lean']));
 
     await TaxCertificateHelper.remove(taxCertificateId);
 

--- a/tests/unit/helpers/thirdPartyPayers.test.js
+++ b/tests/unit/helpers/thirdPartyPayers.test.js
@@ -31,7 +31,7 @@ describe('create', () => {
     const credentials = { company: { _id: new ObjectId() } };
     const payloadWithCompany = { ...payload, company: credentials.company._id };
 
-    create.returns(SinonMongoose.stubChainedQueries([payloadWithCompany], ['toObject']));
+    create.returns(SinonMongoose.stubChainedQueries(payloadWithCompany, ['toObject']));
 
     const result = await ThirdPartyPayersHelper.create(payload, credentials);
 
@@ -56,7 +56,7 @@ describe('list', () => {
     const credentials = { company: { _id: new ObjectId() } };
     const tppList = [{ _id: new ObjectId() }, { _id: new ObjectId() }];
 
-    find.returns(SinonMongoose.stubChainedQueries([tppList], ['lean']));
+    find.returns(SinonMongoose.stubChainedQueries(tppList, ['lean']));
 
     const result = await ThirdPartyPayersHelper.list(credentials);
 
@@ -81,7 +81,7 @@ describe('update', () => {
     const payload = { siret: '13605658901234' };
     const tppId = new ObjectId();
 
-    findOneAndUpdate.returns(SinonMongoose.stubChainedQueries([{ _id: tppId }], ['lean']));
+    findOneAndUpdate.returns(SinonMongoose.stubChainedQueries({ _id: tppId }, ['lean']));
 
     const result = await ThirdPartyPayersHelper.update(tppId, payload);
 

--- a/tests/unit/helpers/userCompanies.test.js
+++ b/tests/unit/helpers/userCompanies.test.js
@@ -28,7 +28,7 @@ describe('create', () => {
     const userId = new ObjectId();
     const companyId = new ObjectId();
 
-    findOne.returns(SinonMongoose.stubChainedQueries([], ['lean']));
+    findOne.returns(SinonMongoose.stubChainedQueries(null, ['lean']));
 
     await UserCompaniesHelper.create(userId, companyId);
 
@@ -44,7 +44,7 @@ describe('create', () => {
     const userId = new ObjectId();
     const companyId = new ObjectId();
 
-    findOne.returns(SinonMongoose.stubChainedQueries([{ user: userId, company: companyId }], ['lean']));
+    findOne.returns(SinonMongoose.stubChainedQueries({ user: userId, company: companyId }, ['lean']));
 
     await UserCompaniesHelper.create(userId, companyId);
 
@@ -61,7 +61,7 @@ describe('create', () => {
     const companyId = new ObjectId();
 
     try {
-      findOne.returns(SinonMongoose.stubChainedQueries([{ user: userId, company: new ObjectId() }], ['lean']));
+      findOne.returns(SinonMongoose.stubChainedQueries({ user: userId, company: new ObjectId() }, ['lean']));
 
       await UserCompaniesHelper.create(userId, companyId);
 

--- a/tests/unit/helpers/users.test.js
+++ b/tests/unit/helpers/users.test.js
@@ -44,7 +44,7 @@ describe('formatQueryForUsersList', () => {
     const users = [{ _id: new ObjectId(), user: new ObjectId() }];
     const query = { company: companyId, _id: { $in: users.map(u => u.user) } };
 
-    findUserCompany.returns(SinonMongoose.stubChainedQueries([users], ['lean']));
+    findUserCompany.returns(SinonMongoose.stubChainedQueries(users, ['lean']));
 
     const result = await UsersHelper.formatQueryForUsersList(query);
 
@@ -65,8 +65,8 @@ describe('formatQueryForUsersList', () => {
     };
     const roles = [{ _id: query.role[0]._id, interface: 'vendor' }, { _id: query.role[1]._id, interface: 'vendor' }];
 
-    find.returns(SinonMongoose.stubChainedQueries([roles], ['lean']));
-    findUserCompany.returns(SinonMongoose.stubChainedQueries([users], ['lean']));
+    find.returns(SinonMongoose.stubChainedQueries(roles, ['lean']));
+    findUserCompany.returns(SinonMongoose.stubChainedQueries(users, ['lean']));
 
     const result = await UsersHelper.formatQueryForUsersList(query);
     expect(result).toEqual({
@@ -87,7 +87,7 @@ describe('formatQueryForUsersList', () => {
   it('should return 404 if role does not exist', async () => {
     const query = { company: companyId, role: [{ _id: new ObjectId() }, { _id: new ObjectId() }] };
     try {
-      find.returns(SinonMongoose.stubChainedQueries([[]], ['lean']));
+      find.returns(SinonMongoose.stubChainedQueries([], ['lean']));
 
       const result = await UsersHelper.formatQueryForUsersList(query);
       expect(result).toBeUndefined();
@@ -124,7 +124,7 @@ describe('getUsersList', () => {
 
     formatQueryForUsersListStub.returns(query);
 
-    find.returns(SinonMongoose.stubChainedQueries([users], ['populate', 'setOptions', 'lean']));
+    find.returns(SinonMongoose.stubChainedQueries(users, ['populate', 'setOptions', 'lean']));
 
     const result = await UsersHelper.getUsersList(query, { ...credentials, role: { client: 'test' } });
 
@@ -160,7 +160,7 @@ describe('getUsersList', () => {
     const roles = [new ObjectId(), new ObjectId()];
     const formattedQuery = { company: companyId, 'role.client': { $in: roles } };
 
-    find.returns(SinonMongoose.stubChainedQueries([users], ['populate', 'setOptions', 'lean']));
+    find.returns(SinonMongoose.stubChainedQueries(users, ['populate', 'setOptions', 'lean']));
 
     formatQueryForUsersListStub.returns(formattedQuery);
 
@@ -220,7 +220,7 @@ describe('getUsersListWithSectorHistories', () => {
       'role.client': { $in: roles },
     };
 
-    find.returns(SinonMongoose.stubChainedQueries([users], ['populate', 'setOptions', 'lean']));
+    find.returns(SinonMongoose.stubChainedQueries(users, ['populate', 'setOptions', 'lean']));
     formatQueryForUsersListStub.returns(formattedQuery);
 
     const result = await UsersHelper.getUsersListWithSectorHistories(
@@ -285,10 +285,7 @@ describe('getLearnerList', () => {
       { _id: users[1]._id, activityHistoryCount: 1, lastActivityHistory: users[1].activityHistories[0] },
     ];
 
-    findUser.returns(SinonMongoose.stubChainedQueries(
-      [users],
-      ['populate', 'setOptions', 'lean']
-    ));
+    findUser.returns(SinonMongoose.stubChainedQueries(users, ['populate', 'setOptions', 'lean']));
 
     const result = await UsersHelper.getLearnerList(query, credentials);
 
@@ -330,12 +327,9 @@ describe('getLearnerList', () => {
       { _id: users[1]._id, activityHistoryCount: 1, lastActivityHistory: users[1].activityHistories[0] },
     ];
 
-    findUserCompany.returns(SinonMongoose.stubChainedQueries([usersCompany], ['lean']));
-    findRole.returns(SinonMongoose.stubChainedQueries([rolesToExclude], ['lean']));
-    findUser.returns(SinonMongoose.stubChainedQueries(
-      [users],
-      ['populate', 'setOptions', 'lean']
-    ));
+    findUserCompany.returns(SinonMongoose.stubChainedQueries(usersCompany, ['lean']));
+    findRole.returns(SinonMongoose.stubChainedQueries(rolesToExclude, ['lean']));
+    findUser.returns(SinonMongoose.stubChainedQueries(users, ['populate', 'setOptions', 'lean']));
 
     const result = await UsersHelper.getLearnerList(query, credentials);
 
@@ -385,11 +379,8 @@ describe('getLearnerList', () => {
       { _id: users[1]._id, activityHistoryCount: 1, lastActivityHistory: users[1].activityHistories[0] },
     ];
 
-    findUserCompany.returns(SinonMongoose.stubChainedQueries([usersCompany], ['lean']));
-    findUser.returns(SinonMongoose.stubChainedQueries(
-      [users],
-      ['populate', 'setOptions', 'lean']
-    ));
+    findUserCompany.returns(SinonMongoose.stubChainedQueries(usersCompany, ['lean']));
+    findUser.returns(SinonMongoose.stubChainedQueries(users, ['populate', 'setOptions', 'lean']));
 
     const result = await UsersHelper.getLearnerList(query, credentials);
 
@@ -438,7 +429,7 @@ describe('getUser', () => {
     const user = { _id: userId, role: { name: 'helper', rights: [] } };
     const credentials = { company: { _id: new ObjectId() }, _id: new ObjectId() };
 
-    findOne.returns(SinonMongoose.stubChainedQueries([user]));
+    findOne.returns(SinonMongoose.stubChainedQueries(user));
 
     await UsersHelper.getUser(userId, credentials);
 
@@ -487,7 +478,7 @@ describe('getUser', () => {
     const user = { _id: userId, role: { vendor: 'trainer', rights: [] } };
     const credentials = { company: { _id: new ObjectId() }, _id: new ObjectId(), role: { vendor: 'trainer' } };
 
-    findOne.returns(SinonMongoose.stubChainedQueries([user]));
+    findOne.returns(SinonMongoose.stubChainedQueries(user));
 
     await UsersHelper.getUser(userId, credentials);
 
@@ -533,7 +524,7 @@ describe('getUser', () => {
     const user = { _id: userId, role: { vendor: 'trainer', rights: [] } };
     const credentials = { company: { _id: new ObjectId() }, _id: userId };
 
-    findOne.returns(SinonMongoose.stubChainedQueries([user]));
+    findOne.returns(SinonMongoose.stubChainedQueries(user));
 
     await UsersHelper.getUser(userId, credentials);
 
@@ -579,7 +570,7 @@ describe('getUser', () => {
     const user = { _id: userId, companyLinkRequest: { company: { _id: new ObjectId(), name: 'Alenvi' } } };
     const credentials = { _id: userId };
 
-    findOne.returns(SinonMongoose.stubChainedQueries([user]));
+    findOne.returns(SinonMongoose.stubChainedQueries(user));
 
     await UsersHelper.getUser(userId, credentials);
 
@@ -629,7 +620,7 @@ describe('getUser', () => {
     };
 
     try {
-      findOne.returns(SinonMongoose.stubChainedQueries([null]));
+      findOne.returns(SinonMongoose.stubChainedQueries(null));
 
       await UsersHelper.getUser(userId, credentials);
     } catch (e) {
@@ -695,7 +686,7 @@ describe('userExists', () => {
   });
 
   it('should find a user if credentials', async () => {
-    findOne.returns(SinonMongoose.stubChainedQueries([user], ['populate', 'lean']));
+    findOne.returns(SinonMongoose.stubChainedQueries(user, ['populate', 'lean']));
 
     const rep = await UsersHelper.userExists(email, vendorCredentials);
 
@@ -713,7 +704,7 @@ describe('userExists', () => {
   });
 
   it('should not find as email does not exist', async () => {
-    findOne.returns(SinonMongoose.stubChainedQueries([null], ['populate', 'lean']));
+    findOne.returns(SinonMongoose.stubChainedQueries(null, ['populate', 'lean']));
 
     const rep = await UsersHelper.userExists(nonExistantEmail, vendorCredentials);
 
@@ -731,7 +722,7 @@ describe('userExists', () => {
   });
 
   it('should only confirm targeted user exist, as logged user has only client role', async () => {
-    findOne.returns(SinonMongoose.stubChainedQueries([user], ['populate', 'lean']));
+    findOne.returns(SinonMongoose.stubChainedQueries(user, ['populate', 'lean']));
 
     const rep = await UsersHelper.userExists(email, clientCredentials);
 
@@ -748,7 +739,7 @@ describe('userExists', () => {
   });
 
   it('should find targeted user and give all infos, as targeted user has no company', async () => {
-    findOne.returns(SinonMongoose.stubChainedQueries([userWithoutCompany], ['populate', 'lean']));
+    findOne.returns(SinonMongoose.stubChainedQueries(userWithoutCompany, ['populate', 'lean']));
 
     const rep = await UsersHelper.userExists(email, clientCredentials);
 
@@ -766,7 +757,7 @@ describe('userExists', () => {
   });
 
   it('should find an email but no user if no credentials', async () => {
-    findOne.returns(SinonMongoose.stubChainedQueries([user], ['populate', 'lean']));
+    findOne.returns(SinonMongoose.stubChainedQueries(user, ['populate', 'lean']));
 
     const rep = await UsersHelper.userExists(email);
 
@@ -929,11 +920,11 @@ describe('createUser', () => {
     };
 
     roleFindById.returns(SinonMongoose.stubChainedQueries(
-      [{ _id: roleId, name: 'auxiliary', interface: 'client' }],
+      { _id: roleId, name: 'auxiliary', interface: 'client' },
       ['lean']
     ));
     userCreate.returns(newUser);
-    userFindOne.returns(SinonMongoose.stubChainedQueries([newUser]));
+    userFindOne.returns(SinonMongoose.stubChainedQueries(newUser));
 
     const result = await UsersHelper.createUser(payload, { company: { _id: companyId } });
 
@@ -980,11 +971,11 @@ describe('createUser', () => {
     const newUser = { ...payload, _id: userId, role: { _id: roleId, name: 'coach' } };
 
     roleFindById.returns(SinonMongoose.stubChainedQueries(
-      [{ _id: roleId, name: 'coach', interface: 'client' }],
+      { _id: roleId, name: 'coach', interface: 'client' },
       ['lean']
     ));
     userCreate.returns(newUser);
-    userFindOne.returns(SinonMongoose.stubChainedQueries([newUser]));
+    userFindOne.returns(SinonMongoose.stubChainedQueries(newUser));
 
     const result = await UsersHelper.createUser(payload, { company: { _id: companyId } });
 
@@ -1023,11 +1014,11 @@ describe('createUser', () => {
     const newUser = { ...payload, _id: userId, role: { _id: roleId, name: 'client_admin' } };
 
     roleFindById.returns(SinonMongoose.stubChainedQueries(
-      [{ _id: roleId, name: 'client_admin', interface: 'client' }],
+      { _id: roleId, name: 'client_admin', interface: 'client' },
       ['lean']
     ));
     userCreate.returns(newUser);
-    userFindOne.returns(SinonMongoose.stubChainedQueries([newUser]));
+    userFindOne.returns(SinonMongoose.stubChainedQueries(newUser));
 
     const result = await UsersHelper.createUser(payload, { company: { _id: credentialsCompanyId } });
 
@@ -1066,7 +1057,7 @@ describe('createUser', () => {
     const newUser = { ...payload, _id: userId, role: { _id: roleId, name: 'trainer' } };
 
     roleFindById.returns(SinonMongoose.stubChainedQueries(
-      [{ _id: roleId, name: 'trainer', interface: 'vendor' }],
+      { _id: roleId, name: 'trainer', interface: 'vendor' },
       ['lean']
     ));
     userCreate.returns(newUser);
@@ -1118,7 +1109,7 @@ describe('createUser', () => {
       origin: WEBAPP,
     };
     try {
-      roleFindById.returns(SinonMongoose.stubChainedQueries([null], ['lean']));
+      roleFindById.returns(SinonMongoose.stubChainedQueries(null, ['lean']));
 
       await UsersHelper.createUser(payload, { company: { _id: companyId } });
     } catch (e) {
@@ -1212,7 +1203,7 @@ describe('updateUser', () => {
     const payloadWithRole = { 'role.client': payload.role.toHexString() };
 
     roleFindById.returns(SinonMongoose.stubChainedQueries(
-      [{ _id: payload.role, name: 'test', interface: 'client' }],
+      { _id: payload.role, name: 'test', interface: 'client' },
       ['lean']
     ));
 
@@ -1250,7 +1241,7 @@ describe('updateUser', () => {
     const payloadWithRole = { 'role.client': payload.role.toHexString() };
 
     roleFindById.returns(SinonMongoose.stubChainedQueries(
-      [{ _id: payload.role, name: 'test', interface: 'client' }],
+      { _id: payload.role, name: 'test', interface: 'client' },
       ['lean']
     ));
 
@@ -1281,7 +1272,7 @@ describe('updateUser', () => {
   it('should return a 400 error if role does not exists', async () => {
     const payload = { role: new ObjectId() };
 
-    roleFindById.returns(SinonMongoose.stubChainedQueries([null], ['lean']));
+    roleFindById.returns(SinonMongoose.stubChainedQueries(null, ['lean']));
 
     try {
       await UsersHelper.updateUser(userId, payload, credentials);
@@ -1459,7 +1450,7 @@ describe('createDriveFolder', () => {
     const user = { _id: userId, identity: { lastname: 'Delenda' } };
 
     userCompanyFindOne.returns(SinonMongoose.stubChainedQueries(
-      [{ company: { auxiliariesFolderId: 'auxiliariesFolderId' }, user }],
+      { company: { auxiliariesFolderId: 'auxiliariesFolderId' }, user },
       ['populate', 'lean']
     ));
     createFolder.returns({ webViewLink: 'webViewLink', id: 'folderId' });
@@ -1486,7 +1477,7 @@ describe('createDriveFolder', () => {
   it('should return a 422 if user has no company', async () => {
     const userId = new ObjectId();
     try {
-      userCompanyFindOne.returns(SinonMongoose.stubChainedQueries([null], ['populate', 'lean']));
+      userCompanyFindOne.returns(SinonMongoose.stubChainedQueries(null, ['populate', 'lean']));
 
       await UsersHelper.createDriveFolder(userId);
     } catch (e) {
@@ -1510,7 +1501,7 @@ describe('createDriveFolder', () => {
     const userId = new ObjectId();
     try {
       userCompanyFindOne.returns(SinonMongoose.stubChainedQueries(
-        [{ user: { _id: userId }, company: { _id: new ObjectId() } }],
+        { user: { _id: userId }, company: { _id: new ObjectId() } },
         ['populate', 'lean']
       ));
 

--- a/tests/unit/jobs/billDispatch.test.js
+++ b/tests/unit/jobs/billDispatch.test.js
@@ -51,7 +51,7 @@ describe('method', () => {
     ];
 
     findBillsAndHelpersByCustomerStub.returns(customers);
-    findCompany.returns(SinonMongoose.stubChainedQueries([[{ name: 'Alenvi', _id: companyId }]], ['lean']));
+    findCompany.returns(SinonMongoose.stubChainedQueries([{ name: 'Alenvi', _id: companyId }], ['lean']));
     billAlertEmailStub
       .onFirstCall()
       .returns(Promise.resolve('leroi@lion.com'))
@@ -85,7 +85,7 @@ describe('method', () => {
     ];
 
     findBillsAndHelpersByCustomerStub.returns(customers);
-    findCompany.returns(SinonMongoose.stubChainedQueries([[{ name: 'Alenvi', _id: companyId }]], ['lean']));
+    findCompany.returns(SinonMongoose.stubChainedQueries([{ name: 'Alenvi', _id: companyId }], ['lean']));
     billAlertEmailStub
       .onFirstCall()
       .returns(Promise.resolve('leroi@lion.com'))

--- a/tests/unit/jobs/eventRepetitions.test.js
+++ b/tests/unit/jobs/eventRepetitions.test.js
@@ -84,8 +84,8 @@ describe('method', () => {
         },
       };
 
-      findRepetition.returns(SinonMongoose.stubChainedQueries([repetition]));
-      findCompany.returns(SinonMongoose.stubChainedQueries([[{ _id: companyId }]], ['lean']));
+      findRepetition.returns(SinonMongoose.stubChainedQueries(repetition));
+      findCompany.returns(SinonMongoose.stubChainedQueries([{ _id: companyId }], ['lean']));
 
       formatEventBasedOnRepetitionStub.returns(futureEvent);
       create.returns(futureEvent);
@@ -128,8 +128,8 @@ describe('method', () => {
       parentId: '5d84f869b7e67963c65236a9',
     }];
 
-    findCompany.returns(SinonMongoose.stubChainedQueries([[{ _id: companyId }]], ['lean']));
-    findRepetition.returns(SinonMongoose.stubChainedQueries([repetitions]));
+    findCompany.returns(SinonMongoose.stubChainedQueries([{ _id: companyId }], ['lean']));
+    findRepetition.returns(SinonMongoose.stubChainedQueries(repetitions));
 
     const result = await eventRepetitions.method(server);
 
@@ -176,8 +176,8 @@ describe('method', () => {
     ];
     const companyId = new ObjectId();
 
-    findRepetition.returns(SinonMongoose.stubChainedQueries([repetitions]));
-    findCompany.returns(SinonMongoose.stubChainedQueries([[{ _id: companyId }]], ['lean']));
+    findRepetition.returns(SinonMongoose.stubChainedQueries(repetitions));
+    findCompany.returns(SinonMongoose.stubChainedQueries([{ _id: companyId }], ['lean']));
 
     const futureEvent = new Event({
       type: 'internal_hour',
@@ -230,8 +230,8 @@ describe('method', () => {
 
     const companyId = new ObjectId();
 
-    findRepetition.returns(SinonMongoose.stubChainedQueries([repetition]));
-    findCompany.returns(SinonMongoose.stubChainedQueries([[{ _id: companyId }]], ['lean']));
+    findRepetition.returns(SinonMongoose.stubChainedQueries(repetition));
+    findCompany.returns(SinonMongoose.stubChainedQueries([{ _id: companyId }], ['lean']));
 
     formatEventBasedOnRepetitionStub.returns(Promise.reject(error));
 
@@ -285,8 +285,8 @@ describe('method', () => {
       repetition: { frequency: 'every_day', parentId },
     };
 
-    findRepetition.returns(SinonMongoose.stubChainedQueries([repetition]));
-    findCompany.returns(SinonMongoose.stubChainedQueries([[{ _id: companyId }]], ['lean']));
+    findRepetition.returns(SinonMongoose.stubChainedQueries(repetition));
+    findCompany.returns(SinonMongoose.stubChainedQueries([{ _id: companyId }], ['lean']));
     formatEventBasedOnRepetitionStub.returns(futureEvent);
     isAbsent.returns(true);
 

--- a/tests/unit/sinonMongoose.js
+++ b/tests/unit/sinonMongoose.js
@@ -9,9 +9,7 @@ const stubChainedQueries = (stubbedMethodReturns, chainedQueries = ['populate', 
   }
 
   let lastChainedQueryStub = sinon.stub();
-  for (let i = 0; i < stubbedMethodReturns.length; i++) {
-    lastChainedQueryStub = lastChainedQueryStub.onCall(i).returns(stubbedMethodReturns[i]);
-  }
+  lastChainedQueryStub = lastChainedQueryStub.returns(stubbedMethodReturns);
 
   chainedQueriesStubs[chainedQueries[chainedQueriesCount - 1]] = lastChainedQueryStub;
 
@@ -20,6 +18,7 @@ const stubChainedQueries = (stubbedMethodReturns, chainedQueries = ['populate', 
 
 const checkFirstQueryCoherence = (stubbedMethod, chainedPayload, callCount) => {
   const expectedQuery = chainedPayload[0].query;
+  if (!stubbedMethod.getCall(callCount)) console.log(stubbedMethod, chainedPayload[0].args, callCount);
   const receivedQuery = String(stubbedMethod.getCall(callCount).proxy);
   if (expectedQuery !== receivedQuery) {
     sinon.assert.fail(`Error in principal query : expected: "${expectedQuery}", received: "${receivedQuery}"`);

--- a/tests/unit/sinonMongoose.js
+++ b/tests/unit/sinonMongoose.js
@@ -8,8 +8,7 @@ const stubChainedQueries = (stubbedMethodReturns, chainedQueries = ['populate', 
     chainedQueriesStubs[chainedQueries[i]] = sinon.stub().returnsThis();
   }
 
-  let lastChainedQueryStub = sinon.stub();
-  lastChainedQueryStub = lastChainedQueryStub.returns(stubbedMethodReturns);
+  const lastChainedQueryStub = sinon.stub().returns(stubbedMethodReturns);
 
   chainedQueriesStubs[chainedQueries[chainedQueriesCount - 1]] = lastChainedQueryStub;
 
@@ -18,7 +17,7 @@ const stubChainedQueries = (stubbedMethodReturns, chainedQueries = ['populate', 
 
 const checkFirstQueryCoherence = (stubbedMethod, chainedPayload, callCount) => {
   const expectedQuery = chainedPayload[0].query;
-  if (!stubbedMethod.getCall(callCount)) sinon.assert.fail(`"${stubbedMethod}" stub not called on call ${callCount}`);
+  if (!stubbedMethod.getCall(callCount)) sinon.assert.fail(`"${stubbedMethod}" is not called ${callCount + 1} times`);
   const receivedQuery = String(stubbedMethod.getCall(callCount).proxy);
   if (expectedQuery !== receivedQuery) {
     sinon.assert.fail(`Error in principal query : expected: "${expectedQuery}", received: "${receivedQuery}"`);

--- a/tests/unit/sinonMongoose.js
+++ b/tests/unit/sinonMongoose.js
@@ -18,7 +18,7 @@ const stubChainedQueries = (stubbedMethodReturns, chainedQueries = ['populate', 
 
 const checkFirstQueryCoherence = (stubbedMethod, chainedPayload, callCount) => {
   const expectedQuery = chainedPayload[0].query;
-  if (!stubbedMethod.getCall(callCount)) console.log(stubbedMethod, chainedPayload[0].args, callCount);
+  if (!stubbedMethod.getCall(callCount)) sinon.assert.fail(`"${stubbedMethod}" stub not called on call ${callCount}`);
   const receivedQuery = String(stubbedMethod.getCall(callCount).proxy);
   if (expectedQuery !== receivedQuery) {
     sinon.assert.fail(`Error in principal query : expected: "${expectedQuery}", received: "${receivedQuery}"`);


### PR DESCRIPTION
|  |  | TESTS  :computer: | |
|----------|----------|----------|----------|
| <ul><li>[x] oui </li></ul> | <ul><li>[ ] non</li></ul> | J'ai codé les tests unitaires
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | J'ai codé les tests d'intégration
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | C'est une ancienne route utilisée par les apps mobiles. | <ul><li>[ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens</li></ul>

---

|  |  | POINTS D'ATTENTION POUR CETTE PR  :warning:  | |
|----------|----------|----------|----------|
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | J'ai fait des modifications sur une route utilisée sur plusieurs plateformes | [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/n3bq2hr9Ia)
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | J'ai modifié un modèle utilisé en mobile | [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/rqTfwpUib)
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | J'ai ajouté un modèle spécifique à une structure | <ul><li>[ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés</li></ul>
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile |  <ul><li>[ ] Si oui, j'ai précisé sur le [slite de MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) qu'il faut forcer la mise à jour</li></ul>
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | J'ai ajouté une variable d'environnement | <ul><li>[ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites</li></ul>

---

|  |  |  FONCTIONNALITÉS APPS MOBILES  :iphone: | |
|----------|----------|----------|----------|
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | Mes changements impactent l'application formation | <ul><li>[ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours</li></ul>
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | Mes changements impactent l'application erp | <ul><li>[ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours</li></ul>

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : tous

- Cas d'usage : refacto des tests : le retour de stubChainedQueries n'est plus un tableau + refacto des tests sur hoursBalanceDetailByAuxiliary + message d'erreur plus explicite que `SinonMongoose.calledOnceWithExactly :  TypeError: Cannot read property 'proxy' of null`

- Comment tester ? :

faire tourner les tests unitaires + pour tester le message d'erreur appeler SinonMongoose.calledOnceWithExactly sur un stub non appelé

Si tu as lu cette description, pense a réagir avec un :eye:
