### PR TITLE
COM-2758: return boolean to display download button

### DIFF
--- a/src/helpers/courses.js
+++ b/src/helpers/courses.js
@@ -130,7 +130,7 @@ exports.getCourseProgress = (steps) => {
   };
 };
 
-exports.formatCourseWithProgress = (course, canAccessCompletionCertificate) => {
+exports.formatCourseWithProgress = (course) => {
   const steps = course.subProgram.steps
     .map((step) => {
       const slots = course.slots.filter(slot => UtilsHelper.areObjectIdsEquals(slot.step._id, step._id));
@@ -140,7 +140,6 @@ exports.formatCourseWithProgress = (course, canAccessCompletionCertificate) => {
 
   return {
     ...course,
-    ...(canAccessCompletionCertificate >= 0 && { canAccessCompletionCertificate: !!canAccessCompletionCertificate }),
     subProgram: { ...course.subProgram, steps },
     progress: exports.getCourseProgress(steps),
   };
@@ -378,9 +377,11 @@ exports.getTraineeCourse = async (courseId, credentials) => {
     .lean({ autopopulate: true, virtuals: true });
 
   const lastSlot = course.slots.sort((a, b) => DatesHelper.descendingSort('startDate')(a, b))[0];
-  const canAccessCompletionCertificate = lastSlot ? await Attendance.countDocuments({ courseSlot: lastSlot._id }) : 0;
+  const canAccessCompletionCertificate = lastSlot
+    ? !!await Attendance.countDocuments({ courseSlot: lastSlot._id })
+    : false;
 
-  return exports.formatCourseWithProgress(course, canAccessCompletionCertificate);
+  return exports.formatCourseWithProgress({ ...course, canAccessCompletionCertificate });
 };
 
 exports.updateCourse = async (courseId, payload) => {

--- a/src/helpers/courses.js
+++ b/src/helpers/courses.js
@@ -377,9 +377,7 @@ exports.getTraineeCourse = async (courseId, credentials) => {
     .lean({ autopopulate: true, virtuals: true });
 
   const lastSlot = course.slots.sort((a, b) => DatesHelper.descendingSort('startDate')(a, b))[0];
-  const canAccessCompletionCertificate = lastSlot
-    ? !!await Attendance.countDocuments({ courseSlot: lastSlot._id })
-    : false;
+  const canAccessCompletionCertificate = !!(lastSlot && await Attendance.countDocuments({ courseSlot: lastSlot._id }));
 
   return exports.formatCourseWithProgress({ ...course, canAccessCompletionCertificate });
 };

--- a/src/helpers/courses.js
+++ b/src/helpers/courses.js
@@ -376,10 +376,15 @@ exports.getTraineeCourse = async (courseId, credentials) => {
     .select('_id misc')
     .lean({ autopopulate: true, virtuals: true });
 
-  const lastSlot = course.slots.sort((a, b) => DatesHelper.descendingSort('startDate')(a, b))[0];
-  const canAccessCompletionCertificate = !!(lastSlot && await Attendance.countDocuments({ courseSlot: lastSlot._id }));
+  if (!course.subProgram.isStrictlyELearning) {
+    const lastSlot = course.slots.sort((a, b) => DatesHelper.descendingSort('startDate')(a, b))[0];
+    const areLastSlotAttendancesValidated = !!(lastSlot &&
+      await Attendance.countDocuments({ courseSlot: lastSlot._id }));
 
-  return exports.formatCourseWithProgress({ ...course, canAccessCompletionCertificate });
+    return exports.formatCourseWithProgress({ ...course, areLastSlotAttendancesValidated });
+  }
+
+  return exports.formatCourseWithProgress(course);
 };
 
 exports.updateCourse = async (courseId, payload) => {

--- a/tests/unit/helpers/courses.test.js
+++ b/tests/unit/helpers/courses.test.js
@@ -353,77 +353,7 @@ describe('formatCourseWithProgress', () => {
     getCourseProgress.restore();
     getProgress.restore();
   });
-  it('should format course (with canAccessCompletionCertificate)', async () => {
-    const stepId = new ObjectId();
-    const course = {
-      misc: 'name',
-      _id: new ObjectId(),
-      subProgram: {
-        steps: [{
-          _id: new ObjectId(),
-          activities: [{ activityHistories: [{}, {}] }],
-          name: 'Développement personnel full stack',
-          type: 'e_learning',
-          areActivitiesValid: false,
-        },
-        {
-          _id: stepId,
-          activities: [],
-          name: 'Développer des équipes agiles et autonomes',
-          type: 'on_site',
-          areActivitiesValid: true,
-        },
-        ],
-      },
-      slots: [
-        { startDate: '2020-11-03T09:00:00.000Z', endDate: '2020-11-03T12:00:00.000Z', step: stepId, attendances: [] },
-        { startDate: '2020-11-04T09:00:00.000Z', endDate: '2020-11-04T16:01:00.000Z', step: stepId, attendances: [] },
-      ],
-    };
-    getProgress.onCall(0).returns({ eLearning: 1 });
-    getProgress.onCall(1).returns({
-      live: 1,
-      presence: { attendanceDuration: { minutes: 0 }, maxDuration: { minutes: 601 } },
-    });
-    getCourseProgress.returns({
-      eLearning: 1,
-      live: 1,
-      presence: { attendanceDuration: { minutes: 0 }, maxDuration: { minutes: 601 } },
-    });
-
-    const result = await CourseHelper.formatCourseWithProgress(course, 0);
-    expect(result).toMatchObject({
-      ...course,
-      canAccessCompletionCertificate: false,
-      subProgram: {
-        ...course.subProgram,
-        steps: [
-          { ...course.subProgram.steps[0], progress: { eLearning: 1 } },
-          {
-            ...course.subProgram.steps[1],
-            progress: { live: 1, presence: { attendanceDuration: { minutes: 0 }, maxDuration: { minutes: 601 } } },
-          },
-        ],
-      },
-      progress: {
-        eLearning: 1,
-        live: 1,
-        presence: { attendanceDuration: { minutes: 0 }, maxDuration: { minutes: 601 } },
-      },
-    });
-    sinon.assert.calledWithExactly(getProgress.getCall(0), course.subProgram.steps[0], []);
-    sinon.assert.calledWithExactly(getProgress.getCall(1), course.subProgram.steps[1], course.slots);
-    sinon.assert.calledWithExactly(getCourseProgress.getCall(0), [
-      { ...course.subProgram.steps[0], slots: [], progress: { eLearning: 1 } },
-      {
-        ...course.subProgram.steps[1],
-        slots: course.slots,
-        progress: { live: 1, presence: { attendanceDuration: { minutes: 0 }, maxDuration: { minutes: 601 } } },
-      },
-    ]);
-  });
-
-  it('should format course (without canAccessCompletionCertificate)', async () => {
+  it('should format course', async () => {
     const stepId = new ObjectId();
     const course = {
       misc: 'name',
@@ -1474,7 +1404,7 @@ describe('getTraineeCourse', () => {
       ]
     );
 
-    sinon.assert.calledWithExactly(formatCourseWithProgress, course, 0);
+    sinon.assert.calledWithExactly(formatCourseWithProgress, { ...course, canAccessCompletionCertificate: false });
     sinon.assert.calledOnceWithExactly(attendanceCountDocuments, { courseSlot: lastSlotId });
   });
 });

--- a/tests/unit/helpers/courses.test.js
+++ b/tests/unit/helpers/courses.test.js
@@ -1253,12 +1253,11 @@ describe('getTraineeCourse', () => {
     attendanceCountDocuments.restore();
   });
 
-  it('should return courses', async () => {
-    const stepId = new ObjectId();
-    const lastSlotId = new ObjectId();
+  it('should return elearning course', async () => {
     const course = {
       _id: new ObjectId(),
       subProgram: {
+        isStrictlyELearning: true,
         steps: [{
           _id: new ObjectId(),
           activities: [{ activityHistories: [{}, {}] }],
@@ -1267,41 +1266,15 @@ describe('getTraineeCourse', () => {
           areActivitiesValid: false,
           theoreticalHours: 0.5,
         },
-        {
-          _id: stepId,
-          activities: [],
-          name: 'Développer des équipes agiles et autonomes',
-          type: 'on_site',
-          areActivitiesValid: true,
-          theoreticalHours: 3.5,
-        },
         ],
       },
-      slots: [
-        {
-          _id: new ObjectId(),
-          startDate: '2020-11-03T09:00:00.000Z',
-          endDate: '2020-11-03T12:00:00.000Z',
-          step: stepId,
-          attendances: [{ _id: new ObjectId() }],
-        },
-        {
-          _id: lastSlotId,
-          startDate: '2020-11-04T09:00:00.000Z',
-          endDate: '2020-11-04T16:01:00.000Z',
-          step: stepId,
-          attendances: [],
-        },
-      ],
     };
     const credentials = { _id: new ObjectId() };
 
     courseFindOne.returns(SinonMongoose.stubChainedQueries(course, ['populate', 'select', 'lean']));
-    attendanceCountDocuments.returns(0);
 
     formatCourseWithProgress.returns({
       ...course,
-      canAccessCompletionCertificate: false,
       subProgram: {
         ...course.subProgram,
         steps: [
@@ -1325,7 +1298,6 @@ describe('getTraineeCourse', () => {
     const result = await CourseHelper.getTraineeCourse(course._id, credentials);
     expect(result).toMatchObject({
       ...course,
-      canAccessCompletionCertificate: false,
       subProgram: {
         ...course.subProgram,
         steps: [
@@ -1404,7 +1376,163 @@ describe('getTraineeCourse', () => {
       ]
     );
 
-    sinon.assert.calledWithExactly(formatCourseWithProgress, { ...course, canAccessCompletionCertificate: false });
+    sinon.assert.calledWithExactly(formatCourseWithProgress, course);
+    sinon.assert.notCalled(attendanceCountDocuments);
+  });
+
+  it('should return blended course', async () => {
+    const stepId = new ObjectId();
+    const lastSlotId = new ObjectId();
+    const course = {
+      _id: new ObjectId(),
+      subProgram: {
+        isStrictlyELearning: false,
+        steps: [{
+          _id: new ObjectId(),
+          activities: [{ activityHistories: [{}, {}] }],
+          name: 'Développement personnel full stack',
+          type: 'e_learning',
+          areActivitiesValid: false,
+          theoreticalHours: 0.5,
+        },
+        {
+          _id: stepId,
+          activities: [],
+          name: 'Développer des équipes agiles et autonomes',
+          type: 'on_site',
+          areActivitiesValid: true,
+          theoreticalHours: 3.5,
+        },
+        ],
+      },
+      slots: [
+        {
+          _id: new ObjectId(),
+          startDate: '2020-11-03T09:00:00.000Z',
+          endDate: '2020-11-03T12:00:00.000Z',
+          step: stepId,
+          attendances: [{ _id: new ObjectId() }],
+        },
+        {
+          _id: lastSlotId,
+          startDate: '2020-11-04T09:00:00.000Z',
+          endDate: '2020-11-04T16:01:00.000Z',
+          step: stepId,
+          attendances: [],
+        },
+      ],
+    };
+    const credentials = { _id: new ObjectId() };
+
+    courseFindOne.returns(SinonMongoose.stubChainedQueries(course, ['populate', 'select', 'lean']));
+    attendanceCountDocuments.returns(0);
+
+    formatCourseWithProgress.returns({
+      ...course,
+      areLastSlotAttendancesValidated: false,
+      subProgram: {
+        ...course.subProgram,
+        steps: [
+          { ...course.subProgram.steps[0], progress: { eLearning: 1 } },
+          {
+            ...course.subProgram.steps[1],
+            progress: {
+              live: 1,
+              presence: { attendanceDuration: { minutes: 180 }, maxDuration: { minutes: 601 } },
+            },
+          },
+        ],
+      },
+      progress: {
+        eLearning: 1,
+        live: 1,
+        presence: { attendanceDuration: { minutes: 180 }, maxDuration: { minutes: 601 } },
+      },
+    });
+
+    const result = await CourseHelper.getTraineeCourse(course._id, credentials);
+    expect(result).toMatchObject({
+      ...course,
+      areLastSlotAttendancesValidated: false,
+      subProgram: {
+        ...course.subProgram,
+        steps: [
+          { ...course.subProgram.steps[0], progress: { eLearning: 1 } },
+          {
+            ...course.subProgram.steps[1],
+            progress: {
+              live: 1,
+              presence: { attendanceDuration: { minutes: 180 }, maxDuration: { minutes: 601 } },
+            },
+          },
+        ],
+      },
+      progress: {
+        eLearning: 1,
+        live: 1,
+        presence: { attendanceDuration: { minutes: 180 }, maxDuration: { minutes: 601 } },
+      },
+    });
+
+    SinonMongoose.calledOnceWithExactly(
+      courseFindOne,
+      [
+        { query: 'findOne', args: [{ _id: course._id }] },
+        {
+          query: 'populate',
+          args: [{
+            path: 'subProgram',
+            select: 'program steps',
+            populate: [
+              { path: 'program', select: 'name image description learningGoals' },
+              {
+                path: 'steps',
+                select: 'name type activities theoreticalHours',
+                populate: {
+                  path: 'activities',
+                  select: 'name type cards activityHistories',
+                  populate: [
+                    { path: 'activityHistories', match: { user: credentials._id } },
+                    { path: 'cards', select: 'template' },
+                  ],
+                },
+              },
+            ],
+          }],
+        },
+        {
+          query: 'populate',
+          args: [
+            {
+              path: 'slots',
+              select: 'startDate endDate step address meetingLink',
+              populate: [
+                { path: 'step', select: 'type' },
+                { path: 'attendances', match: { trainee: credentials._id } },
+              ],
+            },
+          ],
+        },
+        {
+          query: 'populate',
+          args: [{
+            path: 'trainer',
+            select: 'identity.firstname identity.lastname biography picture',
+          }],
+        },
+        {
+          query: 'populate',
+          args: [{
+            path: 'contact',
+            select: 'identity.firstname identity.lastname contact.phone local.email',
+          }],
+        },
+        { query: 'select', args: ['_id misc'] },
+        { query: 'lean', args: [{ virtuals: true, autopopulate: true }] },
+      ]
+    );
+
+    sinon.assert.calledWithExactly(formatCourseWithProgress, { ...course, areLastSlotAttendancesValidated: false });
     sinon.assert.calledOnceWithExactly(attendanceCountDocuments, { courseSlot: lastSlotId });
   });
 });


### PR DESCRIPTION
<details open><summary> TESTS  :computer: </summary>

- [x] J'ai codé les tests unitaires
- [ ] J'ai codé les tests d'intégration -np
- [x] C'est une ancienne route utilisée par les apps mobiles.
  - [ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens : on envoie un nouveau paramètre qui ne pose pas de problème s'il n'est pas géré
</details>

- [ ] Je replie cette section car mes modifications n'ont pas besoin de tests unitaires ou d'intégration

---

<details open><summary> POINTS D'ATTENTION POUR CETTE PR  :warning: </summary>

- [x] J'ai fait des modifications sur une route utilisée sur plusieurs plateformes [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/n3bq2hr9Ia)
- [ ] ~~J'ai modifié un modèle utilisé en mobile [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/rqTfwpUib)~~
- [ ] ~~J'ai ajouté un modèle spécifique à une structure~~
  - [ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés
- [ ] ~~J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile~~
  - [ ] Si oui, j'ai précisé sur le [slite de MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) qu'il faut forcer la mise à jour
- [ ] ~~J'ai ajouté une variable d'environnement~~
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

</details>

- [ ] Je replie cette section car je n'ai pas fait de modifications entrainant un point d'attention

---

<details open><summary> FONCTIONNALITÉS APPS MOBILES  :iphone: </summary>

- [x] Mes changements impactent l'application formation
  - [x] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours
- [ ] ~~Mes changements impactent l'application erp~~
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours

</details>

- [ ] Je replie cette section car mes modifications n'ont pas d'impact sur les applications mobiles

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : mobile / vendeur  tous/rof/admin

- Cas d'usage : je ne vois le bouton de téléchargement que si le dernier créneau a été émargé pour un stagiaire

- Comment tester ? :
  - côté mobile :
    - sur le profil : le nombre de formation s'affiche bien
    - sur la liste des formation : tout s'affiche bien  
    - sur une formation elearning : je ne vois pas le bouton de téléchargement
    - sur une formation mixte en cours ou sans émargement sur le dernier créneau : je ne vois pas le bouton de téléchargement
    - sur une formation mixte dont le dernier créneau a été émargé (peu importe que ça soit le stagiaire concerné ou non) : je vois le bouton de téléchargement d'attestation
  - côté vendeur :  sur la liste des formations sur le profil d'un stagiaire tout s'affiche correctement

_Si tu as lu cette description, pense a réagir avec un :eye:_
