### PR TITLE
Com 2776

### DIFF
--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -162,6 +162,9 @@ module.exports = {
   },
   TWO_WEEKS: 'two_weeks',
   MONTH: 'month',
+  get FIELDS_NOT_APPLICABLE_TO_REPETITION() {
+    return ['misc', 'kmDuringEvent', 'transportMode', 'cancel', 'isCancelled' ];
+  },
   // PAYMENT
   PAYMENT: 'payment',
   REFUND: 'refund',

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -163,7 +163,7 @@ module.exports = {
   TWO_WEEKS: 'two_weeks',
   MONTH: 'month',
   get FIELDS_NOT_APPLICABLE_TO_REPETITION() {
-    return ['misc', 'kmDuringEvent', 'transportMode', 'cancel', 'isCancelled' ];
+    return ['misc', 'kmDuringEvent', 'transportMode', 'cancel', 'isCancelled'];
   },
   // PAYMENT
   PAYMENT: 'payment',

--- a/src/helpers/events.js
+++ b/src/helpers/events.js
@@ -29,6 +29,7 @@ const DistanceMatrixHelper = require('./distanceMatrix');
 const DraftPayHelper = require('./draftPay');
 const ContractHelper = require('./contracts');
 const DatesHelper = require('./dates');
+const RepetitionsHelper = require('./repetitions');
 const Event = require('../models/Event');
 const Repetition = require('../models/Repetition');
 const User = require('../models/User');
@@ -83,14 +84,13 @@ exports.createEvent = async (payload, credentials) => {
 
   if (!isRepeatedEvent) await EventHistoriesHelper.createEventHistoryOnCreate(event, credentials);
   else {
-    const repetition = { ...payload.repetition, parentId: populatedEvent._id };
-    await EventsRepetitionHelper.createRepetitions(
-      populatedEvent,
-      { ...payload, company: companyId, repetition },
-      credentials
-    );
+    await EventsRepetitionHelper.createRepetitions(populatedEvent, payload, credentials);
 
-    await EventHistoriesHelper.createEventHistoryOnCreate({ ...payload, _id: event._id, repetition }, credentials);
+    const eventHistoryPayload = {
+      ...RepetitionsHelper.formatPayloadForRepetitionCreation(populatedEvent, payload, companyId),
+      _id: event._id,
+    };
+    await EventHistoriesHelper.createEventHistoryOnCreate(eventHistoryPayload, credentials);
   }
 
   if (payload.type === ABSENCE) {

--- a/src/helpers/repetitions.js
+++ b/src/helpers/repetitions.js
@@ -18,11 +18,8 @@ exports.updateRepetitions = async (eventPayload, parentId) => {
   await Repetition.findOneAndUpdate({ parentId }, payload);
 };
 
-exports.formatPayloadForRepetitionCreation = (event, payload, companyId) => {
-  const repetition = { ...payload.repetition, parentId: event._id };
-  return {
-    ...omit(payload, FIELDS_NOT_APPLICABLE_TO_REPETITION),
-    company: companyId,
-    repetition,
-  };
-};
+exports.formatPayloadForRepetitionCreation = (event, payload, companyId) => ({
+  ...omit(payload, FIELDS_NOT_APPLICABLE_TO_REPETITION),
+  company: companyId,
+  repetition: { ...payload.repetition, parentId: event._id },
+});

--- a/src/helpers/repetitions.js
+++ b/src/helpers/repetitions.js
@@ -2,6 +2,7 @@ const omit = require('lodash/omit');
 const Repetition = require('../models/Repetition');
 const EventsHelper = require('./events');
 const { CompaniDate } = require('./dates/companiDates');
+const { FIELDS_NOT_APPLICABLE_TO_REPETITION } = require('./constants');
 
 exports.updateRepetitions = async (eventPayload, parentId) => {
   const repetition = await Repetition.findOne({ parentId }).lean();
@@ -15,4 +16,13 @@ exports.updateRepetitions = async (eventPayload, parentId) => {
   const repetitionPayload = { ...omit(eventPayload, ['_id']), startDate, endDate };
   const payload = EventsHelper.formatEditionPayload(repetition, repetitionPayload, false);
   await Repetition.findOneAndUpdate({ parentId }, payload);
+};
+
+exports.formatPayloadForRepetitionCreation = (event, payload, companyId) => {
+  const repetition = { ...payload.repetition, parentId: event._id };
+  return {
+    ...omit(payload, FIELDS_NOT_APPLICABLE_TO_REPETITION),
+    company: companyId,
+    repetition,
+  };
 };

--- a/tests/unit/helpers/repetitions.test.js
+++ b/tests/unit/helpers/repetitions.test.js
@@ -64,3 +64,28 @@ describe('updateRepetitions', () => {
     sinon.assert.notCalled(formatEditionPayloadStub);
   });
 });
+
+describe('formatPayloadForRepetitionCreation', () => {
+  it('should format payload for repetition creation', async () => {
+    const eventId = new ObjectId();
+    const event = {
+      _id: eventId,
+      startDate: '2020-12-01T10:30:00.000Z',
+      endDate: '2020-12-01T12:30:00.000Z',
+    };
+    const payload = {
+      misc: 'Super note pour verifier que ce champ n\'est pas appliqué a la repetition au moment de la creation.',
+      startDate: '2020-12-01T11:30:00.000Z',
+      repetition: { startDate: '2020-01-01T09:10:00.000Z', endDate: '2020-01-01T11:10:00.000Z' },
+    };
+    const companyId = new ObjectId();
+
+    const result = await RepetitionHelper.formatPayloadForRepetitionCreation(event, payload, companyId);
+
+    expect(result).toEqual({
+      startDate: '2020-12-01T11:30:00.000Z',
+      company: companyId,
+      repetition: { startDate: '2020-01-01T09:10:00.000Z', endDate: '2020-01-01T11:10:00.000Z', parentId: eventId },
+    });
+  });
+});


### PR DESCRIPTION
<details open><summary> TESTS  :computer: </summary>

- [x] J'ai codé les tests unitaires
- [ ] J'ai codé les tests d'intégration
- [ ] C'est une ancienne route utilisée par les apps mobiles.
  - [ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens
</details>

- [ ] Je replie cette section car mes modifications n'ont pas besoin de tests unitaires ou d'intégration

---

<details open><summary> POINTS D'ATTENTION POUR CETTE PR  :warning: </summary>

- [ ] J'ai fait des modifications sur une route utilisée sur plusieurs plateformes [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/n3bq2hr9Ia)
- [ ] J'ai modifié un modèle utilisé en mobile [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/rqTfwpUib)
- [ ] J'ai ajouté un modèle spécifique à une structure 
  - [ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés
- [ ] J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile
  - [ ] Si oui, j'ai précisé sur le [slite de MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) qu'il faut forcer la mise à jour
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

</details>

- [x] Je replie cette section car je n'ai pas fait de modifications entrainant un point d'attention

---

<details open><summary> FONCTIONNALITÉS APPS MOBILES  :iphone: </summary>

- [ ] Mes changements impactent l'application formation
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours
- [ ] Mes changements impactent l'application erp
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours

</details>

- [x] Je replie cette section car mes modifications n'ont pas d'impact sur les applications mobiles

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : Auxiliaire/Coach/Admin

- Cas d'usage : Lorsque je créé une répétition, la note n'est pas prise en compte dans la répétition

- Comment tester ? : 
   - creer une repetition avec une note
     - verifier que le champ note n'est présent que sur le premier evenement  

_Si tu as lu cette description, pense a réagir avec un :eye:_
