### PR TITLE
Com 2759

### DIFF
--- a/src/helpers/dates/companiDates.js
+++ b/src/helpers/dates/companiDates.js
@@ -50,7 +50,7 @@ const CompaniDateFactory = (inputDate) => {
       return _date > otherDate;
     },
 
-    isSame(miscTypeOtherDate, unit) {
+    isSame(miscTypeOtherDate, unit = 'millisecond') {
       const otherDate = exports._formatMiscToCompaniDate(miscTypeOtherDate);
 
       return _date.hasSame(otherDate, unit);

--- a/src/helpers/eventHistories.js
+++ b/src/helpers/eventHistories.js
@@ -1,4 +1,3 @@
-const moment = require('moment');
 const get = require('lodash/get');
 const has = require('lodash/has');
 const pickBy = require('lodash/pickBy');
@@ -16,6 +15,7 @@ const {
 } = require('./constants');
 const UtilsHelper = require('./utils');
 const EventHistoryRepository = require('../repositories/EventHistoryRepository');
+const { CompaniDate } = require('./dates/companiDates');
 
 exports.list = async (query, credentials) => {
   if (query.eventId) {
@@ -89,17 +89,17 @@ exports.createEventHistoryOnCreate = async (payload, credentials) =>
 exports.createEventHistoryOnDelete = async (payload, credentials) =>
   exports.createEventHistory(payload, credentials, EVENT_DELETION);
 
-const areDaysChanged = (event, payload) => !moment(event.startDate).isSame(payload.startDate, 'day') ||
-  !moment(event.endDate).isSame(payload.endDate, 'day');
+const areDaysChanged = (event, payload) => !CompaniDate(event.startDate).isSame(payload.startDate, 'day') ||
+  !CompaniDate(event.endDate).isSame(payload.endDate, 'day');
 
 const isAuxiliaryUpdated = (event, payload) => (!event.auxiliary && payload.auxiliary) ||
   (event.auxiliary && !UtilsHelper.areObjectIdsEquals(event.auxiliary, payload.auxiliary));
 
 const areHoursChanged = (event, payload) => {
-  const eventStartHour = moment(event.startDate).format('HH:mm');
-  const eventEndHour = moment(event.endDate).format('HH:mm');
-  const payloadStartHour = moment(payload.startDate).format('HH:mm');
-  const payloadEndHour = moment(payload.endDate).format('HH:mm');
+  const eventStartHour = CompaniDate(event.startDate).format('HH:mm');
+  const eventEndHour = CompaniDate(event.endDate).format('HH:mm');
+  const payloadStartHour = CompaniDate(payload.startDate).format('HH:mm');
+  const payloadEndHour = CompaniDate(payload.endDate).format('HH:mm');
 
   return eventStartHour !== payloadStartHour || eventEndHour !== payloadEndHour;
 };
@@ -181,8 +181,8 @@ exports.formatHistoryForAuxiliaryUpdate = async (mainInfo, payload, event, compa
   return { ...mainInfo, sectors, auxiliaries, update };
 };
 
-const isOneDayEvent = (event, payload) => moment(event.endDate).isSame(event.startDate, 'day') &&
-  moment(payload.endDate).isSame(payload.startDate, 'day');
+const isOneDayEvent = (event, payload) => CompaniDate(event.endDate).isSame(event.startDate, 'day') &&
+  CompaniDate(payload.endDate).isSame(payload.startDate, 'day');
 
 exports.formatHistoryForDatesUpdate = async (mainInfo, payload, event, companyId) => {
   const datesUpdateHistory = {

--- a/src/helpers/events.js
+++ b/src/helpers/events.js
@@ -257,10 +257,8 @@ exports.shouldDetachFromRepetition = (event, payload) => {
  * 2. if the event is cancelled and the payload doesn't contain any cancellation info, it means we should remove the
  * cancellation i.e. delete the cancel object and set isCancelled to false.
  */
-const isOnSameDay = event => moment(event.startDate).isSame(event.endDate, 'day');
-
 exports.updateEvent = async (event, eventPayload, credentials) => {
-  if (event.type !== ABSENCE && !isOnSameDay(eventPayload)) {
+  if (event.type !== ABSENCE && !CompaniDate(eventPayload.startDate).isSame(eventPayload.endDate, 'day')) {
     throw Boom.badRequest(translate[language].eventDatesNotOnSameDay);
   }
 

--- a/src/helpers/events.js
+++ b/src/helpers/events.js
@@ -389,7 +389,7 @@ exports.deleteCustomerEvents = async (customer, startDate, endDate, absenceType,
 };
 
 exports.updateAbsencesOnContractEnd = async (auxiliaryId, contractEndDate, credentials) => {
-  const maxEndDate = moment(contractEndDate).hour(PLANNING_VIEW_END_HOUR).startOf('h');
+  const maxEndDate = CompaniDate(contractEndDate).set({ hour: PLANNING_VIEW_END_HOUR }).startOf('hour').toISO();
   const absences = await EventRepository.getAbsences(auxiliaryId, maxEndDate, get(credentials, 'company._id', null));
   const absencesIds = absences.map(abs => abs._id);
   const promises = [];

--- a/src/helpers/eventsValidation.js
+++ b/src/helpers/eventsValidation.js
@@ -1,8 +1,6 @@
 const Boom = require('@hapi/boom');
-const moment = require('moment');
 const omit = require('lodash/omit');
 const get = require('lodash/get');
-const momentRange = require('moment-range');
 const {
   INTERVENTION,
   ABSENCE,
@@ -18,11 +16,9 @@ const CustomerAbsencesHelper = require('./customerAbsences');
 const EventRepository = require('../repositories/EventRepository');
 const UtilsHelper = require('./utils');
 const translate = require('./translate');
-const DatesHelper = require('./dates');
+const { CompaniDate } = require('./dates/companiDates');
 
 const { language } = translate;
-
-momentRange.extendMoment(moment);
 
 exports.isCustomerSubscriptionValid = async (event) => {
   const customer = await Customer.countDocuments({
@@ -56,7 +52,7 @@ exports.hasConflicts = async (event) => {
   });
 };
 
-const isOneDayEvent = event => moment(event.startDate).isSame(event.endDate, 'day');
+const isOneDayEvent = event => CompaniDate(event.startDate).isSame(event.endDate, 'day');
 
 const isAuxiliaryUpdated = (payload, eventFromDB) => payload.auxiliary &&
   payload.auxiliary !== eventFromDB.auxiliary.toHexString();
@@ -91,8 +87,8 @@ exports.isCreationAllowed = async (event, credentials) => {
 };
 
 exports.isUpdateAllowed = async (eventFromDB, payload, credentials) => {
-  const updateStartDate = payload.startDate && !!DatesHelper.diff(eventFromDB.startDate, payload.startDate);
-  const updateEndDate = payload.endDate && !!DatesHelper.diff(eventFromDB.endDate, payload.endDate);
+  const updateStartDate = payload.startDate && !CompaniDate(eventFromDB.startDate).isSame(payload.startDate);
+  const updateEndDate = payload.endDate && !CompaniDate(eventFromDB.endDate).isSame(payload.endDate);
   const updateAuxiliary = payload.auxiliary &&
     !UtilsHelper.areObjectIdsEquals(eventFromDB.auxiliary, payload.auxiliary);
   const cancelEvent = payload.isCancelled;

--- a/src/routes/events.js
+++ b/src/routes/events.js
@@ -54,8 +54,7 @@ const {
   monthValidation,
   addressValidation,
   objectIdOrArray,
-  dateToISOString,
-
+  requiredDateToISOString,
 } = require('./validations/utils');
 
 exports.plugin = {
@@ -177,8 +176,8 @@ exports.plugin = {
         validate: {
           params: Joi.object({ _id: Joi.objectId().required() }),
           payload: Joi.object().keys({
-            startDate: dateToISOString,
-            endDate: dateToISOString,
+            startDate: requiredDateToISOString,
+            endDate: requiredDateToISOString,
             auxiliary: Joi.objectId(),
             sector: Joi.string(),
             address: Joi.when(
@@ -220,7 +219,6 @@ exports.plugin = {
             transportMode: Joi.string().valid(...EVENT_TRANSPORT_MODE),
             kmDuringEvent: Joi.number().min(0),
           })
-            .and('startDate', 'endDate')
             .assert(
               '.endDate',
               Joi.date().greater(Joi.ref('startDate')),

--- a/tests/integration/events.test.js
+++ b/tests/integration/events.test.js
@@ -1385,6 +1385,22 @@ describe('PUT /events/{_id}', () => {
       expect(response.result.data.event.address).toBeUndefined();
     });
 
+    it('should return a 400 if no startDate and endDate', async () => {
+      const event = eventsList[0];
+      const payload = {
+        auxiliary: event.auxiliary.toHexString(),
+      };
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/events/${event._id.toHexString()}`,
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
     it('should return a 400 if event is not an internal hours and adress is {}', async () => {
       const event = eventsList[2];
       const payload = {

--- a/tests/integration/events.test.js
+++ b/tests/integration/events.test.js
@@ -1367,7 +1367,12 @@ describe('PUT /events/{_id}', () => {
 
     it('should update internalhour if address is {}', async () => {
       const event = eventsList[0];
-      const payload = { auxiliary: event.auxiliary.toHexString(), address: {} };
+      const payload = {
+        auxiliary: event.auxiliary.toHexString(),
+        address: {},
+        startDate: '2019-01-17T10:30:18.653Z',
+        endDate: '2019-01-17T12:00:18.653Z',
+      };
 
       const response = await app.inject({
         method: 'PUT',
@@ -1382,7 +1387,11 @@ describe('PUT /events/{_id}', () => {
 
     it('should return a 400 if event is not an internal hours and adress is {}', async () => {
       const event = eventsList[2];
-      const payload = { address: {} };
+      const payload = {
+        address: {},
+        startDate: '2019-01-16T09:30:19.543Z',
+        endDate: '2019-01-16T11:30:21.653Z',
+      };
 
       const response = await app.inject({
         method: 'PUT',
@@ -1475,6 +1484,8 @@ describe('PUT /events/{_id}', () => {
       const payload = {
         sector: sectors[0]._id.toHexString(),
         subscription: customerFromOtherCompany.subscriptions[0]._id.toHexString(),
+        startDate: '2019-01-17T10:30:18.653Z',
+        endDate: '2019-01-17T12:00:18.653Z',
       };
 
       const response = await app.inject({
@@ -1492,6 +1503,8 @@ describe('PUT /events/{_id}', () => {
       const payload = {
         sector: sectors[0]._id.toHexString(),
         auxiliary: auxiliaryFromOtherCompany._id.toHexString(),
+        startDate: '2019-01-17T10:30:18.653Z',
+        endDate: '2019-01-17T12:00:18.653Z',
       };
 
       const response = await app.inject({
@@ -1506,7 +1519,11 @@ describe('PUT /events/{_id}', () => {
 
     it('should return a 400 if both auxiliary sector and auxiliary are missing', async () => {
       const event = eventsList[0];
-      const payload = { subscription: customerFromOtherCompany.subscriptions[0]._id.toHexString() };
+      const payload = {
+        subscription: customerFromOtherCompany.subscriptions[0]._id.toHexString(),
+        startDate: '2019-01-17T10:30:18.653Z',
+        endDate: '2019-01-17T12:00:18.653Z',
+      };
 
       const response = await app.inject({
         method: 'PUT',
@@ -1523,6 +1540,8 @@ describe('PUT /events/{_id}', () => {
       const payload = {
         sector: sectors[0]._id.toHexString(),
         internalHour: internalHourFromOtherCompany._id,
+        startDate: '2019-01-17T10:30:18.653Z',
+        endDate: '2019-01-17T12:00:18.653Z',
       };
 
       const response = await app.inject({
@@ -1539,6 +1558,8 @@ describe('PUT /events/{_id}', () => {
       const event = eventsList[0];
       const payload = {
         sector: sectors[2]._id.toHexString(),
+        startDate: '2019-01-17T10:30:18.653Z',
+        endDate: '2019-01-17T12:00:18.653Z',
       };
 
       const response = await app.inject({
@@ -1605,7 +1626,11 @@ describe('PUT /events/{_id}', () => {
     });
 
     it('should return a 422 event is startDate timeStamped and user tries to update auxiliary', async () => {
-      const payload = { auxiliary: auxiliaries[1]._id };
+      const payload = {
+        auxiliary: auxiliaries[1]._id,
+        startDate: '2019-01-17T10:30:18.653Z',
+        endDate: '2019-01-17T12:00:18.653Z',
+      };
 
       const response = await app.inject({
         method: 'PUT',
@@ -1623,6 +1648,8 @@ describe('PUT /events/{_id}', () => {
         isCancelled: true,
         cancel: { condition: INVOICED_AND_PAID, reason: AUXILIARY_INITIATIVE },
         misc: 'blablabla',
+        startDate: '2019-01-17T10:30:18.653Z',
+        endDate: '2019-01-17T12:00:18.653Z',
       };
 
       const response = await app.inject({
@@ -1653,7 +1680,11 @@ describe('PUT /events/{_id}', () => {
     });
 
     it('should return a 422 event is endDate timeStamped and user tries to update auxiliary', async () => {
-      const payload = { auxiliary: auxiliaries[1]._id };
+      const payload = {
+        auxiliary: auxiliaries[1]._id,
+        startDate: '2019-01-17T10:30:18.653Z',
+        endDate: '2019-01-17T12:00:18.653Z',
+      };
 
       const response = await app.inject({
         method: 'PUT',
@@ -1671,6 +1702,8 @@ describe('PUT /events/{_id}', () => {
         isCancelled: true,
         cancel: { condition: INVOICED_AND_PAID, reason: AUXILIARY_INITIATIVE },
         misc: 'blablabla',
+        startDate: '2019-01-17T10:30:18.653Z',
+        endDate: '2019-01-17T12:00:18.653Z',
       };
 
       const response = await app.inject({

--- a/tests/unit/helpers/dates/companiDates.test.js
+++ b/tests/unit/helpers/dates/companiDates.test.js
@@ -215,8 +215,7 @@ describe('QUERY', () => {
 
   describe('isSame', () => {
     let _formatMiscToCompaniDate;
-    const companiDate = CompaniDatesHelper.CompaniDate('2021-11-24T07:00:00.000Z');
-    const otherDate = '2021-11-24T10:00:00.000Z';
+    const companiDate = CompaniDatesHelper.CompaniDate('2021-11-24T07:04:00.000Z');
 
     beforeEach(() => {
       _formatMiscToCompaniDate = sinon.spy(CompaniDatesHelper, '_formatMiscToCompaniDate');
@@ -226,14 +225,24 @@ describe('QUERY', () => {
       _formatMiscToCompaniDate.restore();
     });
 
-    it('should return true if same day', () => {
+    it('should return true if otherDate is happening the same day', () => {
+      const otherDate = '2021-11-24T00:00:00.000Z';
       const result = companiDate.isSame(otherDate, 'day');
 
       expect(result).toBe(true);
       sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, otherDate);
     });
 
-    it('should return false if different minute', () => {
+    it('should return true, default unit is milis and otherDate is happening during the same milis', () => {
+      const otherDate = '2021-11-24T07:04:00.000Z';
+      const result = companiDate.isSame(otherDate);
+
+      expect(result).toBe(true);
+      sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, otherDate);
+    });
+
+    it('should return false, even if otherDate has same minute value: 4, it is happening 180 minutes after', () => {
+      const otherDate = '2021-11-24T10:04:00.000Z';
       const result = companiDate.isSame(otherDate, 'minute');
 
       expect(result).toBe(false);
@@ -251,6 +260,7 @@ describe('QUERY', () => {
     });
 
     it('should return error if unit is plural', () => {
+      const otherDate = '2021-11-24T10:04:00.000Z';
       try {
         companiDate.isSame(otherDate, 'days');
       } catch (e) {

--- a/tests/unit/helpers/eventHistories.test.js
+++ b/tests/unit/helpers/eventHistories.test.js
@@ -24,12 +24,12 @@ describe('list', () => {
   });
 
   it('should get event histories', async () => {
-    const query = { createdAt: '2019-11-10' };
+    const query = { createdAt: '2019-11-10T09:00:00.000Z' };
     const credentials = { company: { _id: new ObjectId() } };
     const listQuery = {
       $and: [
         { company: credentials.company._id },
-        { $or: [{ createdAt: { $lte: '2019-11-10' } }] },
+        { $or: [{ createdAt: { $lte: '2019-11-10T09:00:00.000Z' } }] },
       ],
     };
     getListQueryStub.returns(listQuery);
@@ -106,10 +106,10 @@ describe('getListQuery', () => {
   it('should format query with createdAt', () => {
     const companyId = new ObjectId();
     const credentials = { company: { _id: companyId } };
-    const query = { createdAt: '2019-10-11' };
+    const query = { createdAt: '2019-10-11T09:00:00.000Z' };
     const result = EventHistoryHelper.getListQuery(query, credentials);
 
-    expect(result).toEqual({ company: companyId, createdAt: { $lt: '2019-10-11' } });
+    expect(result).toEqual({ company: companyId, createdAt: { $lt: '2019-10-11T09:00:00.000Z' } });
   });
 
   it('should format query with action', () => {
@@ -124,14 +124,14 @@ describe('getListQuery', () => {
   it('should format query with sectors and auxiliaries and createdAt', () => {
     const companyId = new ObjectId();
     const credentials = { company: { _id: companyId } };
-    const query = { sectors: ['toto', 'tata'], auxiliaries: ['toto', 'tata'], createdAt: '2019-10-11' };
+    const query = { sectors: ['toto', 'tata'], auxiliaries: ['toto', 'tata'], createdAt: '2019-10-11T09:00:00.000Z' };
     formatArrayOrStringQueryParam.onCall(0).returns([{ sectors: 'toto' }, { sectors: 'tata' }]);
     formatArrayOrStringQueryParam.onCall(1).returns([{ auxiliaries: 'toto' }, { auxiliaries: 'tata' }]);
     const result = EventHistoryHelper.getListQuery(query, credentials);
 
     expect(result).toEqual({
       company: companyId,
-      createdAt: { $lt: '2019-10-11' },
+      createdAt: { $lt: '2019-10-11T09:00:00.000Z' },
       $or: [{ sectors: 'toto' }, { sectors: 'tata' }, { auxiliaries: 'toto' }, { auxiliaries: 'tata' }],
     });
   });
@@ -241,7 +241,7 @@ describe('createEventHistoryOnDelete', () => {
   });
 });
 
-describe('createEventHistoryOnUpdate', () => {
+describe('createEventHistoryOnUpdate #tag', () => {
   const customerId = new ObjectId();
   let formatHistoryForAuxiliaryUpdate;
   let formatHistoryForDatesUpdate;
@@ -265,15 +265,15 @@ describe('createEventHistoryOnUpdate', () => {
 
   it('should call formatHistoryForAuxiliaryUpdate', async () => {
     const payload = {
-      startDate: '2019-01-21T09:38:18',
-      endDate: '2019-01-22T09:38:18',
+      startDate: '2019-01-21T09:38:18.000Z',
+      endDate: '2019-01-22T09:38:18.000Z',
       misc: 'Toto',
     };
     const event = {
       _id: new ObjectId(),
       auxiliary: new ObjectId(),
-      startDate: '2019-01-21T09:38:18',
-      endDate: '2019-01-22T09:38:18',
+      startDate: '2019-01-21T09:38:18.000Z',
+      endDate: '2019-01-22T09:38:18.000Z',
       customer: customerId,
       type: 'intervention',
     };
@@ -290,8 +290,8 @@ describe('createEventHistoryOnUpdate', () => {
         event: {
           eventId: event._id,
           type: 'intervention',
-          startDate: '2019-01-21T09:38:18',
-          endDate: '2019-01-22T09:38:18',
+          startDate: '2019-01-21T09:38:18.000Z',
+          endDate: '2019-01-22T09:38:18.000Z',
           customer: customerId,
           misc: 'Toto',
         },
@@ -308,14 +308,14 @@ describe('createEventHistoryOnUpdate', () => {
 
   it('should call formatHistoryForDatesUpdate', async () => {
     const payload = {
-      startDate: '2019-01-21T09:38:18',
-      endDate: '2019-01-21T11:38:18',
+      startDate: '2019-01-21T09:38:18.000Z',
+      endDate: '2019-01-21T11:38:18.000Z',
       misc: 'Toto',
     };
     const event = {
       _id: new ObjectId(),
-      startDate: '2019-01-22T09:38:18',
-      endDate: '2019-01-22T09:38:18',
+      startDate: '2019-01-22T09:38:18.000Z',
+      endDate: '2019-01-22T09:38:18.000Z',
       customer: customerId,
       type: 'intervention',
     };
@@ -332,8 +332,8 @@ describe('createEventHistoryOnUpdate', () => {
         event: {
           eventId: event._id,
           type: 'intervention',
-          startDate: '2019-01-21T09:38:18',
-          endDate: '2019-01-21T11:38:18',
+          startDate: '2019-01-21T09:38:18.000Z',
+          endDate: '2019-01-21T11:38:18.000Z',
           customer: customerId,
           misc: 'Toto',
         },
@@ -350,16 +350,16 @@ describe('createEventHistoryOnUpdate', () => {
 
   it('should call formatHistoryForCancelUpdate', async () => {
     const payload = {
-      startDate: '2019-01-21T09:38:18',
-      endDate: '2019-01-21T11:38:18',
+      startDate: '2019-01-21T09:38:18.000Z',
+      endDate: '2019-01-21T11:38:18.000Z',
       misc: 'Toto',
       isCancelled: true,
       cancel: { reason: 'toto', condition: 'payé' },
     };
     const event = {
       _id: new ObjectId(),
-      startDate: '2019-01-21T09:38:18',
-      endDate: '2019-01-21T11:38:18',
+      startDate: '2019-01-21T09:38:18.000Z',
+      endDate: '2019-01-21T11:38:18.000Z',
       customer: customerId,
       type: 'intervention',
     };
@@ -376,8 +376,8 @@ describe('createEventHistoryOnUpdate', () => {
         event: {
           eventId: event._id,
           type: 'intervention',
-          startDate: '2019-01-21T09:38:18',
-          endDate: '2019-01-21T11:38:18',
+          startDate: '2019-01-21T09:38:18.000Z',
+          endDate: '2019-01-21T11:38:18.000Z',
           customer: customerId,
           misc: 'Toto',
         },
@@ -393,14 +393,14 @@ describe('createEventHistoryOnUpdate', () => {
 
   it('should call formatHistoryForHoursUpdate', async () => {
     const payload = {
-      startDate: '2019-01-21T09:38:18',
-      endDate: '2019-01-21T11:38:18',
+      startDate: '2019-01-21T09:38:18.000Z',
+      endDate: '2019-01-21T11:38:18.000Z',
       misc: 'Toto',
     };
     const event = {
       _id: new ObjectId(),
-      startDate: '2019-01-21T10:38:18',
-      endDate: '2019-01-21T11:38:18',
+      startDate: '2019-01-21T10:38:18.000Z',
+      endDate: '2019-01-21T11:38:18.000Z',
       customer: customerId,
       type: 'intervention',
     };
@@ -417,8 +417,8 @@ describe('createEventHistoryOnUpdate', () => {
         event: {
           eventId: event._id,
           type: 'intervention',
-          startDate: '2019-01-21T09:38:18',
-          endDate: '2019-01-21T11:38:18',
+          startDate: '2019-01-21T09:38:18.000Z',
+          endDate: '2019-01-21T11:38:18.000Z',
           customer: customerId,
           misc: 'Toto',
         },
@@ -435,16 +435,16 @@ describe('createEventHistoryOnUpdate', () => {
 
   it('should call formatHistoryForDatesUpdate and formatHistoryForCancelUpdate', async () => {
     const payload = {
-      startDate: '2019-01-20T09:38:18',
-      endDate: '2019-01-21T11:38:18',
+      startDate: '2019-01-20T09:38:18.000Z',
+      endDate: '2019-01-21T11:38:18.000Z',
       misc: 'Toto',
       isCancelled: true,
       cancel: { reason: 'toto', condition: 'payé' },
     };
     const event = {
       _id: new ObjectId(),
-      startDate: '2019-01-21T09:38:18',
-      endDate: '2019-01-21T11:38:18',
+      startDate: '2019-01-21T09:38:18.000Z',
+      endDate: '2019-01-21T11:38:18.000Z',
       customer: customerId,
       type: 'intervention',
     };
@@ -461,8 +461,8 @@ describe('createEventHistoryOnUpdate', () => {
         event: {
           eventId: event._id,
           type: 'intervention',
-          startDate: '2019-01-20T09:38:18',
-          endDate: '2019-01-21T11:38:18',
+          startDate: '2019-01-20T09:38:18.000Z',
+          endDate: '2019-01-21T11:38:18.000Z',
           customer: customerId,
           misc: 'Toto',
         },
@@ -481,8 +481,8 @@ describe('createEventHistoryOnUpdate', () => {
         event: {
           eventId: event._id,
           type: 'intervention',
-          startDate: '2019-01-20T09:38:18',
-          endDate: '2019-01-21T11:38:18',
+          startDate: '2019-01-20T09:38:18.000Z',
+          endDate: '2019-01-21T11:38:18.000Z',
           customer: customerId,
           misc: 'Toto',
         },
@@ -496,16 +496,16 @@ describe('createEventHistoryOnUpdate', () => {
 
   it('should add repetition when repetition is updated', async () => {
     const payload = {
-      startDate: '2019-01-21T09:38:18',
-      endDate: '2019-01-22T09:38:18',
+      startDate: '2019-01-21T09:38:18.000Z',
+      endDate: '2019-01-22T09:38:18.000Z',
       misc: 'Toto',
       shouldUpdateRepetition: true,
     };
     const event = {
       _id: new ObjectId(),
       auxiliary: new ObjectId(),
-      startDate: '2019-01-21T09:38:18',
-      endDate: '2019-01-22T09:38:18',
+      startDate: '2019-01-21T09:38:18.000Z',
+      endDate: '2019-01-22T09:38:18.000Z',
       customer: customerId,
       type: 'intervention',
       repetition: { frequency: 'every_two_weeks' },
@@ -523,8 +523,8 @@ describe('createEventHistoryOnUpdate', () => {
         event: {
           eventId: event._id,
           type: 'intervention',
-          startDate: '2019-01-21T09:38:18',
-          endDate: '2019-01-22T09:38:18',
+          startDate: '2019-01-21T09:38:18.000Z',
+          endDate: '2019-01-22T09:38:18.000Z',
           customer: customerId,
           misc: 'Toto',
           repetition: { frequency: 'every_two_weeks' },
@@ -542,15 +542,15 @@ describe('createEventHistoryOnUpdate', () => {
 
   it('should add internal hour type for internal hour event', async () => {
     const payload = {
-      startDate: '2019-01-21T09:38:18',
-      endDate: '2019-01-22T09:38:18',
+      startDate: '2019-01-21T09:38:18.000Z',
+      endDate: '2019-01-22T09:38:18.000Z',
       misc: 'Toto',
     };
     const event = {
       _id: new ObjectId(),
       auxiliary: new ObjectId(),
-      startDate: '2019-01-21T09:38:18',
-      endDate: '2019-01-22T09:38:18',
+      startDate: '2019-01-21T09:38:18.000Z',
+      endDate: '2019-01-22T09:38:18.000Z',
       customer: customerId,
       type: INTERNAL_HOUR,
       internalHour: { name: 'meeting' },
@@ -568,8 +568,8 @@ describe('createEventHistoryOnUpdate', () => {
         event: {
           eventId: event._id,
           type: INTERNAL_HOUR,
-          startDate: '2019-01-21T09:38:18',
-          endDate: '2019-01-22T09:38:18',
+          startDate: '2019-01-21T09:38:18.000Z',
+          endDate: '2019-01-22T09:38:18.000Z',
           customer: customerId,
           misc: 'Toto',
           internalHour: { name: 'meeting' },
@@ -587,15 +587,15 @@ describe('createEventHistoryOnUpdate', () => {
 
   it('should add absence type for absence event', async () => {
     const payload = {
-      startDate: '2019-01-21T09:38:18',
-      endDate: '2019-01-22T09:38:18',
+      startDate: '2019-01-21T09:38:18.000Z',
+      endDate: '2019-01-22T09:38:18.000Z',
       misc: 'Toto',
     };
     const event = {
       _id: new ObjectId(),
       auxiliary: new ObjectId(),
-      startDate: '2019-01-21T09:38:18',
-      endDate: '2019-01-22T09:38:18',
+      startDate: '2019-01-21T09:38:18.000Z',
+      endDate: '2019-01-22T09:38:18.000Z',
       customer: customerId,
       type: 'absence',
       absence: 'leave',
@@ -613,8 +613,8 @@ describe('createEventHistoryOnUpdate', () => {
         event: {
           eventId: event._id,
           type: 'absence',
-          startDate: '2019-01-21T09:38:18',
-          endDate: '2019-01-22T09:38:18',
+          startDate: '2019-01-21T09:38:18.000Z',
+          endDate: '2019-01-22T09:38:18.000Z',
           customer: customerId,
           misc: 'Toto',
           absence: 'leave',
@@ -832,11 +832,11 @@ describe('formatHistoryForDatesUpdate', () => {
       event: { type: 'intervention' },
     };
     const payload = {
-      startDate: '2019-01-20T09:38:18',
-      endDate: '2019-01-20T11:38:18',
+      startDate: '2019-01-20T09:38:18.000Z',
+      endDate: '2019-01-20T11:38:18.000Z',
       auxiliary: auxiliaryId.toHexString(),
     };
-    const event = { startDate: '2019-01-21T09:38:18', endDate: '2019-01-21T10:38:18' };
+    const event = { startDate: '2019-01-21T09:38:18.000Z', endDate: '2019-01-21T10:38:18.000Z' };
     findOne.returns(SinonMongoose.stubChainedQueries({ _id: auxiliaryId, sector: sectorId }));
 
     const result = await EventHistoryHelper.formatHistoryForDatesUpdate(mainInfo, payload, event, companyId);
@@ -849,7 +849,7 @@ describe('formatHistoryForDatesUpdate', () => {
       auxiliaries: [auxiliaryId.toHexString()],
       event: { type: 'intervention', auxiliary: auxiliaryId.toHexString() },
       update: {
-        startDate: { from: '2019-01-21T09:38:18', to: '2019-01-20T09:38:18' },
+        startDate: { from: '2019-01-21T09:38:18.000Z', to: '2019-01-20T09:38:18.000Z' },
       },
     });
     SinonMongoose.calledOnceWithExactly(
@@ -864,8 +864,8 @@ describe('formatHistoryForDatesUpdate', () => {
 
   it('should format event history without auxiliary', async () => {
     const mainInfo = { createdBy: 'james bond', action: 'event_update', event: { type: 'intervention' } };
-    const payload = { startDate: '2019-01-20T09:38:18', endDate: '2019-01-20T11:38:18', sector: sectorId };
-    const event = { startDate: '2019-01-21T09:38:18', endDate: '2019-01-21T10:38:18' };
+    const payload = { startDate: '2019-01-20T09:38:18.000Z', endDate: '2019-01-20T11:38:18.000Z', sector: sectorId };
+    const event = { startDate: '2019-01-21T09:38:18.000Z', endDate: '2019-01-21T10:38:18.000Z' };
 
     const result = await EventHistoryHelper.formatHistoryForDatesUpdate(mainInfo, payload, event);
 
@@ -876,7 +876,7 @@ describe('formatHistoryForDatesUpdate', () => {
       sectors: [sectorId],
       event: { type: 'intervention' },
       update: {
-        startDate: { from: '2019-01-21T09:38:18', to: '2019-01-20T09:38:18' },
+        startDate: { from: '2019-01-21T09:38:18.000Z', to: '2019-01-20T09:38:18.000Z' },
       },
     });
     sinon.assert.notCalled(findOne);
@@ -884,8 +884,8 @@ describe('formatHistoryForDatesUpdate', () => {
 
   it('should format event history with endDate and startDate', async () => {
     const mainInfo = { createdBy: 'james bond', action: 'event_update', event: { type: 'intervention' } };
-    const payload = { startDate: '2019-01-20T09:38:18', endDate: '2019-01-21T11:38:18', sector: sectorId };
-    const event = { startDate: '2019-01-21T09:38:18', endDate: '2019-01-22T10:38:18' };
+    const payload = { startDate: '2019-01-20T09:38:18.000Z', endDate: '2019-01-21T11:38:18.000Z', sector: sectorId };
+    const event = { startDate: '2019-01-21T09:38:18.000Z', endDate: '2019-01-22T10:38:18.000Z' };
 
     const result = await EventHistoryHelper.formatHistoryForDatesUpdate(mainInfo, payload, event);
 
@@ -896,8 +896,8 @@ describe('formatHistoryForDatesUpdate', () => {
       sectors: [sectorId],
       event: { type: 'intervention' },
       update: {
-        startDate: { from: '2019-01-21T09:38:18', to: '2019-01-20T09:38:18' },
-        endDate: { from: '2019-01-22T10:38:18', to: '2019-01-21T11:38:18' },
+        startDate: { from: '2019-01-21T09:38:18.000Z', to: '2019-01-20T09:38:18.000Z' },
+        endDate: { from: '2019-01-22T10:38:18.000Z', to: '2019-01-21T11:38:18.000Z' },
       },
     });
     sinon.assert.notCalled(findOne);
@@ -919,11 +919,11 @@ describe('formatHistoryForHoursUpdate', () => {
     const companyId = new ObjectId();
     const mainInfo = { createdBy: 'james bond', action: 'event_update', event: { type: 'intervention' } };
     const payload = {
-      startDate: '2019-01-21T09:38:18',
-      endDate: '2019-01-21T11:38:18',
+      startDate: '2019-01-21T09:38:18.000Z',
+      endDate: '2019-01-21T11:38:18.000Z',
       auxiliary: auxiliaryId.toHexString(),
     };
-    const event = { startDate: '2019-01-21T09:38:18', endDate: '2019-01-21T10:38:18' };
+    const event = { startDate: '2019-01-21T09:38:18.000Z', endDate: '2019-01-21T10:38:18.000Z' };
     findOne.returns(SinonMongoose.stubChainedQueries({ _id: auxiliaryId, sector: sectorId }));
 
     const result = await EventHistoryHelper.formatHistoryForHoursUpdate(mainInfo, payload, event, companyId);
@@ -939,8 +939,8 @@ describe('formatHistoryForHoursUpdate', () => {
         auxiliary: auxiliaryId.toHexString(),
       },
       update: {
-        startHour: { from: '2019-01-21T09:38:18', to: '2019-01-21T09:38:18' },
-        endHour: { from: '2019-01-21T10:38:18', to: '2019-01-21T11:38:18' },
+        startHour: { from: '2019-01-21T09:38:18.000Z', to: '2019-01-21T09:38:18.000Z' },
+        endHour: { from: '2019-01-21T10:38:18.000Z', to: '2019-01-21T11:38:18.000Z' },
       },
     });
     SinonMongoose.calledOnceWithExactly(
@@ -957,11 +957,11 @@ describe('formatHistoryForHoursUpdate', () => {
     const sectorId = new ObjectId();
     const mainInfo = { createdBy: 'james bond', action: 'event_update', event: { type: 'intervention' } };
     const payload = {
-      startDate: '2019-01-21T09:38:18',
-      endDate: '2019-01-21T11:38:18',
+      startDate: '2019-01-21T09:38:18.000Z',
+      endDate: '2019-01-21T11:38:18.000Z',
       sector: sectorId.toHexString(),
     };
-    const event = { startDate: '2019-01-21T09:38:18', endDate: '2019-01-21T10:38:18' };
+    const event = { startDate: '2019-01-21T09:38:18.000Z', endDate: '2019-01-21T10:38:18.000Z' };
 
     const result = await EventHistoryHelper.formatHistoryForHoursUpdate(mainInfo, payload, event);
 
@@ -972,8 +972,8 @@ describe('formatHistoryForHoursUpdate', () => {
       sectors: [sectorId.toHexString()],
       event: { type: 'intervention' },
       update: {
-        startHour: { from: '2019-01-21T09:38:18', to: '2019-01-21T09:38:18' },
-        endHour: { from: '2019-01-21T10:38:18', to: '2019-01-21T11:38:18' },
+        startHour: { from: '2019-01-21T09:38:18.000Z', to: '2019-01-21T09:38:18.000Z' },
+        endHour: { from: '2019-01-21T10:38:18.000Z', to: '2019-01-21T11:38:18.000Z' },
       },
     });
     sinon.assert.notCalled(findOne);
@@ -990,14 +990,14 @@ describe('createTimeStampHistory', () => {
   it('should create and event history of type timestamp for startDate', async () => {
     const event = {
       _id: new ObjectId(),
-      startDate: '2021-05-01T10:00:00',
-      endDate: '2021-05-01T12:00:00',
+      startDate: '2021-05-01T10:00:00.000Z',
+      endDate: '2021-05-01T12:00:00.000Z',
       customer: new ObjectId(),
       misc: 'test',
       company: new ObjectId(),
       repetition: { frequency: 'every_day', parentID: new ObjectId() },
     };
-    const payload = { startDate: '2021-05-01T10:02:00', reason: 'qrcode', action: 'manual_time_stamping' };
+    const payload = { startDate: '2021-05-01T10:02:00.000Z', reason: 'qrcode', action: 'manual_time_stamping' };
     const credentials = { _id: new ObjectId() };
 
     await EventHistoryHelper.createTimeStampHistory(event, payload, credentials);
@@ -1005,12 +1005,12 @@ describe('createTimeStampHistory', () => {
     sinon.assert.calledOnceWithExactly(
       create,
       {
-        event: { ...omit(event, ['_id']), eventId: event._id, startDate: '2021-05-01T10:02:00' },
+        event: { ...omit(event, ['_id']), eventId: event._id, startDate: '2021-05-01T10:02:00.000Z' },
         company: event.company,
         action: 'manual_time_stamping',
         manualTimeStampingReason: 'qrcode',
         auxiliaries: [event.auxiliary],
-        update: { startHour: { from: '2021-05-01T10:00:00', to: '2021-05-01T10:02:00' } },
+        update: { startHour: { from: '2021-05-01T10:00:00.000Z', to: '2021-05-01T10:02:00.000Z' } },
         createdBy: credentials._id,
       }
     );
@@ -1019,14 +1019,14 @@ describe('createTimeStampHistory', () => {
   it('should create and event history of type timestamp for endDate', async () => {
     const event = {
       _id: new ObjectId(),
-      startDate: '2021-05-01T10:00:00',
-      endDate: '2021-05-01T12:00:00',
+      startDate: '2021-05-01T10:00:00.000Z',
+      endDate: '2021-05-01T12:00:00.000Z',
       customer: new ObjectId(),
       misc: 'test',
       company: new ObjectId(),
       repetition: { frequency: 'every_day', parentID: new ObjectId() },
     };
-    const payload = { endDate: '2021-05-01T12:05:00', reason: 'qrcode', action: 'manual_time_stamping' };
+    const payload = { endDate: '2021-05-01T12:05:00.000Z', reason: 'qrcode', action: 'manual_time_stamping' };
     const credentials = { _id: new ObjectId() };
 
     await EventHistoryHelper.createTimeStampHistory(event, payload, credentials);
@@ -1034,12 +1034,12 @@ describe('createTimeStampHistory', () => {
     sinon.assert.calledOnceWithExactly(
       create,
       {
-        event: { ...omit(event, ['_id']), eventId: event._id, endDate: '2021-05-01T12:05:00' },
+        event: { ...omit(event, ['_id']), eventId: event._id, endDate: '2021-05-01T12:05:00.000Z' },
         company: event.company,
         action: 'manual_time_stamping',
         manualTimeStampingReason: 'qrcode',
         auxiliaries: [event.auxiliary],
-        update: { endHour: { from: '2021-05-01T12:00:00', to: '2021-05-01T12:05:00' } },
+        update: { endHour: { from: '2021-05-01T12:00:00.000Z', to: '2021-05-01T12:05:00.000Z' } },
         createdBy: credentials._id,
       }
     );
@@ -1048,14 +1048,14 @@ describe('createTimeStampHistory', () => {
   it('shouldn’t add manualTimeStampingReason to query if reason isn’t in payload', async () => {
     const event = {
       _id: new ObjectId(),
-      startDate: '2021-05-01T10:00:00',
-      endDate: '2021-05-01T12:00:00',
+      startDate: '2021-05-01T10:00:00.000Z',
+      endDate: '2021-05-01T12:00:00.000Z',
       customer: new ObjectId(),
       misc: 'test',
       company: new ObjectId(),
       repetition: { frequency: 'every_day', parentID: new ObjectId() },
     };
-    const payload = { endDate: '2021-05-01T12:05:00', action: 'qr_code_time_stamping' };
+    const payload = { endDate: '2021-05-01T12:05:00.000Z', action: 'qr_code_time_stamping' };
     const credentials = { _id: new ObjectId() };
 
     await EventHistoryHelper.createTimeStampHistory(event, payload, credentials);
@@ -1063,11 +1063,11 @@ describe('createTimeStampHistory', () => {
     sinon.assert.calledOnceWithExactly(
       create,
       {
-        event: { ...omit(event, ['_id']), eventId: event._id, endDate: '2021-05-01T12:05:00' },
+        event: { ...omit(event, ['_id']), eventId: event._id, endDate: '2021-05-01T12:05:00.000Z' },
         company: event.company,
         action: 'qr_code_time_stamping',
         auxiliaries: [event.auxiliary],
-        update: { endHour: { from: '2021-05-01T12:00:00', to: '2021-05-01T12:05:00' } },
+        update: { endHour: { from: '2021-05-01T12:00:00.000Z', to: '2021-05-01T12:05:00.000Z' } },
         createdBy: credentials._id,
       }
     );

--- a/tests/unit/helpers/eventHistories.test.js
+++ b/tests/unit/helpers/eventHistories.test.js
@@ -241,7 +241,7 @@ describe('createEventHistoryOnDelete', () => {
   });
 });
 
-describe('createEventHistoryOnUpdate #tag', () => {
+describe('createEventHistoryOnUpdate', () => {
   const customerId = new ObjectId();
   let formatHistoryForAuxiliaryUpdate;
   let formatHistoryForDatesUpdate;

--- a/tests/unit/helpers/events.test.js
+++ b/tests/unit/helpers/events.test.js
@@ -228,8 +228,8 @@ describe('updateEvent', () => {
     const auxiliaryId = new ObjectId();
     const event = { _id: new ObjectId(), type: INTERVENTION, auxiliary: { _id: auxiliaryId } };
     const payload = {
-      startDate: '2019-01-21T09:38:18',
-      endDate: '2019-01-22T10:38:18',
+      startDate: '2019-01-21T09:38:18.000Z',
+      endDate: '2019-01-22T10:38:18.000Z',
       auxiliary: auxiliaryId.toHexString(),
     };
 
@@ -260,8 +260,8 @@ describe('updateEvent', () => {
       const auxiliary = new ObjectId();
       const event = { _id: new ObjectId(), type: INTERVENTION, auxiliary, repetition: { frequency: 'every_week' } };
       const payload = {
-        startDate: '2019-01-21T09:38:18',
-        endDate: '2019-01-21T10:38:18',
+        startDate: '2019-01-21T09:38:18.000Z',
+        endDate: '2019-01-21T10:38:18.000Z',
         auxiliary: auxiliary.toHexString(),
         shouldUpdateRepetition: true,
       };
@@ -292,8 +292,8 @@ describe('updateEvent', () => {
     const auxiliary = new ObjectId();
     const event = { _id: new ObjectId(), type: INTERVENTION, auxiliary, repetition: { frequency: 'every_week' } };
     const payload = {
-      startDate: '2019-01-21T09:38:18',
-      endDate: '2019-01-21T10:38:18',
+      startDate: '2019-01-21T09:38:18.000Z',
+      endDate: '2019-01-21T10:38:18.000Z',
       auxiliary: auxiliary.toHexString(),
       shouldUpdateRepetition: true,
     };
@@ -329,8 +329,8 @@ describe('updateEvent', () => {
     const parentId = new ObjectId();
     const event = { _id: eventId, type: INTERVENTION, auxiliary, repetition: { frequency: 'every_week', parentId } };
     const payload = {
-      startDate: '2019-01-21T09:38:18',
-      endDate: '2019-01-21T10:38:18',
+      startDate: '2019-01-21T09:38:18.000Z',
+      endDate: '2019-01-21T10:38:18.000Z',
       auxiliary: auxiliary.toHexString(),
       shouldUpdateRepetition: true,
     };
@@ -377,8 +377,8 @@ describe('updateEvent', () => {
     const eventId = new ObjectId();
     const event = { _id: eventId, type: INTERVENTION, auxiliary, repetition: { frequency: 'every_week' } };
     const payload = {
-      startDate: '2019-01-21T09:38:18',
-      endDate: '2019-01-21T10:38:18',
+      startDate: '2019-01-21T09:38:18.000Z',
+      endDate: '2019-01-21T10:38:18.000Z',
       auxiliary: auxiliary.toHexString(),
       shouldUpdateRepetition: false,
     };
@@ -415,8 +415,8 @@ describe('updateEvent', () => {
     const auxiliaryId = new ObjectId();
     const event = { _id: eventId, type: INTERVENTION, auxiliary: { _id: auxiliaryId } };
     const payload = {
-      startDate: '2019-01-21T09:38:18',
-      endDate: '2019-01-21T12:38:18',
+      startDate: '2019-01-21T09:38:18.000Z',
+      endDate: '2019-01-21T12:38:18.000Z',
       auxiliary: auxiliaryId.toHexString(),
       misc: 'test',
     };
@@ -468,12 +468,12 @@ describe('updateEvent', () => {
       _id: eventId,
       type: ABSENCE,
       auxiliary: { _id: auxiliaryId },
-      startDate: '2019-01-21T00:00:00',
-      endDate: '2019-01-24T23:59:59',
+      startDate: '2019-01-21T00:00:00.000Z',
+      endDate: '2019-01-24T23:59:59.000Z',
     };
     const payload = {
-      startDate: '2019-01-21T00:00:00',
-      endDate: '2019-01-24T23:59:59',
+      startDate: '2019-01-21T00:00:00.000Z',
+      endDate: '2019-01-24T23:59:59.000Z',
       auxiliary: auxiliaryId.toHexString(),
     };
 
@@ -517,7 +517,7 @@ describe('updateEvent', () => {
     );
     sinon.assert.calledOnceWithExactly(
       unassignConflictInterventions,
-      { startDate: '2019-01-21T00:00:00', endDate: '2019-01-24T23:59:59' },
+      { startDate: '2019-01-21T00:00:00.000Z', endDate: '2019-01-24T23:59:59.000Z' },
       { _id: auxiliaryId },
       credentials
     );
@@ -648,7 +648,7 @@ describe('populateEventSubscription', () => {
             sundays: 2,
           },
           {
-            createdAt: '2019-01-21T09:38:18',
+            createdAt: '2019-01-21T09:38:18.000Z',
             _id: new ObjectId(),
             service: new ObjectId(),
             unitTTCRate: 25,
@@ -690,7 +690,7 @@ describe('populateEventSubscription', () => {
       customer: {
         subscriptions: [
           {
-            createdAt: '2019-01-21T09:38:18',
+            createdAt: '2019-01-21T09:38:18.000Z',
             _id: new ObjectId(),
             service: new ObjectId(),
             unitTTCRate: 25,
@@ -735,7 +735,7 @@ describe('populateEvents', () => {
               sundays: 2,
             },
             {
-              createdAt: '2019-01-21T09:38:18',
+              createdAt: '2019-01-21T09:38:18.000Z',
               _id: new ObjectId(),
               service: new ObjectId(),
               unitTTCRate: 25,
@@ -1340,8 +1340,8 @@ describe('createEvent', () => {
     const auxiliaryId = new ObjectId();
     const payload = {
       type: ABSENCE,
-      startDate: '2019-03-20T10:00:00',
-      endDate: '2019-03-20T12:00:00',
+      startDate: '2019-03-20T10:00:00.000Z',
+      endDate: '2019-03-20T12:00:00.000Z',
       auxiliary: auxiliaryId,
       company: new ObjectId(),
     };
@@ -1365,7 +1365,7 @@ describe('createEvent', () => {
     );
     sinon.assert.calledOnceWithExactly(
       unassignConflictInterventions,
-      { startDate: '2019-03-20T10:00:00', endDate: '2019-03-20T12:00:00' },
+      { startDate: '2019-03-20T10:00:00.000Z', endDate: '2019-03-20T12:00:00.000Z' },
       auxiliary,
       credentials
     );
@@ -1398,7 +1398,7 @@ describe('deleteConflictInternalHoursAndUnavailabilities', () => {
   });
 
   it('should delete conflict events except interventions', async () => {
-    const dates = { startDate: '2019-03-20T10:00:00', endDate: '2019-03-20T12:00:00' };
+    const dates = { startDate: '2019-03-20T10:00:00.000Z', endDate: '2019-03-20T12:00:00.000Z' };
     const auxiliary = { _id: new ObjectId() };
     const credentials = { _id: new ObjectId(), company: { _id: new ObjectId() } };
     const event = { _id: new ObjectId(), startDate: dates.startDate, endDate: dates.endDate };
@@ -1444,7 +1444,7 @@ describe('unassignConflictInterventions', () => {
   });
 
   it('should delete conflict events except interventions', async () => {
-    const dates = { startDate: '2019-03-20T10:00:00', endDate: '2019-03-20T12:00:00' };
+    const dates = { startDate: '2019-03-20T10:00:00.000Z', endDate: '2019-03-20T12:00:00.000Z' };
     const auxiliaryId = new ObjectId();
     const credentials = { _id: new ObjectId(), company: { _id: new ObjectId() } };
     const companyId = credentials.company._id;

--- a/tests/unit/helpers/events.test.js
+++ b/tests/unit/helpers/events.test.js
@@ -29,7 +29,6 @@ const {
   EVERY_WEEK,
   AUXILIARY,
   CUSTOMER,
-  PLANNING_VIEW_END_HOUR,
 } = require('../../../src/helpers/constants');
 const SinonMongoose = require('../sinonMongoose');
 const { CompaniDate } = require('../../../src/helpers/dates/companiDates');
@@ -1135,11 +1134,11 @@ describe('updateAbsencesOnContractEnd', () => {
   });
 
   it('should update future absences events linked to contract', async () => {
-    const contract = { endDate: '2019-10-02T08:00:00.000Z', user: userId };
-    const maxEndDate = moment(contract.endDate).hour(22).startOf('h');
+    const contract = { endDate: '2019-10-02T08:31:33.667Z', user: userId };
+    const maxEndDate = '2019-10-02T20:00:00.000Z'; // local hour: 22:00
     getAbsences.returns(absences);
 
-    payload = { ...payload, endDate: moment(contract.endDate).hour(PLANNING_VIEW_END_HOUR).startOf('h') };
+    payload = { ...payload, endDate: maxEndDate };
     await EventHelper.updateAbsencesOnContractEnd(userId, contract.endDate, credentials);
     sinon.assert.calledOnceWithExactly(getAbsences, userId, maxEndDate, companyId);
     sinon.assert.calledOnceWithExactly(createEventHistoryOnUpdate, payload, absences[0], credentials);

--- a/tests/unit/helpers/eventsValidation.test.js
+++ b/tests/unit/helpers/eventsValidation.test.js
@@ -543,7 +543,7 @@ describe('isCreationAllowed', () => {
   });
 });
 
-describe('isUpdateAllowed #tag', () => {
+describe('isUpdateAllowed', () => {
   let isEditionAllowed;
   let hasConflicts;
   const credentials = { company: { _id: new ObjectId() } };

--- a/tests/unit/helpers/eventsValidation.test.js
+++ b/tests/unit/helpers/eventsValidation.test.js
@@ -119,8 +119,8 @@ describe('isUserContractValidOnEventDates', () => {
   });
 
   it('should return false if contract and no active contract on day and event not absence', async () => {
-    const event = { auxiliary: new ObjectId(), startDate: '2020-04-30T09:00:00', type: INTERVENTION };
-    const contract = { user: event.auxiliary, startDate: '2020-12-05T00:00:00' };
+    const event = { auxiliary: new ObjectId(), startDate: '2020-04-30T09:00:00.000Z', type: INTERVENTION };
+    const contract = { user: event.auxiliary, startDate: '2020-12-05T00:00:00.000Z' };
     const user = { _id: event.auxiliary, contracts: [contract] };
 
     findOne.returns(SinonMongoose.stubChainedQueries(user));
@@ -139,8 +139,8 @@ describe('isUserContractValidOnEventDates', () => {
   });
 
   it('should return true if contract and active contract on day and event not absence', async () => {
-    const event = { auxiliary: new ObjectId(), startDate: '2020-04-30T09:00:00', type: INTERNAL_HOUR };
-    const contract = { user: event.auxiliary, startDate: '2020-01-04T00:00:00' };
+    const event = { auxiliary: new ObjectId(), startDate: '2020-04-30T09:00:00.000Z', type: INTERNAL_HOUR };
+    const contract = { user: event.auxiliary, startDate: '2020-01-04T00:00:00.000Z' };
     const user = { _id: event.auxiliary, contracts: [contract] };
 
     findOne.returns(SinonMongoose.stubChainedQueries(user));
@@ -161,11 +161,11 @@ describe('isUserContractValidOnEventDates', () => {
   it('should return false if contract and no active contract on day and event is absence', async () => {
     const event = {
       auxiliary: new ObjectId(),
-      startDate: '2020-04-30T09:00:00',
-      endDate: '2020-05-12T23:25:59',
+      startDate: '2020-04-30T09:00:00.000Z',
+      endDate: '2020-05-12T23:25:59.000Z',
       type: ABSENCE,
     };
-    const contract = { user: event.auxiliary, startDate: '2020-05-04T00:00:00' };
+    const contract = { user: event.auxiliary, startDate: '2020-05-04T00:00:00.000Z' };
     const user = { _id: event.auxiliary, contracts: [contract] };
 
     findOne.returns(SinonMongoose.stubChainedQueries(user));
@@ -186,11 +186,11 @@ describe('isUserContractValidOnEventDates', () => {
   it('should return true if contract and active contract on day and event is absence', async () => {
     const event = {
       auxiliary: new ObjectId(),
-      startDate: '2020-04-30T09:00:00',
-      endDate: '2020-05-12T23:25:59',
+      startDate: '2020-04-30T09:00:00.000Z',
+      endDate: '2020-05-12T23:25:59.000Z',
       type: ABSENCE,
     };
-    const contract = { user: event.auxiliary, startDate: '2020-01-04T00:00:00' };
+    const contract = { user: event.auxiliary, startDate: '2020-01-04T00:00:00.000Z' };
     const user = { _id: event.auxiliary, contracts: [contract] };
 
     findOne.returns(SinonMongoose.stubChainedQueries(user));
@@ -321,8 +321,8 @@ describe('isEditionAllowed', () => {
     const event = {
       auxiliary: new ObjectId(),
       type: INTERVENTION,
-      startDate: '2019-04-13T09:00:00',
-      endDate: '2019-04-14T11:00:00',
+      startDate: '2019-04-13T09:00:00.000Z',
+      endDate: '2019-04-14T11:00:00.000Z',
     };
 
     const result = await EventsValidationHelper.isEditionAllowed(event, credentials);
@@ -339,8 +339,8 @@ describe('isEditionAllowed', () => {
       auxiliary: new ObjectId(),
       type: ABSENCE,
       absenceNature: HOURLY,
-      startDate: '2019-04-13T09:00:00',
-      endDate: '2019-04-14T11:00:00',
+      startDate: '2019-04-13T09:00:00.000Z',
+      endDate: '2019-04-14T11:00:00.000Z',
     };
 
     const result = await EventsValidationHelper.isEditionAllowed(event, credentials);
@@ -356,8 +356,8 @@ describe('isEditionAllowed', () => {
     const event = {
       sector: new ObjectId(),
       type: ABSENCE,
-      startDate: '2019-04-13T09:00:00',
-      endDate: '2019-04-13T11:00:00',
+      startDate: '2019-04-13T09:00:00.000Z',
+      endDate: '2019-04-13T11:00:00.000Z',
     };
 
     const result = await EventsValidationHelper.isEditionAllowed(event, credentials);
@@ -373,8 +373,8 @@ describe('isEditionAllowed', () => {
     const event = {
       auxiliary: new ObjectId(),
       type: INTERVENTION,
-      startDate: '2019-04-13T09:00:00',
-      endDate: '2019-04-13T11:00:00',
+      startDate: '2019-04-13T09:00:00.000Z',
+      endDate: '2019-04-13T11:00:00.000Z',
     };
 
     isUserContractValidOnEventDates.returns(false);
@@ -392,8 +392,8 @@ describe('isEditionAllowed', () => {
     const event = {
       customer: new ObjectId(),
       type: INTERVENTION,
-      startDate: '2019-04-13T09:00:00',
-      endDate: '2019-04-13T11:00:00',
+      startDate: '2019-04-13T09:00:00.000Z',
+      endDate: '2019-04-13T11:00:00.000Z',
     };
 
     isAbsent.returns(true);
@@ -416,8 +416,8 @@ describe('isEditionAllowed', () => {
     const event = {
       auxiliary: new ObjectId(),
       type: INTERVENTION,
-      startDate: '2019-04-13T09:00:00',
-      endDate: '2019-04-13T11:00:00',
+      startDate: '2019-04-13T09:00:00.000Z',
+      endDate: '2019-04-13T11:00:00.000Z',
     };
 
     isUserContractValidOnEventDates.returns(true);
@@ -436,8 +436,8 @@ describe('isEditionAllowed', () => {
     const event = {
       auxiliary: new ObjectId(),
       type: INTERVENTION,
-      startDate: '2019-04-13T09:00:00',
-      endDate: '2019-04-13T11:00:00',
+      startDate: '2019-04-13T09:00:00.000Z',
+      endDate: '2019-04-13T11:00:00.000Z',
     };
 
     isUserContractValidOnEventDates.returns(true);
@@ -455,8 +455,8 @@ describe('isEditionAllowed', () => {
     const event = {
       auxiliary: new ObjectId(),
       type: INTERNAL_HOUR,
-      startDate: '2019-04-13T09:00:00',
-      endDate: '2019-04-13T11:00:00',
+      startDate: '2019-04-13T09:00:00.000Z',
+      endDate: '2019-04-13T11:00:00.000Z',
     };
 
     isUserContractValidOnEventDates.returns(true);
@@ -487,8 +487,8 @@ describe('isCreationAllowed', () => {
     const event = {
       auxiliary: new ObjectId(),
       type: INTERVENTION,
-      startDate: '2019-04-13T09:00:00',
-      endDate: '2019-04-13T11:00:00',
+      startDate: '2019-04-13T09:00:00.000Z',
+      endDate: '2019-04-13T11:00:00.000Z',
     };
 
     hasConflicts.returns(true);
@@ -509,8 +509,8 @@ describe('isCreationAllowed', () => {
     const event = {
       auxiliary: new ObjectId(),
       type: INTERVENTION,
-      startDate: '2019-04-13T09:00:00',
-      endDate: '2019-04-13T11:00:00',
+      startDate: '2019-04-13T09:00:00.000Z',
+      endDate: '2019-04-13T11:00:00.000Z',
     };
 
     hasConflicts.returns(false);
@@ -529,8 +529,8 @@ describe('isCreationAllowed', () => {
     const event = {
       sector: new ObjectId(),
       type: INTERVENTION,
-      startDate: '2019-04-13T09:00:00',
-      endDate: '2019-04-13T11:00:00',
+      startDate: '2019-04-13T09:00:00.000Z',
+      endDate: '2019-04-13T11:00:00.000Z',
     };
 
     isEditionAllowed.returns(true);
@@ -543,7 +543,7 @@ describe('isCreationAllowed', () => {
   });
 });
 
-describe('isUpdateAllowed', () => {
+describe('isUpdateAllowed #tag', () => {
   let isEditionAllowed;
   let hasConflicts;
   const credentials = { company: { _id: new ObjectId() } };
@@ -558,8 +558,14 @@ describe('isUpdateAllowed', () => {
 
   it('should return true if everything is ok', async () => {
     const auxiliaryId = new ObjectId();
-    const payload = { startDate: '2019-04-13T09:00:00', endDate: '2019-04-13T11:00:00' };
-    const eventFromDB = { auxiliary: auxiliaryId, type: INTERVENTION, repetition: { frequency: 'every_week' } };
+    const payload = { startDate: '2019-04-13T09:00:00.000Z', endDate: '2019-04-13T11:00:00.000Z' };
+    const eventFromDB = {
+      auxiliary: auxiliaryId,
+      type: INTERVENTION,
+      repetition: { frequency: 'every_week' },
+      startDate: '2019-01-01T09:00:00.000Z',
+      endDate: '2019-01-01T11:00:00.000Z',
+    };
     hasConflicts.returns(false);
     isEditionAllowed.returns(true);
 
@@ -570,8 +576,8 @@ describe('isUpdateAllowed', () => {
       hasConflicts,
       {
         type: INTERVENTION,
-        startDate: '2019-04-13T09:00:00',
-        endDate: '2019-04-13T11:00:00',
+        startDate: '2019-04-13T09:00:00.000Z',
+        endDate: '2019-04-13T11:00:00.000Z',
         repetition: { frequency: 'every_week' },
       }
     );
@@ -579,8 +585,8 @@ describe('isUpdateAllowed', () => {
       isEditionAllowed,
       {
         type: INTERVENTION,
-        startDate: '2019-04-13T09:00:00',
-        endDate: '2019-04-13T11:00:00',
+        startDate: '2019-04-13T09:00:00.000Z',
+        endDate: '2019-04-13T11:00:00.000Z',
         repetition: { frequency: 'every_week' },
       },
       credentials
@@ -591,14 +597,14 @@ describe('isUpdateAllowed', () => {
     const auxiliaryId = new ObjectId();
     const payload = {
       auxiliary: auxiliaryId,
-      startDate: '2019-04-13T09:05:00',
-      endDate: '2019-04-13T11:00:00',
+      startDate: '2019-04-13T09:05:00.000Z',
+      endDate: '2019-04-13T11:00:00.000Z',
     };
     const eventFromDB = {
       auxiliary: auxiliaryId,
       type: INTERVENTION,
-      startDate: '2019-04-13T09:00:00',
-      endDate: '2019-04-13T11:00:00',
+      startDate: '2019-04-13T09:00:00.000Z',
+      endDate: '2019-04-13T11:00:00.000Z',
       startDateTimeStamp: 1,
     };
 
@@ -610,12 +616,16 @@ describe('isUpdateAllowed', () => {
   });
 
   it('should return false if event is startDate timeStamped and auxiliary updated', async () => {
-    const payload = { auxiliary: new ObjectId(), startDate: '2019-04-13T09:00:00', endDate: '2019-04-13T11:00:00' };
+    const payload = {
+      auxiliary: new ObjectId(),
+      startDate: '2019-04-13T09:00:00.000Z',
+      endDate: '2019-04-13T11:00:00.000Z',
+    };
     const eventFromDB = {
       auxiliary: new ObjectId(),
       type: INTERVENTION,
-      startDate: '2019-04-13T09:00:00',
-      endDate: '2019-04-13T11:00:00',
+      startDate: '2019-04-13T09:00:00.000Z',
+      endDate: '2019-04-13T11:00:00.000Z',
       startDateTimeStamp: 1,
     };
 
@@ -630,15 +640,15 @@ describe('isUpdateAllowed', () => {
     const auxiliaryId = new ObjectId();
     const payload = {
       auxiliary: auxiliaryId,
-      startDate: '2019-04-13T09:00:00',
-      endDate: '2019-04-13T11:00:00',
+      startDate: '2019-04-13T09:00:00.000Z',
+      endDate: '2019-04-13T11:00:00.000Z',
       isCancelled: true,
     };
     const eventFromDB = {
       auxiliary: auxiliaryId,
       type: INTERVENTION,
-      startDate: '2019-04-13T09:00:00',
-      endDate: '2019-04-13T11:00:00',
+      startDate: '2019-04-13T09:00:00.000Z',
+      endDate: '2019-04-13T11:00:00.000Z',
       startDateTimeStamp: 1,
     };
 
@@ -653,14 +663,14 @@ describe('isUpdateAllowed', () => {
     const auxiliaryId = new ObjectId();
     const payload = {
       auxiliary: auxiliaryId,
-      startDate: '2019-04-13T09:00:00',
-      endDate: '2019-04-13T11:05:00',
+      startDate: '2019-04-13T09:00:00.000Z',
+      endDate: '2019-04-13T11:05:00.000Z',
     };
     const eventFromDB = {
       auxiliary: auxiliaryId,
       type: INTERVENTION,
-      startDate: '2019-04-13T09:00:00',
-      endDate: '2019-04-13T11:00:00',
+      startDate: '2019-04-13T09:00:00.000Z',
+      endDate: '2019-04-13T11:00:00.000Z',
       endDateTimeStamp: 1,
     };
 
@@ -672,12 +682,16 @@ describe('isUpdateAllowed', () => {
   });
 
   it('should return false if event is endDate timeStamped and auxiliary updated', async () => {
-    const payload = { auxiliary: new ObjectId(), startDate: '2019-04-13T09:00:00', endDate: '2019-04-13T11:00:00' };
+    const payload = {
+      auxiliary: new ObjectId(),
+      startDate: '2019-04-13T09:00:00.000Z',
+      endDate: '2019-04-13T11:00:00.000Z',
+    };
     const eventFromDB = {
       auxiliary: new ObjectId(),
       type: INTERVENTION,
-      startDate: '2019-04-13T09:00:00',
-      endDate: '2019-04-13T11:00:00',
+      startDate: '2019-04-13T09:00:00.000Z',
+      endDate: '2019-04-13T11:00:00.000Z',
       endDateTimeStamp: 1,
     };
 
@@ -692,15 +706,15 @@ describe('isUpdateAllowed', () => {
     const auxiliaryId = new ObjectId();
     const payload = {
       auxiliary: auxiliaryId,
-      startDate: '2019-04-13T09:00:00',
-      endDate: '2019-04-13T11:00:00',
+      startDate: '2019-04-13T09:00:00.000Z',
+      endDate: '2019-04-13T11:00:00.000Z',
       isCancelled: true,
     };
     const eventFromDB = {
       auxiliary: auxiliaryId,
       type: INTERVENTION,
-      startDate: '2019-04-13T09:00:00',
-      endDate: '2019-04-13T11:00:00',
+      startDate: '2019-04-13T09:00:00.000Z',
+      endDate: '2019-04-13T11:00:00.000Z',
       endDateTimeStamp: 1,
     };
 
@@ -715,11 +729,17 @@ describe('isUpdateAllowed', () => {
     const auxiliaryId = new ObjectId();
     const payload = {
       auxiliary: auxiliaryId,
-      startDate: '2019-04-13T09:00:00',
-      endDate: '2019-04-13T11:00:00',
+      startDate: '2019-04-13T09:00:00.000Z',
+      endDate: '2019-04-13T11:00:00.000Z',
       endDateTimeStamp: 1,
     };
-    const eventFromDB = { auxiliary: auxiliaryId, type: INTERVENTION, isBilled: true };
+    const eventFromDB = {
+      auxiliary: auxiliaryId,
+      type: INTERVENTION,
+      isBilled: true,
+      startDate: '2019-01-01T09:00:00.000Z',
+      endDate: '2019-01-01T11:00:00.000Z',
+    };
 
     const result = await EventsValidationHelper.isUpdateAllowed(eventFromDB, payload, credentials);
 
@@ -731,12 +751,12 @@ describe('isUpdateAllowed', () => {
   it('should return false as event is absence and auxiliary is updated', async () => {
     const payload = {
       auxiliary: new ObjectId(),
-      startDate: '2019-04-13T09:00:00',
-      endDate: '2019-04-13T11:00:00',
+      startDate: '2019-04-13T09:00:00.000Z',
+      endDate: '2019-04-13T11:00:00.000Z',
     };
     const eventFromDB = {
-      startDate: '2019-04-13T09:00:00',
-      endDate: '2019-04-13T11:00:00',
+      startDate: '2019-04-13T09:00:00.000Z',
+      endDate: '2019-04-13T11:00:00.000Z',
       endDateTimeStamp: 1,
       auxiliary: new ObjectId(),
       type: ABSENCE,
@@ -752,12 +772,12 @@ describe('isUpdateAllowed', () => {
   it('should return false as event is unavailability and auxiliary is updated', async () => {
     const payload = {
       auxiliary: new ObjectId(),
-      startDate: '2019-04-13T09:00:00',
-      endDate: '2019-04-13T11:00:00',
+      startDate: '2019-04-13T09:00:00.000Z',
+      endDate: '2019-04-13T11:00:00.000Z',
     };
     const eventFromDB = {
-      startDate: '2019-04-13T09:00:00',
-      endDate: '2019-04-13T11:00:00',
+      startDate: '2019-04-13T09:00:00.000Z',
+      endDate: '2019-04-13T11:00:00.000Z',
       endDateTimeStamp: 1,
       auxiliary: new ObjectId(),
       type: UNAVAILABILITY,
@@ -774,10 +794,15 @@ describe('isUpdateAllowed', () => {
     const auxiliaryId = new ObjectId();
     const payload = {
       auxiliary: auxiliaryId,
-      startDate: '2019-04-13T09:00:00',
-      endDate: '2019-04-13T11:00:00',
+      startDate: '2019-04-13T09:00:00.000Z',
+      endDate: '2019-04-13T11:00:00.000Z',
     };
-    const eventFromDB = { auxiliary: auxiliaryId, type: INTERVENTION };
+    const eventFromDB = {
+      auxiliary: auxiliaryId,
+      type: INTERVENTION,
+      startDate: '2019-01-01T09:00:00.000Z',
+      endDate: '2019-01-01T11:00:00.000Z',
+    };
     hasConflicts.returns(true);
 
     try {
@@ -789,8 +814,8 @@ describe('isUpdateAllowed', () => {
         hasConflicts,
         {
           auxiliary: auxiliaryId,
-          startDate: '2019-04-13T09:00:00',
-          endDate: '2019-04-13T11:00:00',
+          startDate: '2019-04-13T09:00:00.000Z',
+          endDate: '2019-04-13T11:00:00.000Z',
           type: INTERVENTION,
         }
       );
@@ -802,8 +827,8 @@ describe('isUpdateAllowed', () => {
     const auxiliaryId = new ObjectId();
     const payload = {
       auxiliary: auxiliaryId,
-      startDate: '2019-04-13T09:00:00',
-      endDate: '2019-04-13T11:00:00',
+      startDate: '2019-04-13T09:00:00.000Z',
+      endDate: '2019-04-13T11:00:00.000Z',
       isCancelled: false,
       'repetition.frequency': 'never',
     };
@@ -812,6 +837,8 @@ describe('isUpdateAllowed', () => {
       type: INTERVENTION,
       isCancelled: true,
       repetition: { frequency: 'every_week' },
+      startDate: '2019-01-01T09:00:00.000Z',
+      endDate: '2019-01-01T11:00:00.000Z',
     };
     hasConflicts.returns(true);
 
@@ -824,8 +851,8 @@ describe('isUpdateAllowed', () => {
         hasConflicts,
         {
           auxiliary: auxiliaryId,
-          startDate: '2019-04-13T09:00:00',
-          endDate: '2019-04-13T11:00:00',
+          startDate: '2019-04-13T09:00:00.000Z',
+          endDate: '2019-04-13T11:00:00.000Z',
           type: INTERVENTION,
           isCancelled: false,
           repetition: { frequency: 'never' },
@@ -837,8 +864,14 @@ describe('isUpdateAllowed', () => {
 
   it('should return false if edition is not allowed', async () => {
     const auxiliaryId = new ObjectId();
-    const payload = { startDate: '2019-04-13T09:00:00', endDate: '2019-04-13T11:00:00' };
-    const eventFromDB = { auxiliary: auxiliaryId, type: INTERVENTION, repetition: { frequency: 'every_week' } };
+    const payload = { startDate: '2019-04-13T09:00:00.000Z', endDate: '2019-04-13T11:00:00.000Z' };
+    const eventFromDB = {
+      auxiliary: auxiliaryId,
+      type: INTERVENTION,
+      repetition: { frequency: 'every_week' },
+      startDate: '2019-01-01T09:00:00.000Z',
+      endDate: '2019-01-01T11:00:00.000Z',
+    };
     hasConflicts.returns(false);
     isEditionAllowed.returns(false);
 
@@ -849,8 +882,8 @@ describe('isUpdateAllowed', () => {
       hasConflicts,
       {
         type: INTERVENTION,
-        startDate: '2019-04-13T09:00:00',
-        endDate: '2019-04-13T11:00:00',
+        startDate: '2019-04-13T09:00:00.000Z',
+        endDate: '2019-04-13T11:00:00.000Z',
         repetition: { frequency: 'every_week' },
       }
     );
@@ -858,8 +891,8 @@ describe('isUpdateAllowed', () => {
       isEditionAllowed,
       {
         type: INTERVENTION,
-        startDate: '2019-04-13T09:00:00',
-        endDate: '2019-04-13T11:00:00',
+        startDate: '2019-04-13T09:00:00.000Z',
+        endDate: '2019-04-13T11:00:00.000Z',
         repetition: { frequency: 'every_week' },
       },
       credentials


### PR DESCRIPTION
<details open><summary> TESTS  :computer: </summary>

- [x] J'ai codé les tests unitaires
- [] J'ai codé les tests d'intégration
- [x] C'est une ancienne route utilisée par les apps mobiles.
  - [] Si oui, J'ai fait de nouveaux tests sans modifier les anciens
</details>

- [ ] Je replie cette section car mes modifications n'ont pas besoin de tests unitaires ou d'intégration

---

<details open><summary> POINTS D'ATTENTION POUR CETTE PR  :warning: </summary>

- [x] J'ai fait des modifications sur une route utilisée sur plusieurs plateformes [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/n3bq2hr9Ia)
- [ ] J'ai modifié un modèle utilisé en mobile [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/rqTfwpUib)
- [ ] J'ai ajouté un modèle spécifique à une structure 
  - [ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés
- [ ] J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile
  - [ ] Si oui, j'ai précisé sur le [slite de MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) qu'il faut forcer la mise à jour
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

</details>

- [x] Je replie cette section car je n'ai pas fait de modifications entrainant un point d'attention

---

<details open><summary> FONCTIONNALITÉS APPS MOBILES  :iphone: </summary>

- [ ] Mes changements impactent l'application formation
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours
- [x] Mes changements impactent l'application erp
  - [x] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours

</details>

- [x] Je replie cette section car mes modifications n'ont pas d'impact sur les applications mobiles

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : outils webapp / aux ou coach

- Cas d'usage : migration de moment vers luxon

- Comment tester ? : 

**Partie 1**: les migrations vers luxon
  - tester la modification d'un evenement sans conflit OK
  - rendre modifiable la date de fin (DateTimeRange > disable="false") et tester d'etendre l'evenement sur plusieurs jour : KO
  - modifier + verifier dans l'historique des evenements que la modif est bien faite
     - un evenemnet d'une repetition
        - modifier les heures => "Changement d'horaire ..."
     - un evenement pas d'une repetition
        - modifier le jour => changement de date...
        - modifier les heures => "Changement d'horaire ..."
  - créer une absence sur plusieurs jours a un.e auxiliaire
     - mettre fin au contrat de l'aux pdt cette periode d'absence
     - verifier que l'abscence se termine a 22 le jour de la fin de contrat
     - bug trouvé par Ulysse 🐛 : tous les jours de l'absence sont modifiés et se terminent a 22h

  - sur mobile:
     - je peux horodater un evenement

J'ai  trouvé un bug 🐛 : lorsqu'on modifie le jour d'une intervention et qu'on applique le changement a la repetition. Le changement n'est pas appliqué (et c bien normal) mais on a :
  - on a une notif OK
  - un historique de modification est créé a tort

**Partie 2**: la route PUT qui demande startDate et EndDate en required

sur mobile: je peux modifier un evenement (sans toucher a la date)

sur webapp etq coach : 
   - sur planning aux:
     - je peux modifier un evenement (sans toucher a la date)
     - je peux drag&drop
   - sur planning aux
     - je peux modifier un evenement (sans toucher a la date)
     - je peux drag&drop 
   - menu > Paie > absences : je peux modifier une absence

sur webapp etq aux : 
  - je peux modifier un evenement (sans toucher a la date)

_Si tu as lu cette description, pense a réagir avec un :eye:_
