### PR TITLE
COM-2650 isHoliday

### DIFF
--- a/src/helpers/dates/companiDates.js
+++ b/src/helpers/dates/companiDates.js
@@ -1,5 +1,6 @@
 const pick = require('lodash/pick');
 const luxon = require('./luxon');
+const { getHolidays } = require('./holidays');
 
 exports.CompaniDate = (...args) => CompaniDateFactory(exports._formatMiscToCompaniDate(...args));
 
@@ -52,6 +53,13 @@ const CompaniDateFactory = (inputDate) => {
       const otherDate = exports._formatMiscToCompaniDate(miscTypeOtherDate);
 
       return (_date.hasSame(otherDate, unit) || _date.startOf(unit) < otherDate.startOf(unit));
+    },
+
+    isHoliday() {
+      const { year } = _date;
+      const holidays = getHolidays(year);
+
+      return !!holidays.find(h => _date.hasSame(h, 'day'));
     },
 
     // MANIPULATE

--- a/src/helpers/dates/holidays.js
+++ b/src/helpers/dates/holidays.js
@@ -1,0 +1,15 @@
+const Holidays = require('date-holidays');
+const memoize = require('lodash/memoize');
+
+const OMITED_HOLIDAYS = ['easter 49', 'easter 50', 'sunday before 06-01'];
+
+const _getHolidays = (year) => {
+  const holidays = new Holidays('FR');
+  const yearHolidays = holidays.getHolidays(year);
+
+  return yearHolidays
+    .filter(h => !OMITED_HOLIDAYS.includes(h.rule))
+    .map(h => h.start);
+};
+
+exports.getHolidays = memoize(_getHolidays);

--- a/tests/unit/helpers/dates/companiDates.test.js
+++ b/tests/unit/helpers/dates/companiDates.test.js
@@ -323,6 +323,56 @@ describe('QUERY', () => {
       }
     });
   });
+
+  describe('isHoliday', () => {
+    const christmas = CompaniDatesHelper.CompaniDate('2000-12-25T07:00:00.000Z');
+    const laborDay = CompaniDatesHelper.CompaniDate('2010-05-01T07:00:00.000Z');
+    const mothersDay = CompaniDatesHelper.CompaniDate('2025-05-25T07:00:00.000Z'); // 'sunday before 06.01'
+    const pentecost = CompaniDatesHelper.CompaniDate('2022-06-05T07:00:00.000Z'); // 'easter 49'
+    const mondayAfterPentecost = CompaniDatesHelper.CompaniDate('2022-06-06T07:00:00.000Z'); // 'easter 50'
+    let _formatMiscToCompaniDate;
+    beforeEach(() => {
+      _formatMiscToCompaniDate = sinon.spy(CompaniDatesHelper, '_formatMiscToCompaniDate');
+    });
+    afterEach(() => {
+      _formatMiscToCompaniDate.restore();
+    });
+
+    it('should return true, Christmas is a holiday', () => {
+      const result = christmas.isHoliday();
+
+      expect(result).toEqual(true);
+      sinon.assert.notCalled(_formatMiscToCompaniDate);
+    });
+
+    it('should return true, Labor day is a holiday', () => {
+      const result = laborDay.isHoliday();
+
+      expect(result).toEqual(true);
+      sinon.assert.notCalled(_formatMiscToCompaniDate);
+    });
+
+    it('should return false, Mother\'s day isn\'t a holiday', () => {
+      const result = mothersDay.isHoliday();
+
+      expect(result).toEqual(false);
+      sinon.assert.notCalled(_formatMiscToCompaniDate);
+    });
+
+    it('should return false, Pentecost isn\'t a holiday', () => {
+      const result = pentecost.isHoliday();
+
+      expect(result).toEqual(false);
+      sinon.assert.notCalled(_formatMiscToCompaniDate);
+    });
+
+    it('should return false, monday after Pentecost isn\'t a holiday', () => {
+      const result = mondayAfterPentecost.isHoliday();
+
+      expect(result).toEqual(false);
+      sinon.assert.notCalled(_formatMiscToCompaniDate);
+    });
+  });
 });
 
 describe('MANIPULATE', () => {

--- a/tests/unit/helpers/dates/companiDates.test.js
+++ b/tests/unit/helpers/dates/companiDates.test.js
@@ -325,52 +325,39 @@ describe('QUERY', () => {
   });
 
   describe('isHoliday', () => {
-    const christmas = CompaniDatesHelper.CompaniDate('2000-12-25T07:00:00.000Z');
-    const laborDay = CompaniDatesHelper.CompaniDate('2010-05-01T07:00:00.000Z');
-    const mothersDay = CompaniDatesHelper.CompaniDate('2025-05-25T07:00:00.000Z'); // 'sunday before 06.01'
-    const pentecost = CompaniDatesHelper.CompaniDate('2022-06-05T07:00:00.000Z'); // 'easter 49'
-    const mondayAfterPentecost = CompaniDatesHelper.CompaniDate('2022-06-06T07:00:00.000Z'); // 'easter 50'
-    let _formatMiscToCompaniDate;
-    beforeEach(() => {
-      _formatMiscToCompaniDate = sinon.spy(CompaniDatesHelper, '_formatMiscToCompaniDate');
-    });
-    afterEach(() => {
-      _formatMiscToCompaniDate.restore();
-    });
-
     it('should return true, Christmas is a holiday', () => {
+      const christmas = CompaniDatesHelper.CompaniDate('2000-12-25T07:00:00.000Z');
       const result = christmas.isHoliday();
 
       expect(result).toEqual(true);
-      sinon.assert.notCalled(_formatMiscToCompaniDate);
     });
 
     it('should return true, Labor day is a holiday', () => {
+      const laborDay = CompaniDatesHelper.CompaniDate('2010-05-01T07:00:00.000Z');
       const result = laborDay.isHoliday();
 
       expect(result).toEqual(true);
-      sinon.assert.notCalled(_formatMiscToCompaniDate);
     });
 
     it('should return false, Mother\'s day isn\'t a holiday', () => {
+      const mothersDay = CompaniDatesHelper.CompaniDate('2025-05-25T07:00:00.000Z'); // 'sunday before 06.01'
       const result = mothersDay.isHoliday();
 
       expect(result).toEqual(false);
-      sinon.assert.notCalled(_formatMiscToCompaniDate);
     });
 
     it('should return false, Pentecost isn\'t a holiday', () => {
+      const pentecost = CompaniDatesHelper.CompaniDate('2022-06-05T07:00:00.000Z'); // 'easter 49'
       const result = pentecost.isHoliday();
 
       expect(result).toEqual(false);
-      sinon.assert.notCalled(_formatMiscToCompaniDate);
     });
 
     it('should return false, monday after Pentecost isn\'t a holiday', () => {
+      const mondayAfterPentecost = CompaniDatesHelper.CompaniDate('2022-06-06T07:00:00.000Z'); // 'easter 50'
       const result = mondayAfterPentecost.isHoliday();
 
       expect(result).toEqual(false);
-      sinon.assert.notCalled(_formatMiscToCompaniDate);
     });
   });
 });


### PR DESCRIPTION
<details open><summary> TESTS  :computer: </summary>

- [x] J'ai codé les tests unitaires
- [ ] J'ai codé les tests d'intégration
- [ ] C'est une ancienne route utilisée par les apps mobiles.
  - [ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens
</details>

- [ ] Je replie cette section car mes modifications n'ont pas besoin de tests unitaires ou d'intégration

---

<details><summary> POINTS D'ATTENTION POUR CETTE PR  :warning: </summary>

- [ ] J'ai fait des modifications sur une route utilisée sur plusieurs plateformes [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/n3bq2hr9Ia)
- [ ] J'ai modifié un modèle utilisé en mobile [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/rqTfwpUib)
- [ ] J'ai ajouté un modèle spécifique à une structure 
  - [ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés
- [ ] J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile
  - [ ] Si oui, j'ai précisé sur le [slite de MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) qu'il faut forcer la mise à jour
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

</details>

- [x] Je replie cette section car je n'ai pas fait de modifications entrainant un point d'attention

---

<details><summary> FONCTIONNALITÉS APPS MOBILES  :iphone: </summary>

- [ ] Mes changements impactent l'application formation
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours
- [ ] Mes changements impactent l'application erp
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours

</details>

- [x] Je replie cette section car mes modifications n'ont pas d'impact sur les applications mobiles

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : ---

- Cas d'usage : 
   - Creation de la fct `isHoliday`
   - pas de changement dans le code (ca viendra plus tard)

- Comment tester ? : 
   - bien regarder les tests, eventuellement faire des console.log
   - Avec momen.js, on utilise qui s'appelle `moment-business-days`. Cette lib est configurée pour l'année en cours, l'année suivante et l'année precedente... Avec la fct developpée dans cette PR, on peut calculer si une date est feriee ou non, et ce pour n'importe quelle annee. C'est pourquoi je test avec des dates de 2000, 2010 etc dans les tests unitaires.

_Si tu as lu cette description, pense a réagir avec un :eye:_
