### PR TITLE
COM-2642: return slots in steps

### DIFF
--- a/src/helpers/courses.js
+++ b/src/helpers/courses.js
@@ -111,7 +111,11 @@ exports.getCourseProgress = (steps) => {
 
 exports.formatCourseWithProgress = (course) => {
   const steps = course.subProgram.steps
-    .map(step => ({ ...step, progress: StepsHelper.getProgress(step, course.slots) }));
+    .map((step) => {
+      const slots = course.slots.filter(slot => UtilsHelper.areObjectIdsEquals(slot.step._id, step._id));
+
+      return { ...step, slots, progress: StepsHelper.getProgress(step, slots) };
+    });
 
   return {
     ...course,

--- a/src/helpers/steps.js
+++ b/src/helpers/steps.js
@@ -56,17 +56,13 @@ exports.getPresenceStepProgress = (slots) => {
   };
 };
 
-exports.getProgress = (step, slots = []) => {
-  const stepSlotList = slots.filter(slot => UtilsHelper.areObjectIdsEquals(slot.step._id, step._id));
-
-  return step.type === E_LEARNING
-    ? { eLearning: exports.getElearningStepProgress(step) }
-    : {
-      ...(step.activities.length && { eLearning: exports.getElearningStepProgress(step) }),
-      live: exports.getLiveStepProgress(step, stepSlotList),
-      presence: exports.getPresenceStepProgress(stepSlotList),
-    };
-};
+exports.getProgress = (step, slots = []) => (step.type === E_LEARNING
+  ? { eLearning: exports.getElearningStepProgress(step) }
+  : {
+    ...(step.activities.length && { eLearning: exports.getElearningStepProgress(step) }),
+    live: exports.getLiveStepProgress(step, slots),
+    presence: exports.getPresenceStepProgress(slots),
+  });
 
 exports.list = async (programId) => {
   const steps = await Step.find()

--- a/tests/unit/helpers/courses.test.js
+++ b/tests/unit/helpers/courses.test.js
@@ -345,12 +345,13 @@ describe('formatCourseWithProgress', () => {
         presence: { attendanceDuration: { minutes: 0 }, maxDuration: { minutes: 601 } },
       },
     });
-    sinon.assert.calledWithExactly(getProgress.getCall(0), course.subProgram.steps[0], course.slots);
+    sinon.assert.calledWithExactly(getProgress.getCall(0), course.subProgram.steps[0], []);
     sinon.assert.calledWithExactly(getProgress.getCall(1), course.subProgram.steps[1], course.slots);
     sinon.assert.calledWithExactly(getCourseProgress.getCall(0), [
-      { ...course.subProgram.steps[0], progress: { eLearning: 1 } },
+      { ...course.subProgram.steps[0], slots: [], progress: { eLearning: 1 } },
       {
         ...course.subProgram.steps[1],
+        slots: course.slots,
         progress: { live: 1, presence: { attendanceDuration: { minutes: 0 }, maxDuration: { minutes: 601 } } },
       },
     ]);


### PR DESCRIPTION
<details open><summary> TESTS  :computer: </summary>

- [x] J'ai codé les tests unitaires
- [ ] J'ai codé les tests d'intégration -np
- [x] C'est une ancienne route utilisée par les apps mobiles.
  - [ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens (modif mineure)
</details>

- [ ] Je replie cette section car mes modifications n'ont pas besoin de tests unitaires ou d'intégration

---

<details open><summary> POINTS D'ATTENTION POUR CETTE PR  :warning: </summary>

- [x] J'ai fait des modifications sur une route utilisée sur plusieurs plateformes [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/n3bq2hr9Ia)
- [ ] ~~J'ai modifié un modèle utilisé en mobile~~ [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/rqTfwpUib)
- [ ] ~~J'ai ajouté un modèle spécifique à une structure~~
  - [ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés
- [ ] ~~J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile~~
  - [ ] Si oui, j'ai précisé sur le [slite de MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) qu'il faut forcer la mise à jour
- [ ] ~~J'ai ajouté une variable d'environnement~~
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

</details>

- [ ] Je replie cette section car je n'ai pas fait de modifications entrainant un point d'attention

---

<details open><summary> FONCTIONNALITÉS APPS MOBILES  :iphone: </summary>

- [ ] ~~Mes changements impactent l'application formation~~
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours
- [ ] ~~Mes changements impactent l'application erp~~
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours

</details>

- [ ] Je replie cette section car mes modifications n'ont pas d'impact sur les applications mobiles

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : client_admin/coach/vendor_admin/rof

- Cas d'usage : je peux visualiser les émargements d'un apprenant sur son profil

- Comment tester ? : 
  - sur le profil d'un appreant dans le suivi des formations je vois ses émargements pour les formations mixtes (côté client et vendeur)
 
_Si tu as lu cette description, pense a réagir avec un :eye:_
