### PR TITLE
Com 2659

### DIFF
--- a/src/helpers/events.js
+++ b/src/helpers/events.js
@@ -191,7 +191,10 @@ exports.populateEventSubscription = (event) => {
     .find(sub => sub._id.toHexString() === event.subscription.toHexString());
   if (!subscription) throw Boom.badImplementation();
 
-  return { ...event, subscription };
+  const startDateTimeStamp = new Event(event).isStartDateTimeStamped();
+  const endDateTimeStamp = new Event(event).isEndDateTimeStamped();
+
+  return { ...event, startDateTimeStamp, endDateTimeStamp, subscription };
 };
 
 exports.populateEvents = async (events) => {

--- a/src/models/Event.js
+++ b/src/models/Event.js
@@ -143,7 +143,8 @@ EventSchema.virtual(
   }
 );
 
-const isStartDateTimeStamped = event => !!event.histories.find(history => get(history, 'update.startHour', ''));
+const isStartDateTimeStamped = event =>
+  (event.histories ? !!event.histories.find(history => get(history, 'update.startHour', '')) : false);
 
 EventSchema.methods.isStartDateTimeStamped = function () {
   return isStartDateTimeStamped(this);
@@ -167,7 +168,8 @@ EventSchema.virtual(
   }
 );
 
