### PR TITLE
Com 2729 fix 2

### DIFF
--- a/src/routes/thirdPartyPayers.js
+++ b/src/routes/thirdPartyPayers.js
@@ -68,8 +68,16 @@ exports.plugin = {
             isApa: Joi.boolean().required(),
             teletransmissionId: Joi.string().default(''),
             teletransmissionType: Joi.string().valid(...TELETRANSMISSION_TYPES)
-              .when('teletransmissionId', { is: Joi.string().exist(), then: Joi.required() }),
-            companyCode: Joi.string().when('teletransmissionId', { is: Joi.string().exist(), then: Joi.required() }),
+              .when('teletransmissionId', {
+                is: Joi.string().exist(),
+                then: Joi.required(),
+                otherwise: Joi.string().default(''),
+              }),
+            companyCode: Joi.string().when('teletransmissionId', {
+              is: Joi.string().exist(),
+              then: Joi.required(),
+              otherwise: Joi.string().default(''),
+            }),
           }),
         },
         pre: [{ method: authorizeThirdPartyPayersUpdate }],

--- a/tests/integration/seed/thirdPartyPayersSeed.js
+++ b/tests/integration/seed/thirdPartyPayersSeed.js
@@ -5,7 +5,16 @@ const { authCompany, otherCompany } = require('../../seed/authCompaniesSeed');
 const { deleteNonAuthenticationSeeds } = require('../helpers/authentication');
 
 const thirdPartyPayersList = [
-  { _id: new ObjectId(), name: 'Toto', company: authCompany._id, isApa: false, billingMode: BILLING_DIRECT },
+  {
+    _id: new ObjectId(),
+    name: 'Toto',
+    company: authCompany._id,
+    isApa: false,
+    billingMode: BILLING_DIRECT,
+    teletransmissionId: '1234567890',
+    teletransmissionType: 'AM',
+    companyCode: '448',
+  },
   { _id: new ObjectId(), name: 'Tata', company: authCompany._id, isApa: false, billingMode: BILLING_DIRECT },
 ];
 

--- a/tests/integration/thirdPartyPayers.test.js
+++ b/tests/integration/thirdPartyPayers.test.js
@@ -204,6 +204,29 @@ describe('THIRD PARTY PAYERS ROUTES', () => {
       expect(response.statusCode).toBe(200);
     });
 
+    it('should remove companyCode and teletransmissionType by default if no teletransmissionId', async () => {
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/thirdpartypayers/${thirdPartyPayersList[0]._id.toHexString()}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+        payload: {
+          name: 'Aide départementale au skusku',
+          billingMode: 'indirect',
+          isApa: false,
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      const updatedTpp = await ThirdPartyPayer.countDocuments({
+        _id: thirdPartyPayersList[0]._id,
+        teletransmissionId: '',
+        teletransmissionType: '',
+        companyCode: '',
+      });
+      expect(updatedTpp).toBe(1);
+    });
+
     it('should update ttp name even if only case or diacritics have changed', async () => {
       const response = await app.inject({
         method: 'PUT',

--- a/tests/integration/thirdPartyPayers.test.js
+++ b/tests/integration/thirdPartyPayers.test.js
@@ -205,6 +205,14 @@ describe('THIRD PARTY PAYERS ROUTES', () => {
     });
 
     it('should remove companyCode and teletransmissionType by default if no teletransmissionId', async () => {
+      const tppToUpdate = await ThirdPartyPayer.countDocuments({
+        _id: thirdPartyPayersList[0]._id,
+        teletransmissionId: { $exists: true, $ne: '' },
+        teletransmissionType: { $exists: true, $ne: '' },
+        companyCode: { $exists: true, $ne: '' },
+      });
+      expect(tppToUpdate).toBe(1);
+
       const response = await app.inject({
         method: 'PUT',
         url: `/thirdpartypayers/${thirdPartyPayersList[0]._id.toHexString()}`,


### PR DESCRIPTION
<details open><summary> TESTS  :computer: </summary>

- [ ] J'ai codé les tests unitaires
- [x] J'ai codé les tests d'intégration
- [ ] C'est une ancienne route utilisée par les apps mobiles.
  - [ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens
</details>

- [ ] Je replie cette section car mes modifications n'ont pas besoin de tests unitaires ou d'intégration

---

<details><summary> POINTS D'ATTENTION POUR CETTE PR  :warning: </summary>

- [ ] J'ai fait des modifications sur une route utilisée sur plusieurs plateformes [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/n3bq2hr9Ia)
- [ ] J'ai modifié un modèle utilisé en mobile [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/rqTfwpUib)
- [ ] J'ai ajouté un modèle spécifique à une structure 
  - [ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés
- [ ] J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile
  - [ ] Si oui, j'ai précisé sur le [slite de MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) qu'il faut forcer la mise à jour
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

</details>

- [x] Je replie cette section car je n'ai pas fait de modifications entrainant un point d'attention

---

<details><summary> FONCTIONNALITÉS APPS MOBILES  :iphone: </summary>

- [ ] Mes changements impactent l'application formation
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours
- [ ] Mes changements impactent l'application erp
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours

</details>

- [x] Je replie cette section car mes modifications n'ont pas d'impact sur les applications mobiles

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : compani outils

- Cas d'usage : 
   - dans config benef > modal edition de ttp :  je peux remettre a '' les champs "type d'aide" et "identifiant structure" (si l'id de teletransmission est null)

- Comment tester ? :
    -  lorsque l'id teletransmission est nul, je vide le champ "type d'aide", je valide et je reouvre la modal d'edition => la valeur a disparue
    - meme chose avec le champ "id structure"

_Si tu as lu cette description, pense a réagir avec un :eye:_
