### PR TITLE
Com 2708

### DIFF
--- a/src/helpers/eventsRepetition.js
+++ b/src/helpers/eventsRepetition.js
@@ -132,6 +132,8 @@ exports.createRepetitions = async (eventFromDb, payload, credentials) => {
 exports.updateRepetition = async (eventFromDb, eventPayload, credentials) => {
   const promises = [];
   const companyId = get(credentials, 'company._id', null);
+  const payloadStartHour = CompaniDate(eventPayload.startDate).getUnits(['hour', 'minute']);
+  const payloadEndHour = CompaniDate(eventPayload.endDate).getUnits(['hour', 'minute']);
 
   const query = {
     'repetition.parentId': eventFromDb.repetition.parentId,
@@ -150,8 +152,6 @@ exports.updateRepetition = async (eventFromDb, eventPayload, credentials) => {
   }
 
   for (let i = 0, l = events.length; i < l; i++) {
-    const payloadStartHour = CompaniDate(eventPayload.startDate).getUnits(['hour', 'minute']);
-    const payloadEndHour = CompaniDate(eventPayload.endDate).getUnits(['hour', 'minute']);
     const startDate = CompaniDate(events[i].startDate).set(payloadStartHour).toISO();
     const endDate = CompaniDate(events[i].endDate).set(payloadEndHour).toISO();
 

--- a/src/helpers/repetitions.js
+++ b/src/helpers/repetitions.js
@@ -1,20 +1,16 @@
-const moment = require('moment');
 const omit = require('lodash/omit');
 const Repetition = require('../models/Repetition');
 const EventsHelper = require('./events');
+const { CompaniDate } = require('./dates/companiDates');
 
 exports.updateRepetitions = async (eventPayload, parentId) => {
   const repetition = await Repetition.findOne({ parentId }).lean();
   if (!repetition) return;
 
-  const eventStartDate = moment(eventPayload.startDate);
-  const eventEndDate = moment(eventPayload.endDate);
-  const startDate = moment(repetition.startDate)
-    .hours(eventStartDate.hours())
-    .minutes(eventStartDate.minutes()).toISOString();
-  const endDate = moment(repetition.endDate)
-    .hours(eventEndDate.hours())
-    .minutes(eventEndDate.minutes()).toISOString();
+  const payloadStartHour = CompaniDate(eventPayload.startDate).getUnits(['hour', 'minute']);
+  const payloadEndHour = CompaniDate(eventPayload.endDate).getUnits(['hour', 'minute']);
+  const startDate = CompaniDate(repetition.startDate).set(payloadStartHour).toISO();
+  const endDate = CompaniDate(repetition.endDate).set(payloadEndHour).toISO();
 
   const repetitionPayload = { ...omit(eventPayload, ['_id']), startDate, endDate };
   const payload = EventsHelper.formatEditionPayload(repetition, repetitionPayload, false);

--- a/src/routes/events.js
+++ b/src/routes/events.js
@@ -50,7 +50,13 @@ const {
   authorizeEventForCreditNoteGet,
   authorizeTimeStamping,
 } = require('./preHandlers/events');
-const { monthValidation, addressValidation, objectIdOrArray } = require('./validations/utils');
+const {
+  monthValidation,
+  addressValidation,
+  objectIdOrArray,
+  dateToISOString,
+
+} = require('./validations/utils');
 
 exports.plugin = {
   name: 'routes-event',
@@ -171,8 +177,8 @@ exports.plugin = {
         validate: {
           params: Joi.object({ _id: Joi.objectId().required() }),
           payload: Joi.object().keys({
-            startDate: Joi.date(),
-            endDate: Joi.date().greater(Joi.ref('startDate')),
+            startDate: dateToISOString,
+            endDate: dateToISOString,
             auxiliary: Joi.objectId(),
             sector: Joi.string(),
             address: Joi.when(
@@ -215,6 +221,11 @@ exports.plugin = {
             kmDuringEvent: Joi.number().min(0),
           })
             .and('startDate', 'endDate')
+            .assert(
+              '.endDate',
+              Joi.date().greater(Joi.ref('startDate')),
+              'Error in joi asserting validation: endDate must be greater than startDate'
+            )
             .xor('auxiliary', 'sector'),
         },
         pre: [

--- a/src/routes/validations/utils.js
+++ b/src/routes/validations/utils.js
@@ -1,6 +1,8 @@
 const Joi = require('joi');
 const { MONTH_VALIDATION, PHONE_VALIDATION } = require('../../models/utils');
 
+const dateToISOString = Joi.date().custom(value => value.toISOString());
+
 const monthValidation = Joi.string().regex(MONTH_VALIDATION);
 const phoneNumberValidation = Joi.string().regex(PHONE_VALIDATION);
 
@@ -44,4 +46,5 @@ module.exports = {
   stringOrArray,
   expoTokenValidation,
   formDataPayload,
+  dateToISOString,
 };

--- a/tests/integration/events.test.js
+++ b/tests/integration/events.test.js
@@ -1310,7 +1310,7 @@ describe('PUT /events/{_id}', () => {
       const event = eventsList[9];
       const payload = {
         startDate: new Date('2019-10-16T10:00:00.000Z'), // testing dateJS on purpose
-        endDate: '2019-10-16T14:00', // ~ 2019-10-16T12:00:00.000Z, testing incomplete ISO on purpose
+        endDate: '2019-10-16T14:00+02:00', // ~ 2019-10-16T12:00:00.000Z, testing incomplete ISO on purpose
         auxiliary: event.auxiliary.toHexString(),
         shouldUpdateRepetition: true,
       };

--- a/tests/integration/events.test.js
+++ b/tests/integration/events.test.js
@@ -1306,7 +1306,7 @@ describe('PUT /events/{_id}', () => {
       expect(resultEvent.sector.toHexString()).toBe(payload.sector);
     });
 
-    it('should update events and repetition with startDate, endDate #tag', async () => {
+    it('should update events and repetition with startDate, endDate', async () => {
       const event = eventsList[9];
       const payload = {
         startDate: new Date('2019-10-16T10:00:00.000Z'), // testing dateJS on purpose

--- a/tests/integration/events.test.js
+++ b/tests/integration/events.test.js
@@ -1353,6 +1353,25 @@ describe('PUT /events/{_id}', () => {
       expect(response.statusCode).toBe(400);
     });
 
+    it('should return a 400 error as startDate is after endDate', async () => {
+      const event = eventsList[0];
+      const payload = {
+        startDate: '2019-01-23T20:00:00.000Z',
+        endDate: '2019-01-23T12:00:00.000Z',
+        auxiliary: event.auxiliary.toHexString(),
+      };
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/events/${event._id.toHexString()}`,
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.result.message.endsWith('endDate must be greater than startDate')).toBeTruthy();
+    });
+
     it('should return a 400 error as startDate and endDate are not on the same day', async () => {
       const payload = {
         startDate: '2019-01-23T10:00:00.000Z',

--- a/tests/integration/seed/eventsSeed.js
+++ b/tests/integration/seed/eventsSeed.js
@@ -406,6 +406,8 @@ const repetitions = [{
   parentId: repetitionParentId,
   repetition: { frequency: EVERY_WEEK },
   company: authCompany._id,
+  startDate: '2019-10-16T14:30:00.000Z',
+  endDate: '2019-10-16T16:30:00.000Z',
 }];
 
 const customerAbsences = [
@@ -426,7 +428,7 @@ const customerAbsences = [
 ];
 
 const eventsList = [
-  {
+  { // 0
     _id: new ObjectId(),
     company: authCompany._id,
     type: INTERNAL_HOUR,
@@ -607,8 +609,8 @@ const eventsList = [
     _id: repetitionParentId,
     company: authCompany._id,
     type: INTERVENTION,
-    startDate: '2019-10-16T14:30:19.543Z',
-    endDate: '2019-10-16T16:30:19.543Z',
+    startDate: '2019-10-16T14:30:00.000Z',
+    endDate: '2019-10-16T16:30:00.000Z',
     auxiliary: auxiliaries[0]._id,
     customer: customerAuxiliaries[0]._id,
     repetition: { frequency: EVERY_WEEK, parentId: repetitionParentId },
@@ -789,8 +791,8 @@ const eventsList = [
     company: authCompany._id,
     sector: sectors[0]._id,
     type: INTERVENTION,
-    startDate: '2019-10-23T14:30:19.543Z',
-    endDate: '2019-10-23T16:30:19.543Z',
+    startDate: '2019-10-23T14:30:00.000Z',
+    endDate: '2019-10-23T16:30:00.000Z',
     auxiliary: auxiliaries[0]._id,
     customer: customerAuxiliaries[0]._id,
     repetition: { frequency: EVERY_WEEK, parentId: repetitionParentId },
@@ -1146,4 +1148,5 @@ module.exports = {
   eventHistoriesList,
   creditNote,
   creditNoteFromOtherCompany,
+  repetitionParentId,
 };

--- a/tests/unit/helpers/eventsRepetition.test.js
+++ b/tests/unit/helpers/eventsRepetition.test.js
@@ -659,7 +659,7 @@ describe('updateRepetition', () => {
           args: [{
             'repetition.parentId': 'qwertyuiop',
             'repetition.frequency': { $not: { $eq: 'never' } },
-            startDate: { $gte: new Date('2019-03-23T09:00:00.000Z') },
+            startDate: { $gte: '2019-03-23T09:00:00.000Z' },
             company: credentials.company._id,
           }],
         },
@@ -747,7 +747,7 @@ describe('updateRepetition', () => {
           args: [{
             'repetition.parentId': 'qwertyuiop',
             'repetition.frequency': { $not: { $eq: 'never' } },
-            startDate: { $gte: new Date('2019-03-23T09:00:00.000Z') },
+            startDate: { $gte: '2019-03-23T09:00:00.000Z' },
             company: credentials.company._id,
           }],
         },
@@ -853,7 +853,7 @@ describe('updateRepetition', () => {
           args: [{
             'repetition.parentId': 'qwertyuiop',
             'repetition.frequency': { $not: { $eq: 'never' } },
-            startDate: { $gte: new Date('2019-03-23T09:00:00.000Z') },
+            startDate: { $gte: '2019-03-23T09:00:00.000Z' },
             company: companyId,
           }],
         },
@@ -948,7 +948,7 @@ describe('updateRepetition', () => {
           args: [{
             'repetition.parentId': 'qwertyuiop',
             'repetition.frequency': { $not: { $eq: 'never' } },
-            startDate: { $gte: new Date('2019-03-23T09:00:00') },
+            startDate: { $gte: '2019-03-23T09:00:00' },
             company: credentials.company._id,
           }],
         },
@@ -1035,7 +1035,7 @@ describe('updateRepetition', () => {
           args: [{
             'repetition.parentId': 'qwertyuiop',
             'repetition.frequency': { $not: { $eq: 'never' } },
-            startDate: { $gte: new Date('2019-03-23T09:00:00.000Z') },
+            startDate: { $gte: '2019-03-23T09:00:00.000Z' },
             company: credentials.company._id,
           }],
         },
@@ -1072,7 +1072,7 @@ describe('deleteRepetition', () => {
     };
     const query = {
       'repetition.parentId': event.repetition.parentId,
-      startDate: { $gte: new Date(event.startDate) },
+      startDate: { $gte: event.startDate },
       company: credentials.company._id,
     };
 

--- a/tests/unit/helpers/utilsValidation.test.js
+++ b/tests/unit/helpers/utilsValidation.test.js
@@ -36,7 +36,7 @@ describe('dateToISOString', () => {
     expect(result.value).toBe('2022-03-07T07:00:00.000Z');
   });
 
-  it('should accept number', async () => {
+  it('should accept date in miliseconds', async () => {
     const payload = 1646636400000;
 
     const result = dateToISOString.validate(payload);
@@ -44,7 +44,7 @@ describe('dateToISOString', () => {
     expect(result.value).toBe('2022-03-07T07:00:00.000Z');
   });
 
-  it('should accept us commun format "MM/DD/YYYY"', async () => {
+  it('should accept US commun format "MM/DD/YYYY"', async () => {
     const payload = '03/07/2022';
 
     const result = dateToISOString.validate(payload);

--- a/tests/unit/helpers/utilsValidation.test.js
+++ b/tests/unit/helpers/utilsValidation.test.js
@@ -1,7 +1,8 @@
 const expect = require('expect');
 const { dateToISOString } = require('../../../src/routes/validations/utils');
+const { CompaniDate } = require('../../../src/helpers/dates/companiDates');
 
-describe('dateToISOString #tag', () => {
+describe('dateToISOString', () => {
   it('should accept dateJS and return complete ISO string', async () => {
     const payload = new Date('2022-03-07T07:00:00.000Z');
 
@@ -48,7 +49,7 @@ describe('dateToISOString #tag', () => {
 
     const result = dateToISOString.validate(payload);
     expect(result.error).toBeFalsy();
-    expect(result.value).toBe('2022-03-06T23:00:00.000Z');
+    expect(CompaniDate(result.value).isSame('2022-03-07', 'day')).toBeTruthy();
   });
 
   it('should not accept unexisting date', async () => {

--- a/tests/unit/helpers/utilsValidation.test.js
+++ b/tests/unit/helpers/utilsValidation.test.js
@@ -1,0 +1,61 @@
+const expect = require('expect');
+const { dateToISOString } = require('../../../src/routes/validations/utils');
+
+describe('dateToISOString #tag', () => {
+  it('should accept dateJS and return complete ISO string', async () => {
+    const payload = new Date('2022-03-07T07:00:00.000Z');
+
+    const result = dateToISOString.validate(payload);
+    expect(result.error).toBeFalsy();
+    expect(result.value).toBe('2022-03-07T07:00:00.000Z');
+  });
+
+  it('should accept stringed dateJS', async () => {
+    const dateJS = new Date('2022-03-07T07:00:00.000Z');
+    const payload = dateJS.toString(); // Mon Mar 07 2022 08:00:00 GMT+0100 (heure normale d’Europe centrale)
+
+    const result = dateToISOString.validate(payload);
+    expect(result.error).toBeFalsy();
+    expect(result.value).toBe('2022-03-07T07:00:00.000Z');
+  });
+
+  it('should accept complete ISO string', async () => {
+    const payload = '2022-03-07T07:00:00.000Z';
+
+    const result = dateToISOString.validate(payload);
+    expect(result.error).toBeFalsy();
+    expect(result.value).toBe('2022-03-07T07:00:00.000Z');
+  });
+
+  it('should accept incomplete ISO string', async () => {
+    const payload = '2022-03-07T07:00Z';
+
+    const result = dateToISOString.validate(payload);
+    expect(result.error).toBeFalsy();
+    expect(result.value).toBe('2022-03-07T07:00:00.000Z');
+  });
+
+  it('should accept number', async () => {
+    const payload = 1646636400000;
+
+    const result = dateToISOString.validate(payload);
+    expect(result.error).toBeFalsy();
+    expect(result.value).toBe('2022-03-07T07:00:00.000Z');
+  });
+
+  it('should accept us commun format "MM/DD/YYYY"', async () => {
+    const payload = '03/07/2022';
+
+    const result = dateToISOString.validate(payload);
+    expect(result.error).toBeFalsy();
+    expect(result.value).toBe('2022-03-06T23:00:00.000Z');
+  });
+
+  it('should not accept unexisting date', async () => {
+    const payload = '2022-03-32T23:00:00.000Z';
+
+    const result = dateToISOString.validate(payload);
+    expect(result.error).toBeTruthy();
+    expect(result.error.message.startsWith('"value" must be a valid date')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
<details open><summary> TESTS  :computer: </summary>

- [x] J'ai codé les tests unitaires
- [x] J'ai codé les tests d'intégration
- [ ] C'est une ancienne route utilisée par les apps mobiles.
  - [ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens
</details>

- [ ] Je replie cette section car mes modifications n'ont pas besoin de tests unitaires ou d'intégration

---

<details open><summary> POINTS D'ATTENTION POUR CETTE PR  :warning: </summary>

- [x] J'ai fait des modifications sur une route utilisée sur plusieurs plateformes [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/n3bq2hr9Ia)
- [ ] J'ai modifié un modèle utilisé en mobile [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/rqTfwpUib)
- [ ] J'ai ajouté un modèle spécifique à une structure 
  - [ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés
- [ ] J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile
  - [ ] Si oui, j'ai précisé sur le [slite de MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) qu'il faut forcer la mise à jour
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

</details>

- [ ] Je replie cette section car je n'ai pas fait de modifications entrainant un point d'attention

---

<details open><summary> FONCTIONNALITÉS APPS MOBILES  :iphone: </summary>

- [ ] Mes changements impactent l'application formation
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours
- [x] Mes changements impactent l'application erp
  - [x] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours

</details>

- [] Je replie cette section car mes modifications n'ont pas d'impact sur les applications mobiles

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : compani-outil webapp / coach-aux ET compani-outil mobile / aux

- Cas d'usage : 
     - apres la refacto, je peux toujours modifier un evenement, la repetition associé et tous les evements lié a cette repetition qui suivent.
     - g remplacé moment pas companiDate
     - comme en s'attend a recevoir un date ISO, j'ai remplacé la validation Joi pour qu'elle
        - accepte tous les formats de date
        - renvoie une date ISO a l'api
     - j'ai ajouté un test d'inté car la partie du code que j'ai modifé n'etait pas testé

- Comment tester ? :
    - sur mobile, modifier un evenement
    - sur webapp: 
        - modifier un evenement qui n'appartient pas a une repet
        - je peux modifier un evenement d'une repet sans modifier la repet
        - je peux modifier un evenement d'une repet en modifiant tous les autres evenements de la repet
    - Aujourd'hui on n'a pas de test unitaire pour verifier des validations custom qu'on aurai codé avec Joi.
       - c'est pour ca que j'ai testé deux formats differents pour les dates du payload dans le test d'inté
          - le format dateJS
          - le format ISO incomplet et sans timezone
       - tu peux tester a la main
          - le format ISO complet
          - le format dateJS.toString()
          - le format en miliseconde
          - le format MM/JJ/AAAA

💬 Comme on touche a un truc critique: l'edition d'evenement, et comme ce ticket n'a rien d'urgent. On peut le fusionner au debut du prochain sprint. Qu'en pensez vous ?

_Si tu as lu cette description, pense a réagir avec un :eye:_