-const isEndDateTimeStamped = event => !!event.histories.find(history => get(history, 'update.endHour', ''));
+const isEndDateTimeStamped = event =>
+  (event.histories ? !!event.histories.find(history => get(history, 'update.endHour', '')) : false);
 
 EventSchema.methods.isEndDateTimeStamped = function () {
   return isEndDateTimeStamped(this);

--- a/src/models/Event.js
+++ b/src/models/Event.js
@@ -1,4 +1,5 @@
 const mongoose = require('mongoose');
+const { get } = require('lodash');
 const {
   INTERNAL_HOUR,
   ABSENCE,
@@ -142,15 +143,11 @@ EventSchema.virtual(
   }
 );
 
-const isStartDateTimeStamped = event => (event.startDateTimeStamp ? !!event.startDateTimeStamp : false);
+const isStartDateTimeStamped = event => event.histories.find(history => get(history, 'update.startHour'));
 
-function setIsStartDateTimeStamped() {
+EventSchema.methods.isStartDateTimeStamped = function setIsStartDateTimeStamped() {
   return isStartDateTimeStamped(this);
-}
-
-EventSchema.statics.isStartDateTimeStamped = isStartDateTimeStamped;
-
-EventSchema.virtual('isStartDateTimeStamped').get(setIsStartDateTimeStamped);
+};
 
 EventSchema.virtual(
   'endDateTimeStamp',
@@ -170,14 +167,11 @@ EventSchema.virtual(
   }
 );
 
-const isEndDateTimeStamped = event => (event.endDateTimeStamp ? !!event.endDateTimeStamp : false);
+const isEndDateTimeStamped = event => event.histories.find(history => get(history, 'update.endHour'));
 
-function setIsEndDateTimeStamped() {
+EventSchema.methods.isEndDateTimeStamped = function setIsEndDateTimeStamped() {
   return isEndDateTimeStamped(this);
-}
-
-EventSchema.statics.isEndDateTimeStamped = isEndDateTimeStamped;
-EventSchema.virtual('isEndDateTimeStamped').get(setIsEndDateTimeStamped);
+};
 
 EventSchema.pre('find', validateQuery);
 EventSchema.pre('aggregate', validateAggregation);

--- a/src/models/Event.js
+++ b/src/models/Event.js
@@ -144,7 +144,9 @@ EventSchema.virtual(
 );
 
 const isStartDateTimeStamped = event =>
-  (event.histories ? !!event.histories.find(history => get(history, 'update.startHour', '')) : false);
+  (event.histories
+    ? !!event.histories.find(history => get(history, 'update.startHour', '') && !get(history, 'isCancelled'))
+    : false);
 
 EventSchema.methods.isStartDateTimeStamped = function () {
   return isStartDateTimeStamped(this);
@@ -169,7 +171,9 @@ EventSchema.virtual(
 );
 
 const isEndDateTimeStamped = event =>
-  (event.histories ? !!event.histories.find(history => get(history, 'update.endHour', '')) : false);
+  (event.histories
+    ? !!event.histories.find(history => get(history, 'update.endHour', '') && !get(history, 'isCancelled'))
+    : false);
 
 EventSchema.methods.isEndDateTimeStamped = function () {
   return isEndDateTimeStamped(this);

--- a/src/models/Event.js
+++ b/src/models/Event.js
@@ -143,10 +143,14 @@ EventSchema.virtual(
   }
 );
 
-const isStartDateTimeStamped = event =>
-  (event.histories
-    ? !!event.histories.find(history => get(history, 'update.startHour', '') && !get(history, 'isCancelled'))
-    : false);
+const isStartDateTimeStamped = (event) => {
+  if (get(event, 'histories')) {
+    return !!event.histories.find(h =>
+      TIME_STAMPING_ACTIONS.includes(get(h, 'action')) && get(h, 'update.startHour', '') && !get(h, 'isCancelled')
+    );
+  }
+  return false;
+};
 
 EventSchema.methods.isStartDateTimeStamped = function () {
   return isStartDateTimeStamped(this);
@@ -170,10 +174,14 @@ EventSchema.virtual(
   }
 );
 
-const isEndDateTimeStamped = event =>
-  (event.histories
-    ? !!event.histories.find(history => get(history, 'update.endHour', '') && !get(history, 'isCancelled'))
-    : false);
+const isEndDateTimeStamped = (event) => {
+  if (event.histories) {
+    return !!event.histories.find(h =>
+      TIME_STAMPING_ACTIONS.includes(get(h, 'action')) && get(h, 'update.endHour', '') && !get(h, 'isCancelled')
+    );
+  }
+  return false;
+};
 
 EventSchema.methods.isEndDateTimeStamped = function () {
   return isEndDateTimeStamped(this);

--- a/src/models/Event.js
+++ b/src/models/Event.js
@@ -143,9 +143,9 @@ EventSchema.virtual(
   }
 );
 
-const isStartDateTimeStamped = event => event.histories.find(history => get(history, 'update.startHour'));
+const isStartDateTimeStamped = event => !!event.histories.find(history => get(history, 'update.startHour', ''));
 
-EventSchema.methods.isStartDateTimeStamped = function setIsStartDateTimeStamped() {
+EventSchema.methods.isStartDateTimeStamped = function () {
   return isStartDateTimeStamped(this);
 };
 
@@ -167,9 +167,9 @@ EventSchema.virtual(
   }
 );
 
-const isEndDateTimeStamped = event => event.histories.find(history => get(history, 'update.endHour'));
+const isEndDateTimeStamped = event => !!event.histories.find(history => get(history, 'update.endHour', ''));
 
-EventSchema.methods.isEndDateTimeStamped = function setIsEndDateTimeStamped() {
+EventSchema.methods.isEndDateTimeStamped = function () {
   return isEndDateTimeStamped(this);
 };
 

--- a/src/models/Event.js
+++ b/src/models/Event.js
@@ -142,6 +142,16 @@ EventSchema.virtual(
   }
 );
 
+const isStartDateTimeStamped = event => (event.startDateTimeStamp ? !!event.startDateTimeStamp : false);
+
+function setIsStartDateTimeStamped() {
+  return isStartDateTimeStamped(this);
+}
+
+EventSchema.statics.isStartDateTimeStamped = isStartDateTimeStamped;
+
+EventSchema.virtual('isStartDateTimeStamped').get(setIsStartDateTimeStamped);
+
 EventSchema.virtual(
   'endDateTimeStamp',
   {
@@ -159,6 +169,15 @@ EventSchema.virtual(
     count: true,
   }
 );
+
+const isEndDateTimeStamped = event => (event.endDateTimeStamp ? !!event.endDateTimeStamp : false);
+
+function setIsEndDateTimeStamped() {
+  return isEndDateTimeStamped(this);
+}
+
+EventSchema.statics.isEndDateTimeStamped = isEndDateTimeStamped;
+EventSchema.virtual('isEndDateTimeStamped').get(setIsEndDateTimeStamped);
 
 EventSchema.pre('find', validateQuery);
 EventSchema.pre('aggregate', validateAggregation);

--- a/src/repositories/EventRepository.js
+++ b/src/repositories/EventRepository.js
@@ -18,7 +18,11 @@ const {
 } = require('../helpers/constants');
 
 exports.formatEvent = (event) => {
-  const formattedEvent = cloneDeep(event);
+  const formattedEvent = {
+    ...cloneDeep(omit(event, 'histories')),
+    startDateTimeStamp: new Event(event).isStartDateTimeStamped,
+    endDateTimeStamp: new Event(event).isEndDateTimeStamped,
+  };
 
   const { auxiliary, subscription, customer } = event;
   if (auxiliary) {
@@ -49,7 +53,8 @@ exports.getEventsGroupedBy = async (rules, groupByFunc, companyId) => {
     })
     .populate({ path: 'internalHour' })
     .populate({ path: 'extension' })
-    .lean();
+    .populate({ path: 'histories', match: { company: companyId } })
+    .lean({ autopopulate: true, viruals: true });
 
   return groupBy(events.map(exports.formatEvent), groupByFunc);
 };

--- a/src/repositories/EventRepository.js
+++ b/src/repositories/EventRepository.js
@@ -20,8 +20,8 @@ const {
 exports.formatEvent = (event) => {
   const formattedEvent = {
     ...cloneDeep(omit(event, 'histories')),
-    startDateTimeStamp: new Event(event).isStartDateTimeStamped,
-    endDateTimeStamp: new Event(event).isEndDateTimeStamped,
+    startDateTimeStamp: new Event(event).isStartDateTimeStamped(),
+    endDateTimeStamp: new Event(event).isEndDateTimeStamped(),
   };
 
   const { auxiliary, subscription, customer } = event;
@@ -54,7 +54,7 @@ exports.getEventsGroupedBy = async (rules, groupByFunc, companyId) => {
     .populate({ path: 'internalHour' })
     .populate({ path: 'extension' })
     .populate({ path: 'histories', match: { company: companyId } })
-    .lean({ autopopulate: true, viruals: true });
+    .lean();
 
   return groupBy(events.map(exports.formatEvent), groupByFunc);
 };

--- a/tests/integration/events.test.js
+++ b/tests/integration/events.test.js
@@ -88,7 +88,11 @@ describe('EVENTS ROUTES - GET /events', () => {
       expect(response.statusCode).toEqual(200);
       const { events } = response.result.data;
       const customerId = Object.keys(events)[0];
-      events[customerId].forEach(e => expect(UtilsHelper.areObjectIdsEquals(e.customer._id, customerId)).toBeTruthy());
+      events[customerId].forEach((e) => {
+        expect(UtilsHelper.areObjectIdsEquals(e.customer._id, customerId)).toBeTruthy();
+        expect(e.startDateTimeStamp).toBeDefined();
+        expect(e.endDateTimeStamp).toBeDefined();
+      });
     });
 
     it('should return a list of events groupedBy auxiliaries', async () => {
@@ -101,7 +105,11 @@ describe('EVENTS ROUTES - GET /events', () => {
       expect(response.statusCode).toEqual(200);
       const { events } = response.result.data;
       const auxId = Object.keys(events)[0];
-      events[auxId].forEach(e => expect(UtilsHelper.areObjectIdsEquals(e.auxiliary._id, auxId)).toBeTruthy());
+      events[auxId].forEach((e) => {
+        expect(UtilsHelper.areObjectIdsEquals(e.auxiliary._id, auxId)).toBeTruthy();
+        expect(e.startDateTimeStamp).toBeDefined();
+        expect(e.endDateTimeStamp).toBeDefined();
+      });
     });
 
     it('should return a 200 if same id send twice - sectors', async () => {

--- a/tests/unit/helpers/events.test.js
+++ b/tests/unit/helpers/events.test.js
@@ -658,6 +658,7 @@ describe('populateEventSubscription', () => {
         ],
       },
       subscription: subId,
+      histories: [],
     };
 
     const result = await EventHelper.populateEventSubscription(event);

--- a/tests/unit/repositories/EventRepositories.test.js
+++ b/tests/unit/repositories/EventRepositories.test.js
@@ -20,6 +20,7 @@ describe('formatEvents', () => {
       _id: eventId,
       type: INTERVENTION,
       histories: [{
+        action: 'manual_time_stamping',
         update: { startHour: { from: '2022-02-11T15:00:00Z', to: '2022-02-11T15:04:00Z' } },
       }],
     };

--- a/tests/unit/repositories/EventRepositories.test.js
+++ b/tests/unit/repositories/EventRepositories.test.js
@@ -3,6 +3,7 @@ const sinon = require('sinon');
 const { ObjectId } = require('mongodb');
 const UtilsHelper = require('../../../src/helpers/utils');
 const EventRepository = require('../../../src/repositories/EventRepository');
+const { INTERVENTION } = require('../../../src/helpers/constants');
 
 describe('formatEvents', () => {
   let getMatchingObject;
@@ -14,8 +15,22 @@ describe('formatEvents', () => {
   });
 
   it('should format event', () => {
-    const event = { _id: new ObjectId(), internalHour: new ObjectId() };
-    expect(EventRepository.formatEvent(event)).toEqual(event);
+    const eventId = new ObjectId();
+    const event = {
+      _id: eventId,
+      type: INTERVENTION,
+      histories: [{
+        update: { startHour: { from: '2022-02-11T15:00:00Z', to: '2022-02-11T15:04:00Z' } },
+      }],
+    };
+    const formattedEvent = EventRepository.formatEvent(event);
+
+    expect(formattedEvent).toEqual({
+      _id: eventId,
+      type: INTERVENTION,
+      startDateTimeStamp: true,
+      endDateTimeStamp: false,
+    });
 
     sinon.assert.notCalled(getMatchingObject);
   });
@@ -26,6 +41,7 @@ describe('formatEvents', () => {
       internalHour: new ObjectId(),
       auxiliary: { sectorHistories: [{ startDate: '2021-02-12T09:00:00' }, { startDate: '2021-01-12T09:00:00' }] },
       startDate: '2021-03-12T09:00:00',
+      histories: [],
     };
 
     getMatchingObject.returns({ sector: { startDate: '2021-02-12T09:00:00' } });
@@ -37,6 +53,8 @@ describe('formatEvents', () => {
       internalHour: event.internalHour,
       startDate: '2021-03-12T09:00:00',
       auxiliary: { sector: { startDate: '2021-02-12T09:00:00' } },
+      startDateTimeStamp: false,
+      endDateTimeStamp: false,
     });
     sinon.assert.calledOnceWithExactly(
       getMatchingObject,
@@ -55,6 +73,7 @@ describe('formatEvents', () => {
       startDate: '2021-03-12T09:00:00',
       customer: { subscriptions: [{ _id: subId }, { _id: otherSubId }] },
       subscription: subId,
+      histories: [],
     };
 
     const formattedEvent = EventRepository.formatEvent(event);
@@ -65,6 +84,8 @@ describe('formatEvents', () => {
       startDate: '2021-03-12T09:00:00',
       customer: { subscriptions: [{ _id: subId }, { _id: otherSubId }] },
       subscription: { _id: subId },
+      startDateTimeStamp: false,
+      endDateTimeStamp: false,
     });
     sinon.assert.notCalled(getMatchingObject);
   });

--- a/tests/unit/repositories/EventRepositories.test.js
+++ b/tests/unit/repositories/EventRepositories.test.js
@@ -32,7 +32,6 @@ describe('formatEvents', () => {
       startDateTimeStamp: true,
       endDateTimeStamp: false,
     });
-
     sinon.assert.notCalled(getMatchingObject);
   });
 


### PR DESCRIPTION
<details open><summary> TESTS  :computer: </summary>

- [x] J'ai codé les tests unitaires
- [x] J'ai codé les tests d'intégration 
- [ ] C'est une ancienne route utilisée par les apps mobiles. -np
  - [ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens
</details>

- [ ] Je replie cette section car mes modifications n'ont pas besoin de tests unitaires ou d'intégration

---

<details open><summary> POINTS D'ATTENTION POUR CETTE PR  :warning: </summary>

- [x] J'ai fait des modifications sur une route utilisée sur plusieurs plateformes [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/n3bq2hr9Ia)
- [x] J'ai modifié un modèle utilisé en mobile [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/rqTfwpUib)
- [ ] J'ai ajouté un modèle spécifique à une structure 
  - [ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés
- [ ] J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile
  - [ ] Si oui, j'ai précisé sur le [slite de MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) qu'il faut forcer la mise à jour
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

</details>

- [ ] Je replie cette section car je n'ai pas fait de modifications entrainant un point d'attention

---

<details open><summary> FONCTIONNALITÉS APPS MOBILES  :iphone: </summary>

- [ ] Mes changements impactent l'application formation
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours
- [ ] Mes changements impactent l'application erp
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours

</details>

- [x] Je replie cette section car mes modifications n'ont pas d'impact sur les applications mobiles

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : auxiliaire / aidant / coach / admin

- Cas d'usage : Sur le planning/agenda, je vois lorsqu'une intervention a été horodatée.

- Comment tester ? : 
     - Creer un compte Auxiliaire 
     - Se connecter ETQ Auxiliaire et creer des evenements pour le jour meme
     -  Horodater un evenement depuis l'app mobile
     - Sur la webApp, on voit l'icône indiquant que l'évènement a été horodaté
     - Jouer avec la largeur de la page pour voir que le design de la cellule change

Tests sur les performances: branche déployée sur dev
- chargement du planning de toutes les auxiliaires 
    - events:
       - avant: 1,62s
       - apres: 2,54s  
    - working_stats:
       - avant: 3,43s
       - apres: 3,17s
      

_Si tu as lu cette description, pense a réagir avec un :eye:_
