### PR TITLE
COM-2607 - displays cancelled events invoiced and paid in transport e…

### DIFF
--- a/src/repositories/EventRepository.js
+++ b/src/repositories/EventRepository.js
@@ -611,7 +611,7 @@ exports.getEventsByDayAndAuxiliary = async (startDate, endDate, companyId) => Ev
       startDate: { $gte: startDate },
       endDate: { $lte: endDate },
       auxiliary: { $exists: true },
-      isCancelled: false,
+      $or: [{ isCancelled: false }, { 'cancel.condition': { $in: [INVOICED_AND_PAID] } }],
       type: { $in: [INTERNAL_HOUR, INTERVENTION] },
     },
   },

--- a/tests/integration/seed/exportsSeed.js
+++ b/tests/integration/seed/exportsSeed.js
@@ -543,7 +543,7 @@ const eventList = [
       location: { type: 'Point', coordinates: [2.377133, 48.801389] },
     },
   },
-  { // 8 - origin
+  { // 8 - origin cancelled event invoiced and paid
     _id: new ObjectId(),
     company: authCompany._id,
     sector,
@@ -561,6 +561,9 @@ const eventList = [
       street: '42 Rue de la Procession',
       location: { type: 'Point', coordinates: [2.377133, 48.801389] },
     },
+    isCancelled: true,
+    cancel: { condition: 'invoiced_and_paid', reason: 'customer_initiative' },
+    misc: 'bénéficiaire absent',
   },
   { // 9 - destination
     _id: new ObjectId(),
@@ -580,6 +583,28 @@ const eventList = [
       street: '42 Rue de la Procession',
       location: { type: 'Point', coordinates: [2.377133, 48.801389] },
     },
+  },
+  { // 10 - cancelled event - invoiced and not paid
+    _id: new ObjectId(),
+    company: authCompany._id,
+    sector,
+    type: INTERVENTION,
+    startDate: '2019-01-11T08:00:00.000Z',
+    endDate: '2019-01-11T09:00:00.000Z',
+    auxiliary: auxiliaryList[1]._id,
+    customer: customersList[3]._id,
+    createdAt: '2019-01-09T11:33:14.343Z',
+    subscription: customersList[3].subscriptions[0]._id,
+    address: {
+      fullAddress: '35 Rue du Test 75015 Paris',
+      zipCode: '75015',
+      city: 'Paris',
+      street: '42 Rue de la Procession',
+      location: { type: 'Point', coordinates: [2.377133, 48.801389] },
+    },
+    isCancelled: true,
+    cancel: { condition: 'invoiced_and_not_paid', reason: 'auxiliary_initiative' },
+    misc: 'auxiliaire absente',
   },
 ];
 


### PR DESCRIPTION


|  |  | TESTS  :computer: | |
|----------|----------|----------|----------|
| <ul><li>[x] oui </li></ul> | <ul><li>[ ] non</li></ul> | J'ai codé les tests unitaires
| <ul><li>[x] oui </li></ul> | <ul><li>[ ] non</li></ul> | J'ai codé les tests d'intégration
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | C'est une ancienne route utilisée par les apps mobiles. | <ul><li>[ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens</li></ul>

---

|  |  | POINTS D'ATTENTION POUR CETTE PR  :warning:  | |
|----------|----------|----------|----------|
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | J'ai fait des modifications sur une route utilisée sur plusieurs plateformes | [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/n3bq2hr9Ia)
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | J'ai modifié un modèle utilisé en mobile | [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/rqTfwpUib)
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | J'ai ajouté un modèle spécifique à une structure | <ul><li>[ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés</li></ul>
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile |  <ul><li>[ ] Si oui, j'ai précisé sur le [slite de MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) qu'il faut forcer la mise à jour</li></ul>
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | J'ai ajouté une variable d'environnement | <ul><li>[ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites</li></ul>

---

|  |  |  FONCTIONNALITÉS APPS MOBILES  :iphone: | |
|----------|----------|----------|----------|
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | Mes changements impactent l'application formation | <ul><li>[ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours</li></ul>
| <ul><li>[ ] oui </li></ul> | <ul><li>[x] non</li></ul> | Mes changements impactent l'application erp | <ul><li>[ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours</li></ul>

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : admin

- Cas d'usage : L'export des transports est cohérent avec la page paie mensuelle 

- Comment tester ? 
   - télécharger l'export des transports
   - verifier que pour chaque auxiliaire, la somme des heures dans la colonne `Heures prises en compte` est égale au temps de transport affiché sur la page paie mensuelle

Si tu as lu cette description, pense a réagir avec un :eye:
