### PR TITLE
COM-2677 - fix funding display

### DIFF
--- a/src/helpers/dates/companiDates.js
+++ b/src/helpers/dates/companiDates.js
@@ -60,6 +60,12 @@ const CompaniDateFactory = (inputDate) => {
       return (_date.hasSame(otherDate, unit) || _date.startOf(unit) < otherDate.startOf(unit));
     },
 
+    isSameOrAfter(miscTypeOtherDate, unit = 'millisecond') {
+      const otherDate = exports._formatMiscToCompaniDate(miscTypeOtherDate);
+
+      return (_date.hasSame(otherDate, unit) || _date.startOf(unit) > otherDate.startOf(unit));
+    },
+
     isHoliday() {
       const { year } = _date;
       const holidays = getHolidays(year);

--- a/tests/unit/helpers/dates/companiDates.test.js
+++ b/tests/unit/helpers/dates/companiDates.test.js
@@ -271,7 +271,7 @@ describe('QUERY', () => {
       _formatMiscToCompaniDate.restore();
     });
 
-    it('should return true if same moment', () => {
+    it('should return true if same', () => {
       const otherDate = '2021-11-24T07:00:00.000Z';
 
       const result = companiDate.isSameOrBefore(otherDate);
@@ -328,7 +328,85 @@ describe('QUERY', () => {
     it('should return error if unit is plural', () => {
       const otherDate = '2021-11-24T06:00:00.000Z';
       try {
-        companiDate.isSame(otherDate, 'minutes');
+        companiDate.isSameOrBefore(otherDate, 'minutes');
+      } catch (e) {
+        expect(e).toEqual(new Error('Invalid unit minutes'));
+      } finally {
+        sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, otherDate);
+      }
+    });
+  });
+
+  describe('isSameOrAfter', () => {
+    let _formatMiscToCompaniDate;
+    const companiDate = CompaniDatesHelper.CompaniDate('2021-11-24T07:00:00.000Z');
+
+    beforeEach(() => {
+      _formatMiscToCompaniDate = sinon.spy(CompaniDatesHelper, '_formatMiscToCompaniDate');
+    });
+
+    afterEach(() => {
+      _formatMiscToCompaniDate.restore();
+    });
+
+    it('should return true if same', () => {
+      const otherDate = '2021-11-24T07:00:00.000Z';
+
+      const result = companiDate.isSameOrAfter(otherDate);
+
+      expect(result).toBe(true);
+      sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, otherDate);
+    });
+
+    it('should return false if before', () => {
+      const otherDate = '2021-11-25T10:00:00.000Z';
+      const result = companiDate.isSameOrAfter(otherDate);
+
+      expect(result).toBe(false);
+      sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, otherDate);
+    });
+
+    it('should return true if before but same as specified unit', () => {
+      const otherDate = '2021-11-24T08:00:00.000Z';
+
+      const result = companiDate.isSameOrAfter(otherDate, 'day');
+
+      expect(result).toBe(true);
+      sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, otherDate);
+    });
+
+    it('should return true if after', () => {
+      const otherDate = '2021-11-23T10:00:00.000Z';
+
+      const result = companiDate.isSameOrAfter(otherDate);
+
+      expect(result).toBe(true);
+      sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, otherDate);
+    });
+
+    it('should return false if before specified unit', () => {
+      const otherDate = '2021-11-24T08:00:00.000Z';
+
+      const result = companiDate.isSameOrAfter(otherDate, 'minute');
+
+      expect(result).toBe(false);
+      sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, otherDate);
+    });
+
+    it('should return error if invalid otherDate', () => {
+      try {
+        companiDate.isSameOrAfter(null);
+      } catch (e) {
+        expect(e).toEqual(new Error('Invalid DateTime: wrong arguments'));
+      } finally {
+        sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, null);
+      }
+    });
+
+    it('should return error if unit is plural', () => {
+      const otherDate = '2021-11-24T06:00:00.000Z';
+      try {
+        companiDate.isSameOrAfter(otherDate, 'minutes');
       } catch (e) {
         expect(e).toEqual(new Error('Invalid unit minutes'));
       } finally {


### PR DESCRIPTION
<details open><summary> TESTS  :computer: </summary>

- [x] J'ai codé les tests unitaires
- [ ] J'ai codé les tests d'intégration
- [ ] ~~C'est une ancienne route utilisée par les apps mobiles.~~
  - [ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens
</details>

- [ ] Je replie cette section car mes modifications n'ont pas besoin de tests unitaires ou d'intégration

---

<details open><summary> POINTS D'ATTENTION POUR CETTE PR  :warning: </summary>

- [ ] J'ai fait des modifications sur une route utilisée sur plusieurs plateformes [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/n3bq2hr9Ia)
- [ ] J'ai modifié un modèle utilisé en mobile [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/rqTfwpUib)
- [ ] J'ai ajouté un modèle spécifique à une structure 
  - [ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés
- [ ] J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile
  - [ ] Si oui, j'ai précisé sur le [slite de MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) qu'il faut forcer la mise à jour
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

</details>

- [x] Je replie cette section car je n'ai pas fait de modifications entrainant un point d'attention

---

<details open><summary> FONCTIONNALITÉS APPS MOBILES  :iphone: </summary>

- [ ] Mes changements impactent l'application formation
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours
- [ ] Mes changements impactent l'application erp
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours

</details>

- [x] Je replie cette section car mes modifications n'ont pas d'impact sur les applications mobiles

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : Admin / Aidant 

- Cas d'usage : Quand il y a plusieurs financement pour une même souscription, je vois le montant du dernier évènement facturé dans le pdf de la facture

- Comment tester ? :
Ajouter un financement avec une date de fin
Ajouter un nouveau financement sans date de fin - mettre un prix different
Facturer les interventions : au moins une qui est facturée avec le 2eme financement
Quand je telecharge le PDF, j'ai bien le montant du 2eme financement

_Si tu as lu cette description, pense a réagir avec un :eye:_
