### PR TITLE
COM-2623 - replaces ThirdPartyPayer Object by thirdPartyPayer's id in…

### DIFF
--- a/src/helpers/billSlips.js
+++ b/src/helpers/billSlips.js
@@ -8,6 +8,7 @@ const BillRepository = require('../repositories/BillRepository');
 const CreditNoteRepository = require('../repositories/CreditNoteRepository');
 const DocxHelper = require('./docx');
 const UtilsHelper = require('./utils');
+const NumbersHelper = require('./numbers');
 const { MONTHLY } = require('./constants');
 
 exports.getBillSlips = async (credentials) => {
@@ -127,7 +128,7 @@ exports.formatBillingDataForFile = (billList, creditNoteList) => {
   let total = 0;
   const formattedBills = [];
   for (const bill of billsAndCreditNotes) {
-    total += bill.netInclTaxes;
+    total = NumbersHelper.add(total, bill.netInclTaxes.toFixed(2));
     formattedBills.push({
       ...bill,
       netInclTaxes: UtilsHelper.formatPrice(bill.netInclTaxes),

--- a/src/repositories/BillRepository.js
+++ b/src/repositories/BillRepository.js
@@ -111,7 +111,7 @@ exports.getBillsSlipList = async companyId => Bill.aggregate([
 
 exports.getBillsFromBillSlip = async (billSlip, companyId) => {
   const query = {
-    thirdPartyPayer: billSlip.thirdPartyPayer,
+    thirdPartyPayer: billSlip.thirdPartyPayer._id,
     date: {
       $gte: moment(billSlip.month, 'MM-YYYY').startOf('month').toDate(),
       $lte: moment(billSlip.month, 'MM-YYYY').endOf('month').toDate(),

--- a/src/repositories/CreditNoteRepository.js
+++ b/src/repositories/CreditNoteRepository.js
@@ -111,7 +111,7 @@ exports.getCreditNoteList = async companyId => CreditNote.aggregate([
 
 exports.getCreditNoteFromBillSlip = async (billSlip, companyId) => {
   const query = {
-    thirdPartyPayer: billSlip.thirdPartyPayer,
+    thirdPartyPayer: billSlip.thirdPartyPayer._id,
     date: {
       $gte: moment(billSlip.month, 'MM-YYYY').startOf('month').toDate(),
       $lte: moment(billSlip.month, 'MM-YYYY').endOf('month').toDate(),


### PR DESCRIPTION
## Fix du bug:  ETQAdmin, quand je telecharge un bordereau tiers-payeur, le document word est vierge

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : Admin

- Comment tester: Lorsque je telecharge le bordereaux tiers-payeur, le document contient les bonnes informations.

Si tu as lu cette description, pense a réagir avec un :eye:
