### PR TITLE
Com 2713

### DIFF
--- a/src/helpers/historyExport.js
+++ b/src/helpers/historyExport.js
@@ -759,7 +759,7 @@ exports.exportCourseHistory = async (startDate, endDate) => {
     });
   }
 
-  return [Object.keys(rows[0]), ...rows.map(d => Object.values(d))];
+  return rows.length ? [Object.keys(rows[0]), ...rows.map(d => Object.values(d))] : [];
 };
 
 const getAddress = (slot) => {
@@ -815,7 +815,7 @@ exports.exportCourseSlotHistory = async (startDate, endDate) => {
     });
   }
 
-  return [Object.keys(rows[0]), ...rows.map(d => Object.values(d))];
+  return rows.length ? [Object.keys(rows[0]), ...rows.map(d => Object.values(d))] : [];
 };
 
 exports.exportTransportsHistory = async (startDate, endDate, credentials) => {
@@ -875,5 +875,5 @@ exports.exportTransportsHistory = async (startDate, endDate, credentials) => {
     }
   }
 
-  return [Object.keys(rows[0]), ...rows.map(d => Object.values(d))];
+  return rows.length ? [Object.keys(rows[0]), ...rows.map(d => Object.values(d))] : [];
 };

--- a/src/helpers/historyExport.js
+++ b/src/helpers/historyExport.js
@@ -53,6 +53,8 @@ const UserRepository = require('../repositories/UserRepository');
 const { TIME_STAMPING_ACTIONS } = require('../models/EventHistory');
 const QuestionnaireHistory = require('../models/QuestionnaireHistory');
 
+const NO_DATA = 'Aucune donnée sur la periode selectionnée';
+
 const workingEventExportHeader = [
   'Type',
   'Heure interne',
@@ -759,7 +761,7 @@ exports.exportCourseHistory = async (startDate, endDate) => {
     });
   }
 
-  return rows.length ? [Object.keys(rows[0]), ...rows.map(d => Object.values(d))] : [];
+  return rows.length ? [Object.keys(rows[0]), ...rows.map(d => Object.values(d))] : [[NO_DATA]];
 };
 
 const getAddress = (slot) => {
@@ -815,7 +817,7 @@ exports.exportCourseSlotHistory = async (startDate, endDate) => {
     });
   }
 
-  return rows.length ? [Object.keys(rows[0]), ...rows.map(d => Object.values(d))] : [];
+  return rows.length ? [Object.keys(rows[0]), ...rows.map(d => Object.values(d))] : [[NO_DATA]];
 };
 
 exports.exportTransportsHistory = async (startDate, endDate, credentials) => {
@@ -875,5 +877,5 @@ exports.exportTransportsHistory = async (startDate, endDate, credentials) => {
     }
   }
 
-  return rows.length ? [Object.keys(rows[0]), ...rows.map(d => Object.values(d))] : [];
+  return rows.length ? [Object.keys(rows[0]), ...rows.map(d => Object.values(d))] : [[NO_DATA]];
 };

--- a/tests/unit/helpers/historyExport.test.js
+++ b/tests/unit/helpers/historyExport.test.js
@@ -1790,7 +1790,7 @@ describe('exportCourseHistory', () => {
 
     const result = await ExportHelper.exportCourseHistory('2021-01-14T23:00:00.000Z', '2022-01-20T22:59:59.000Z');
 
-    expect(result).toEqual([]);
+    expect(result).toEqual([['Aucune donnée sur la periode selectionnée']]);
     SinonMongoose.calledOnceWithExactly(
       findCourseSlot,
       [
@@ -2118,7 +2118,7 @@ describe('exportCourseSlotHistory', () => {
 
     const result = await ExportHelper.exportCourseSlotHistory('2021-01-14T23:00:00.000Z', '2022-01-20T22:59:59.000Z');
 
-    expect(result).toEqual([]);
+    expect(result).toEqual([['Aucune donnée sur la periode selectionnée']]);
     SinonMongoose.calledOnceWithExactly(
       findCourseSlot,
       [
@@ -2290,7 +2290,7 @@ describe('exportTransportsHistory', () => {
     const credentials = { company: { _id: new ObjectId() } };
     const exportArray = await ExportHelper.exportTransportsHistory('2021-06-24', '2021-06-30', credentials);
 
-    expect(exportArray).toEqual([]);
+    expect(exportArray).toEqual([['Aucune donnée sur la periode selectionnée']]);
     sinon.assert.notCalled(getPaidTransportInfo);
   });
 


### PR DESCRIPTION
<details open><summary> TESTS  :computer: </summary>

- [x] J'ai codé les tests unitaires
- [ ] ~~J'ai codé les tests d'intégration~~
- [ ] ~~C'est une ancienne route utilisée par les apps mobiles.~~
  - [ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens
</details>

- [ ] Je replie cette section car mes modifications n'ont pas besoin de tests unitaires ou d'intégration

---

<details open><summary> POINTS D'ATTENTION POUR CETTE PR  :warning: </summary>

- [ ] J'ai fait des modifications sur une route utilisée sur plusieurs plateformes [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/n3bq2hr9Ia)
- [ ] J'ai modifié un modèle utilisé en mobile [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/rqTfwpUib)
- [ ] J'ai ajouté un modèle spécifique à une structure 
  - [ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés
- [ ] J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile
  - [ ] Si oui, j'ai précisé sur le [slite de MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) qu'il faut forcer la mise à jour
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

</details>

- [x] Je replie cette section car je n'ai pas fait de modifications entrainant un point d'attention

---

<details open><summary> FONCTIONNALITÉS APPS MOBILES  :iphone: </summary>

- [ ] Mes changements impactent l'application formation
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours
- [ ] Mes changements impactent l'application erp
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours

</details>

- [x] Je replie cette section car mes modifications n'ont pas d'impact sur les applications mobiles

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : Admin

- Cas d'usage : Quand j'exporte les temps de transport sur une periode ou il n'y a pas d'intervention, je n'ai pas d'erreur - le fichier obtenu est vide

- Comment tester ? : exporter les temps de transport sur 2023 par exemple
meme changement fait sur les formations et les créneaux

_Si tu as lu cette description, pense a réagir avec un :eye:_
