### PR TITLE
Com 2652

### DIFF
--- a/src/helpers/stats.js
+++ b/src/helpers/stats.js
@@ -1,7 +1,6 @@
 const { ObjectId } = require('mongodb');
 const get = require('lodash/get');
 const pick = require('lodash/pick');
-const moment = require('../extensions/moment');
 const UtilsHelper = require('./utils');
 const { CompaniDate } = require('./dates/companiDates');
 const { CompaniDuration } = require('./dates/companiDurations');
@@ -104,8 +103,8 @@ exports.getPaidInterventionStats = async (query, credentials) => {
   const companyId = get(credentials, 'company._id', null);
   if (query.sector) {
     const sectors = UtilsHelper.formatObjectIdsArray(query.sector);
-    const startOfMonth = moment(query.month, 'MMYYYY').startOf('M').toDate();
-    const endOfMonth = moment(query.month, 'MMYYYY').endOf('M').toDate();
+    const startOfMonth = CompaniDate(query.month, 'MM-yyyy').startOf('month').toISO();
+    const endOfMonth = CompaniDate(query.month, 'MM-yyyy').endOf('month').toISO();
     const auxiliariesFromSectorHistories = await SectorHistoryRepository.getUsersFromSectorHistories(
       startOfMonth,
       endOfMonth,

--- a/src/repositories/SectorHistoryRepository.js
+++ b/src/repositories/SectorHistoryRepository.js
@@ -129,10 +129,10 @@ exports.getUsersFromSectorHistories = async (startDate, endDate, sectors, compan
     {
       $match: {
         sector: { $in: sectors },
-        startDate: { $lte: endDate },
+        startDate: { $lte: new Date(endDate) },
         $or: [
           { endDate: { $exists: false } },
-          { endDate: { $gte: startDate } },
+          { endDate: { $gte: new Date(startDate) } },
         ],
       },
     },

--- a/src/repositories/SectorHistoryRepository.js
+++ b/src/repositories/SectorHistoryRepository.js
@@ -1,6 +1,7 @@
 const moment = require('moment');
 const SectorHistory = require('../models/SectorHistory');
 const { ABSENCE, INTERVENTION, INVOICED_AND_PAID } = require('../helpers/constants');
+const { CompaniDate } = require('../helpers/dates/companiDates');
 
 exports.getContractsAndAbsencesBySector = async (month, sectors, companyId) => {
   const minDate = moment(month, 'MMYYYY').startOf('month').toDate();
@@ -144,8 +145,8 @@ exports.getUsersFromSectorHistories = async (startDate, endDate, sectors, compan
 ]).option({ company: companyId });
 
 exports.getPaidInterventionStats = async (auxiliaryIds, month, companyId) => {
-  const minDate = moment(month, 'MMYYYY').startOf('month').toDate();
-  const maxDate = moment(month, 'MMYYYY').endOf('month').toDate();
+  const minDate = CompaniDate(month, 'MM-yyyy').startOf('month').toDate();
+  const maxDate = CompaniDate(month, 'MM-yyyy').endOf('month').toDate();
 
   return SectorHistory.aggregate([
     {

--- a/src/repositories/SectorHistoryRepository.js
+++ b/src/repositories/SectorHistoryRepository.js
@@ -145,15 +145,15 @@ exports.getUsersFromSectorHistories = async (startDate, endDate, sectors, compan
 ]).option({ company: companyId });
 
 exports.getPaidInterventionStats = async (auxiliaryIds, month, companyId) => {
-  const minDate = CompaniDate(month, 'MM-yyyy').startOf('month').toDate();
-  const maxDate = CompaniDate(month, 'MM-yyyy').endOf('month').toDate();
+  const minDate = CompaniDate(month, 'MM-yyyy').startOf('month').toISO();
+  const maxDate = CompaniDate(month, 'MM-yyyy').endOf('month').toISO();
 
   return SectorHistory.aggregate([
     {
       $match: {
         auxiliary: { $in: auxiliaryIds },
-        startDate: { $lte: maxDate },
-        $or: [{ endDate: { $gte: minDate } }, { endDate: { $exists: false } }],
+        startDate: { $lte: new Date(maxDate) },
+        $or: [{ endDate: { $gte: new Date(minDate) } }, { endDate: { $exists: false } }],
       },
     },
     {
@@ -163,14 +163,14 @@ exports.getPaidInterventionStats = async (auxiliaryIds, month, companyId) => {
         let: {
           auxiliaryId: '$auxiliary',
           sectorStartDate: '$startDate',
-          sectorEndDate: { $ifNull: ['$endDate', maxDate] },
+          sectorEndDate: { $ifNull: ['$endDate', new Date(maxDate)] },
         },
         pipeline: [
           {
             $match: {
               type: INTERVENTION,
-              startDate: { $lte: maxDate },
-              endDate: { $gte: minDate },
+              startDate: { $lte: new Date(maxDate) },
+              endDate: { $gte: new Date(minDate) },
               $or: [{ isCancelled: false }, { 'cancel.condition': INVOICED_AND_PAID }],
               $expr: {
                 $and: [

--- a/src/repositories/StatRepository.js
+++ b/src/repositories/StatRepository.js
@@ -1,4 +1,3 @@
-const moment = require('moment');
 const { ObjectId } = require('mongodb');
 const Customer = require('../models/Customer');
 const Event = require('../models/Event');
@@ -278,15 +277,15 @@ exports.getEventsGroupedByFundingsforAllCustomers = async (fundingsDate, eventsD
 };
 
 exports.getCustomersAndDurationBySector = async (sectors, month, companyId) => {
-  const minStartDate = moment(month, 'MMYYYY').startOf('month').toDate();
-  const maxStartDate = moment(month, 'MMYYYY').endOf('month').toDate();
+  const minStartDate = CompaniDate(month, 'MM-yyyy').startOf('month').toISO();
+  const maxStartDate = CompaniDate(month, 'MM-yyyy').endOf('month').toISO();
 
   const sectorsCustomers = [
     {
       $match: {
         sector: { $in: sectors },
-        startDate: { $lt: maxStartDate },
-        $or: [{ endDate: { $exists: false } }, { endDate: { $gt: minStartDate } }],
+        startDate: { $lt: new Date(maxStartDate) },
+        $or: [{ endDate: { $exists: false } }, { endDate: { $gt: new Date(minStartDate) } }],
       },
     },
     {
@@ -297,8 +296,8 @@ exports.getCustomersAndDurationBySector = async (sectors, month, companyId) => {
         pipeline: [
           {
             $match: {
-              $or: [{ endDate: { $exists: false } }, { endDate: { $exists: true, $gte: minStartDate } }],
-              startDate: { $lte: maxStartDate },
+              $or: [{ endDate: { $exists: false } }, { endDate: { $exists: true, $gte: new Date(minStartDate) } }],
+              startDate: { $lte: new Date(maxStartDate) },
               $and: [{ $expr: { $and: [{ $eq: ['$auxiliary', '$$referentId'] }] } }],
             },
           },
@@ -323,8 +322,8 @@ exports.getCustomersAndDurationBySector = async (sectors, month, companyId) => {
         as: 'event',
         let: {
           customerId: '$customer',
-          startDate: { $max: ['$startDate', minStartDate] },
-          endDate: { $min: [{ $ifNull: ['$endDate', maxStartDate] }, maxStartDate] },
+          startDate: { $max: ['$startDate', new Date(minStartDate)] },
+          endDate: { $min: [{ $ifNull: ['$endDate', new Date(maxStartDate)] }, new Date(maxStartDate)] },
         },
         pipeline: [
           {
@@ -384,15 +383,15 @@ exports.getCustomersAndDurationBySector = async (sectors, month, companyId) => {
 };
 
 exports.getIntenalAndBilledHoursBySector = async (sectors, month, companyId) => {
-  const minStartDate = moment(month, 'MMYYYY').startOf('month').toDate();
-  const maxStartDate = moment(month, 'MMYYYY').endOf('month').toDate();
+  const minStartDate = CompaniDate(month, 'MM-yyyy').startOf('month').toISO();
+  const maxStartDate = CompaniDate(month, 'MM-yyyy').endOf('month').toISO();
 
   return SectorHistory.aggregate([
     {
       $match: {
         sector: { $in: sectors },
-        startDate: { $lt: maxStartDate },
-        $or: [{ endDate: { $exists: false } }, { endDate: { $gt: minStartDate } }],
+        startDate: { $lt: new Date(maxStartDate) },
+        $or: [{ endDate: { $exists: false } }, { endDate: { $gt: new Date(minStartDate) } }],
       },
     },
     {
@@ -401,8 +400,8 @@ exports.getIntenalAndBilledHoursBySector = async (sectors, month, companyId) => 
         as: 'event',
         let: {
           auxiliaryId: '$auxiliary',
-          startDate: { $max: ['$startDate', minStartDate] },
-          endDate: { $min: [{ $ifNull: ['$endDate', maxStartDate] }, maxStartDate] },
+          startDate: { $max: ['$startDate', new Date(minStartDate)] },
+          endDate: { $min: [{ $ifNull: ['$endDate', new Date(maxStartDate)] }, new Date(maxStartDate)] },
         },
         pipeline: [
           {

--- a/tests/unit/helpers/stat.test.js
+++ b/tests/unit/helpers/stat.test.js
@@ -1,7 +1,6 @@
 const expect = require('expect');
 const { ObjectId } = require('mongodb');
 const sinon = require('sinon');
-const moment = require('../../../src/extensions/moment');
 const { CompaniDate } = require('../../../src/helpers/dates/companiDates');
 const StatsHelper = require('../../../src/helpers/stats');
 const SectorHistoryRepository = require('../../../src/repositories/SectorHistoryRepository');
@@ -530,7 +529,7 @@ describe('getPaidInterventionStats', () => {
   });
 
   it('Case sector : should format sector as array', async () => {
-    const query = { sector: new ObjectId(), month: '102019' };
+    const query = { sector: new ObjectId(), month: '10-2019' };
     const auxiliaries = [{ auxiliaryId: new ObjectId() }];
     getUsersFromSectorHistoriesStub.returns(auxiliaries);
     const getPaidInterventionStatsResult = [{
@@ -539,8 +538,8 @@ describe('getPaidInterventionStats', () => {
       sectors: ['12345'],
     }];
     getPaidInterventionStats.returns(getPaidInterventionStatsResult);
-    const startOfMonth = moment(query.month, 'MMYYYY').startOf('M').toDate();
-    const endOfMonth = moment(query.month, 'MMYYYY').endOf('M').toDate();
+    const startOfMonth = '2019-09-30T22:00:00.000Z';
+    const endOfMonth = '2019-10-31T22:59:59.999Z';
 
     const result = await StatsHelper.getPaidInterventionStats(query, credentials);
 
@@ -561,10 +560,10 @@ describe('getPaidInterventionStats', () => {
   });
 
   it('Case sector : should format array sector with objectId', async () => {
-    const query = { sector: [new ObjectId(), new ObjectId()], month: '102019' };
+    const query = { sector: [new ObjectId(), new ObjectId()], month: '10-2019' };
     const auxiliaries = [{ auxiliaryId: new ObjectId() }, { auxiliaryId: new ObjectId() }];
-    const startOfMonth = moment(query.month, 'MMYYYY').startOf('M').toDate();
-    const endOfMonth = moment(query.month, 'MMYYYY').endOf('M').toDate();
+    const startOfMonth = '2019-09-30T22:00:00.000Z';
+    const endOfMonth = '2019-10-31T22:59:59.999Z';
 
     getUsersFromSectorHistoriesStub.returns(auxiliaries);
     const getPaidInterventionStatsResult = [
@@ -592,7 +591,7 @@ describe('getPaidInterventionStats', () => {
   });
 
   it('Case auxiliary', async () => {
-    const query = { auxiliary: new ObjectId(), month: '102019' };
+    const query = { auxiliary: new ObjectId(), month: '10-2019' };
     getPaidInterventionStats.returns({ customerCount: 9 });
     const result = await StatsHelper.getPaidInterventionStats(query, credentials);
 
@@ -600,7 +599,7 @@ describe('getPaidInterventionStats', () => {
     sinon.assert.calledWithExactly(
       getPaidInterventionStats,
       [query.auxiliary],
-      '102019',
+      '10-2019',
       credentials.company._id
     );
     sinon.assert.notCalled(getUsersFromSectorHistoriesStub);
@@ -619,7 +618,7 @@ describe('getCustomersAndDurationBySector', () => {
 
   it('Case sector : should format sector as array', async () => {
     const sectorId = new ObjectId();
-    const query = { sector: sectorId, month: '102019' };
+    const query = { sector: sectorId, month: '10-2019' };
     getCustomersAndDurationBySector.returns({ customerCount: 9 });
     const result = await StatsHelper.getCustomersAndDurationBySector(query, credentials);
 
@@ -627,14 +626,14 @@ describe('getCustomersAndDurationBySector', () => {
     sinon.assert.calledWithExactly(
       getCustomersAndDurationBySector,
       [sectorId],
-      '102019',
+      '10-2019',
       credentials.company._id
     );
   });
 
   it('Case sector : should format array sector with objectId', async () => {
     const sectors = [new ObjectId(), new ObjectId()];
-    const query = { sector: sectors, month: '102019' };
+    const query = { sector: sectors, month: '10-2019' };
     getCustomersAndDurationBySector.returns({ customerCount: 9 });
     const result = await StatsHelper.getCustomersAndDurationBySector(query, credentials);
 
@@ -642,7 +641,7 @@ describe('getCustomersAndDurationBySector', () => {
     sinon.assert.calledWithExactly(
       getCustomersAndDurationBySector,
       sectors,
-      '102019',
+      '10-2019',
       credentials.company._id
     );
   });
@@ -660,7 +659,7 @@ describe('getIntenalAndBilledHoursBySector', () => {
 
   it('Case sector : should format sector as array', async () => {
     const sectorId = new ObjectId();
-    const query = { sector: sectorId, month: '102019' };
+    const query = { sector: sectorId, month: '10-2019' };
     getIntenalAndBilledHoursBySector.returns({ interventions: 9 });
     const result = await StatsHelper.getIntenalAndBilledHoursBySector(query, credentials);
 
@@ -668,14 +667,14 @@ describe('getIntenalAndBilledHoursBySector', () => {
     sinon.assert.calledWithExactly(
       getIntenalAndBilledHoursBySector,
       [sectorId],
-      '102019',
+      '10-2019',
       credentials.company._id
     );
   });
 
   it('Case sector : should format array sector with objectId', async () => {
     const sectors = [new ObjectId(), new ObjectId()];
-    const query = { sector: sectors, month: '102019' };
+    const query = { sector: sectors, month: '10-2019' };
     getIntenalAndBilledHoursBySector.returns({ interventions: 9 });
     const result = await StatsHelper.getIntenalAndBilledHoursBySector(query, credentials);
 
@@ -683,7 +682,7 @@ describe('getIntenalAndBilledHoursBySector', () => {
     sinon.assert.calledWithExactly(
       getIntenalAndBilledHoursBySector,
       sectors,
-      '102019',
+      '10-2019',
       credentials.company._id
     );
   });


### PR DESCRIPTION
<details open><summary> TESTS  :computer: </summary>

- [x] J'ai codé les tests unitaires
- [x] J'ai codé les tests d'intégration
- [ ] C'est une ancienne route utilisée par les apps mobiles.
  - [ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens
</details>

- [ ] Je replie cette section car mes modifications n'ont pas besoin de tests unitaires ou d'intégration

---

<details><summary> POINTS D'ATTENTION POUR CETTE PR  :warning: </summary>

- [ ] J'ai fait des modifications sur une route utilisée sur plusieurs plateformes [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/n3bq2hr9Ia)
- [ ] J'ai modifié un modèle utilisé en mobile [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/rqTfwpUib)
- [ ] J'ai ajouté un modèle spécifique à une structure 
  - [ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés
- [ ] J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile
  - [ ] Si oui, j'ai précisé sur le [slite de MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) qu'il faut forcer la mise à jour
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

</details>

- [x] Je replie cette section car je n'ai pas fait de modifications entrainant un point d'attention

---

<details><summary> FONCTIONNALITÉS APPS MOBILES  :iphone: </summary>

- [ ] Mes changements impactent l'application formation
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours
- [ ] Mes changements impactent l'application erp
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours

</details>

- [x] Je replie cette section car mes modifications n'ont pas d'impact sur les applications mobiles

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : coach coté outils

- Cas d'usage : j'ai retiré momentJS sur les routes 
   -` /paid-intervention-stats`
   - `/internal-billed-hours`
   - `/customer-duration/sector`
 Il dans le service stat.js il n'y a plus moment

- Comment tester ? :
   - dans la tableau de bord > detail sur un.e auxiliaire / planning auxiliaire :  " X bénéficiaires accompagnés, X h en moyenne "
   - dans le tableau de bord > données par equipe : " X beneficiaire" et "X heures par beneficiaire"
   - dans le tableau de bord > en dessous du compteur d'heure: "Heures internes XXh"

_Si tu as lu cette description, pense a réagir avec un :eye:_
