### PR TITLE
Com 2777

### DIFF
--- a/src/helpers/eSign.js
+++ b/src/helpers/eSign.js
@@ -4,19 +4,19 @@ const ESign = require('../models/ESign');
 
 exports.generateSignatureRequest = async (params) => {
   const filePath = await DocxHelper.generateDocx({ file: { fileId: params.templateId }, data: params.fields });
-  const file64 = await FileHelper.fileToBase64(filePath);
-  const payload = {
-    sandbox: process.env.NODE_ENV !== 'production' ? 1 : 0,
-    title: params.title,
-    embedded_signing_enabled: 1,
-    use_hidden_tags: 1,
-    reminders: 0,
-    files: [{ name: params.title, file_base64: file64 }],
-    signers: params.signers,
-    meta: params.meta,
-    redirect: params.redirect || '',
-    redirect_decline: params.redirectDecline || '',
-  };
+    const file64 = await FileHelper.fileToBase64(filePath);
+    const payload = {
+      sandbox: process.env.NODE_ENV !== 'production' ? 1 : 0,
+      title: params.title,
+      embedded_signing_enabled: 1,
+      use_hidden_tags: 1,
+      reminders: 0,
+      files: [{ name: params.title, file_base64: file64 }],
+      signers: params.signers,
+      meta: params.meta,
+      redirect: params.redirect || '',
+      redirect_decline: params.redirectDecline || '',
+    };
 
   return ESign.createDocument(payload);
 };

--- a/src/helpers/eSign.js
+++ b/src/helpers/eSign.js
@@ -4,19 +4,19 @@ const ESign = require('../models/ESign');
 
 exports.generateSignatureRequest = async (params) => {
   const filePath = await DocxHelper.generateDocx({ file: { fileId: params.templateId }, data: params.fields });
-    const file64 = await FileHelper.fileToBase64(filePath);
-    const payload = {
-      sandbox: process.env.NODE_ENV !== 'production' ? 1 : 0,
-      title: params.title,
-      embedded_signing_enabled: 1,
-      use_hidden_tags: 1,
-      reminders: 0,
-      files: [{ name: params.title, file_base64: file64 }],
-      signers: params.signers,
-      meta: params.meta,
-      redirect: params.redirect || '',
-      redirect_decline: params.redirectDecline || '',
-    };
+  const file64 = await FileHelper.fileToBase64(filePath);
+  const payload = {
+    sandbox: process.env.NODE_ENV !== 'production' ? 1 : 0,
+    title: params.title,
+    embedded_signing_enabled: 1,
+    use_hidden_tags: 1,
+    reminders: 0,
+    files: [{ name: params.title, file_base64: file64 }],
+    signers: params.signers,
+    meta: params.meta,
+    redirect: params.redirect || '',
+    redirect_decline: params.redirectDecline || '',
+  };
 
   return ESign.createDocument(payload);
 };

--- a/src/helpers/events.js
+++ b/src/helpers/events.js
@@ -251,14 +251,12 @@ exports.shouldDetachFromRepetition = (event, payload) => {
 };
 
 const getEventSector = async (event, companyId) => {
-  let sectorId = event.sector;
-  if (!event.sector) {
-    const user = await User.findOne({ _id: event.auxiliary }, { _id: 1 })
-      .populate({ path: 'sector', select: '_id sector', match: { company: companyId } })
-      .lean();
-    sectorId = user.sector;
-  }
-  return sectorId;
+  if (event.sector) return event.sector;
+
+  const user = await User.findOne({ _id: event.auxiliary }, { _id: 1 })
+    .populate({ path: 'sector', select: '_id sector', match: { company: companyId } })
+    .lean();
+  return user.sector;
 };
 
 /**

--- a/src/helpers/eventsRepetition.js
+++ b/src/helpers/eventsRepetition.js
@@ -139,11 +139,11 @@ exports.updateEventBelongingToRepetition = async (eventPayload, event, companyId
   });
   if (event.type !== INTERVENTION && hasConflicts) return Event.deleteOne({ _id: event._id });
 
-  const detachFromRepetition = !!eventPayload.auxiliary && hasConflicts;
-  const newEventPayload = detachFromRepetition || !eventPayload.auxiliary
+  const newEventPayload = !eventPayload.auxiliary || hasConflicts
     ? { ...omit(eventPayload, 'auxiliary'), sector: sectorId }
     : { ...eventPayload };
 
+  const detachFromRepetition = !!eventPayload.auxiliary && hasConflicts;
   const editionPayload = EventsHelper.formatEditionPayload(event, newEventPayload, detachFromRepetition);
 
   return Event.updateOne({ _id: event._id }, editionPayload);

--- a/src/helpers/eventsRepetition.js
+++ b/src/helpers/eventsRepetition.js
@@ -180,7 +180,7 @@ exports.updateRepetition = async (eventFromDb, eventPayload, credentials, sector
       companyId,
       sectorId
     );
-    if (updateEventPromise) promises.push(updateEventPromise);
+    promises.push(updateEventPromise);
   }
 
   await Promise.all([

--- a/tests/unit/helpers/events.test.js
+++ b/tests/unit/helpers/events.test.js
@@ -381,7 +381,7 @@ describe('updateEvent', () => {
     SinonMongoose.calledOnceWithExactly(
       userFindOne,
       [
-        { query: 'findOne', args: [{ _id: event.auxiliary }] },
+        { query: 'findOne', args: [{ _id: event.auxiliary }, { _id: 1 }] },
         {
           query: 'populate',
           args: [{
@@ -392,14 +392,7 @@ describe('updateEvent', () => {
         },
         { query: 'lean' },
       ]);
-    sinon.assert.calledOnceWithExactly(
-      updateEventBelongingToRepetition,
-      { ...payload, _id: event._id, type: event.type },
-      payload,
-      event,
-      companyId,
-      sectorId
-    );
+    sinon.assert.calledOnceWithExactly(updateEventBelongingToRepetition, payload, event, companyId, sectorId);
     sinon.assert.calledOnceWithExactly(populateEventSubscription, event);
     sinon.assert.notCalled(isRepetition);
     sinon.assert.notCalled(shouldDetachFromRepetition);
@@ -459,14 +452,7 @@ describe('updateEvent', () => {
       ]
     );
     sinon.assert.notCalled(userFindOne);
-    sinon.assert.calledOnceWithExactly(
-      updateEventBelongingToRepetition,
-      { ...payload, _id: event._id, type: event.type },
-      payload,
-      event,
-      companyId,
-      sectorId
-    );
+    sinon.assert.calledOnceWithExactly(updateEventBelongingToRepetition, payload, event, companyId, sectorId);
     sinon.assert.calledOnceWithExactly(populateEventSubscription, event);
     sinon.assert.notCalled(isRepetition);
     sinon.assert.notCalled(shouldDetachFromRepetition);

--- a/tests/unit/helpers/eventsRepetition.test.js
+++ b/tests/unit/helpers/eventsRepetition.test.js
@@ -645,29 +645,34 @@ describe('updateEventBelongingToRepetition', () => {
     const auxiliaryId = new ObjectId();
     const sectorId = new ObjectId();
     const companyId = new ObjectId();
+    const parentId = new ObjectId();
     const event = {
       _id: '123456',
-      repetition: { parentId: 'qwertyuiop', frequency: 'every_day' },
+      repetition: { parentId, frequency: 'every_day' },
       startDate: '2019-03-23T09:00:00',
       type: INTERNAL_HOUR,
       auxiliary: auxiliaryId,
     };
-    const repetitionPayload = { startDate: '2019-03-23T10:00:00.000Z', endDate: '2019-03-23T11:00:00.000Z' };
-    const eventPayload = { misc: 'super note' };
+    const eventPayload = {
+      startDate: '2019-03-23T10:00:00.000Z',
+      endDate: '2019-03-23T11:00:00.000Z',
+      misc: 'super note',
+    };
 
     hasConflicts.returns(true);
 
-    await EventsRepetitionHelper.updateEventBelongingToRepetition(
-      repetitionPayload,
-      eventPayload,
-      event,
-      companyId,
-      sectorId
-    );
+    await EventsRepetitionHelper.updateEventBelongingToRepetition(eventPayload, event, companyId, sectorId);
 
     sinon.assert.calledOnceWithExactly(
       hasConflicts,
-      { startDate: '2019-03-23T10:00:00.000Z', endDate: '2019-03-23T11:00:00.000Z', company: companyId }
+      {
+        startDate: '2019-03-23T10:00:00.000Z',
+        endDate: '2019-03-23T11:00:00.000Z',
+        misc: 'super note',
+        company: companyId,
+        _id: '123456',
+        type: INTERNAL_HOUR,
+      }
     );
     sinon.assert.calledWithExactly(deleteOne, { _id: '123456' });
     sinon.assert.notCalled(formatEditionPayload);
@@ -678,29 +683,34 @@ describe('updateEventBelongingToRepetition', () => {
     const auxiliaryId = new ObjectId();
     const sectorId = new ObjectId();
     const companyId = new ObjectId();
+    const parentId = new ObjectId();
     const event = {
       _id: '123456',
-      repetition: { parentId: 'qwertyuiop', frequency: 'every_day' },
+      repetition: { parentId, frequency: 'every_day' },
       startDate: '2019-03-23T09:00:00',
       type: UNAVAILABILITY,
       auxiliary: auxiliaryId,
     };
-    const repetitionPayload = { startDate: '2019-03-23T10:00:00.000Z', endDate: '2019-03-23T11:00:00.000Z' };
-    const eventPayload = { misc: 'super note' };
+    const eventPayload = {
+      startDate: '2019-03-23T10:00:00.000Z',
+      endDate: '2019-03-23T11:00:00.000Z',
+      misc: 'super note',
+    };
 
     hasConflicts.returns(true);
 
-    await EventsRepetitionHelper.updateEventBelongingToRepetition(
-      repetitionPayload,
-      eventPayload,
-      event,
-      companyId,
-      sectorId
-    );
+    await EventsRepetitionHelper.updateEventBelongingToRepetition(eventPayload, event, companyId, sectorId);
 
     sinon.assert.calledOnceWithExactly(
       hasConflicts,
-      { startDate: '2019-03-23T10:00:00.000Z', endDate: '2019-03-23T11:00:00.000Z', company: companyId }
+      {
+        startDate: '2019-03-23T10:00:00.000Z',
+        endDate: '2019-03-23T11:00:00.000Z',
+        misc: 'super note',
+        company: companyId,
+        _id: '123456',
+        type: UNAVAILABILITY,
+      }
     );
     sinon.assert.calledWithExactly(deleteOne, { _id: '123456' });
     sinon.assert.notCalled(formatEditionPayload);
@@ -711,16 +721,20 @@ describe('updateEventBelongingToRepetition', () => {
     const auxiliaryId = new ObjectId();
     const sectorId = new ObjectId();
     const companyId = new ObjectId();
+    const parentId = new ObjectId();
     const event = {
       _id: '123456',
-      repetition: { parentId: 'qwertyuiop', frequency: 'every_day' },
+      repetition: { parentId, frequency: 'every_day' },
       startDate: '2019-03-24T10:00:00.000Z',
       type: INTERVENTION,
       auxiliary: auxiliaryId,
     };
-
-    const repetitionPayload = { startDate: '2019-03-24T10:00:00.000Z', endDate: '2019-03-24T11:00:00.000Z' };
-    const eventPayload = { misc: 'super note', auxiliary: '1234567890' };
+    const eventPayload = {
+      startDate: '2019-03-24T10:00:00.000Z',
+      endDate: '2019-03-24T11:00:00.000Z',
+      misc: 'super note',
+      auxiliary: '1234567890',
+    };
 
     hasConflicts.returns(true);
     formatEditionPayload.returns({
@@ -733,28 +747,35 @@ describe('updateEventBelongingToRepetition', () => {
       $unset: { auxiliary: '' },
     });
 
-    await EventsRepetitionHelper.updateEventBelongingToRepetition(
-      repetitionPayload,
-      eventPayload,
-      event,
-      companyId,
-      sectorId
-    );
+    await EventsRepetitionHelper.updateEventBelongingToRepetition(eventPayload, event, companyId, sectorId);
 
     sinon.assert.calledWithExactly(
       hasConflicts,
-      { startDate: '2019-03-24T10:00:00.000Z', endDate: '2019-03-24T11:00:00.000Z', company: companyId }
+      {
+        startDate: '2019-03-24T10:00:00.000Z',
+        endDate: '2019-03-24T11:00:00.000Z',
+        misc: 'super note',
+        auxiliary: '1234567890',
+        company: companyId,
+        _id: '123456',
+        type: INTERVENTION,
+      }
     );
     sinon.assert.calledOnceWithExactly(
       formatEditionPayload,
       {
         _id: '123456',
-        repetition: { parentId: 'qwertyuiop', frequency: 'every_day' },
+        repetition: { parentId, frequency: 'every_day' },
         startDate: '2019-03-24T10:00:00.000Z',
         type: INTERVENTION,
         auxiliary: auxiliaryId,
       },
-      { startDate: '2019-03-24T10:00:00.000Z', endDate: '2019-03-24T11:00:00.000Z', sector: sectorId },
+      {
+        startDate: '2019-03-24T10:00:00.000Z',
+        endDate: '2019-03-24T11:00:00.000Z',
+        misc: 'super note',
+        sector: sectorId,
+      },
       true
     );
     sinon.assert.calledWithExactly(
@@ -776,16 +797,20 @@ describe('updateEventBelongingToRepetition', () => {
     const auxiliaryId = new ObjectId();
     const sectorId = new ObjectId();
     const companyId = new ObjectId();
+    const parentId = new ObjectId();
     const event = {
       _id: '123456',
-      repetition: { parentId: 'qwertyuiop', frequency: 'every_day' },
+      repetition: { parentId, frequency: 'every_day' },
       startDate: '2019-03-24T10:00:00.000Z',
       type: INTERVENTION,
       auxiliary: auxiliaryId,
     };
-
-    const repetitionPayload = { startDate: '2019-03-24T10:00:00.000Z', endDate: '2019-03-24T11:00:00.000Z' };
-    const eventPayload = { misc: 'super note', auxiliary: '' };
+    const eventPayload = {
+      startDate: '2019-03-24T10:00:00.000Z',
+      endDate: '2019-03-24T11:00:00.000Z',
+      misc: 'super note',
+      auxiliary: '',
+    };
 
     hasConflicts.returns(true);
     formatEditionPayload.returns({
@@ -793,28 +818,35 @@ describe('updateEventBelongingToRepetition', () => {
       $unset: { auxiliary: '' },
     });
 
-    await EventsRepetitionHelper.updateEventBelongingToRepetition(
-      repetitionPayload,
-      eventPayload,
-      event,
-      companyId,
-      sectorId
-    );
+    await EventsRepetitionHelper.updateEventBelongingToRepetition(eventPayload, event, companyId, sectorId);
 
     sinon.assert.calledWithExactly(
       hasConflicts,
-      { startDate: '2019-03-24T10:00:00.000Z', endDate: '2019-03-24T11:00:00.000Z', company: companyId }
+      {
+        startDate: '2019-03-24T10:00:00.000Z',
+        endDate: '2019-03-24T11:00:00.000Z',
+        misc: 'super note',
+        auxiliary: '',
+        company: companyId,
+        _id: '123456',
+        type: INTERVENTION,
+      }
     );
     sinon.assert.calledOnceWithExactly(
       formatEditionPayload,
       {
         _id: '123456',
-        repetition: { parentId: 'qwertyuiop', frequency: 'every_day' },
+        repetition: { parentId, frequency: 'every_day' },
         startDate: '2019-03-24T10:00:00.000Z',
         type: INTERVENTION,
         auxiliary: auxiliaryId,
       },
-      { startDate: '2019-03-24T10:00:00.000Z', endDate: '2019-03-24T11:00:00.000Z', sector: sectorId },
+      {
+        startDate: '2019-03-24T10:00:00.000Z',
+        endDate: '2019-03-24T11:00:00.000Z',
+        misc: 'super note',
+        sector: sectorId,
+      },
       false
     );
     sinon.assert.calledWithExactly(
@@ -849,8 +881,9 @@ describe('updateRepetition', () => {
     const auxiliaryId = new ObjectId();
     const customerId = new ObjectId();
     const sectorId = new ObjectId();
+    const parentId = new ObjectId();
     const event = {
-      repetition: { parentId: 'qwertyuiop', frequency: 'every_day' },
+      repetition: { parentId, frequency: 'every_day' },
       startDate: '2019-03-23T09:00:00.000Z',
       type: INTERVENTION,
       customer: customerId,
@@ -867,14 +900,14 @@ describe('updateRepetition', () => {
     };
     const events = [
       {
-        repetition: { parentId: 'qwertyuiop', frequency: 'every_day' },
+        repetition: { parentId, frequency: 'every_day' },
         startDate: '2019-03-23T09:00:00.000Z',
         endDate: '2019-03-23T11:00:00.000Z',
         _id: 'asdfghjk',
         type: INTERVENTION,
       },
       {
-        repetition: { parentId: 'qwertyuiop', frequency: 'every_day' },
+        repetition: { parentId, frequency: 'every_day' },
         startDate: '2019-03-24T09:00:00.000Z',
         endDate: '2019-03-24T11:00:00.000Z',
         type: INTERVENTION,
@@ -882,7 +915,7 @@ describe('updateRepetition', () => {
         _id: '123456',
       },
       {
-        repetition: { parentId: 'qwertyuiop', frequency: 'every_day' },
+        repetition: { parentId, frequency: 'every_day' },
         startDate: '2019-03-25T09:00:00.000Z',
         endDate: '2019-03-25T11:00:00.000Z',
         type: INTERVENTION,
@@ -900,7 +933,7 @@ describe('updateRepetition', () => {
         {
           query: 'find',
           args: [{
-            'repetition.parentId': 'qwertyuiop',
+            'repetition.parentId': parentId,
             'repetition.frequency': { $not: { $eq: 'never' } },
             startDate: { $gt: '2019-03-23T09:00:00.000Z' },
             company: credentials.company._id,
@@ -915,10 +948,7 @@ describe('updateRepetition', () => {
         startDate: '2019-03-23T10:00:00.000Z',
         endDate: '2019-03-23T11:00:00.000Z',
         auxiliary: '1234567890',
-        _id: 'asdfghjk',
-        type: INTERVENTION,
       },
-      payload,
       events[0],
       companyId,
       sectorId
@@ -929,11 +959,7 @@ describe('updateRepetition', () => {
         startDate: '2019-03-24T10:00:00.000Z',
         endDate: '2019-03-24T11:00:00.000Z',
         auxiliary: '1234567890',
-        _id: '123456',
-        type: INTERVENTION,
-        customer: customerId,
       },
-      payload,
       events[1],
       companyId,
       sectorId
@@ -944,19 +970,12 @@ describe('updateRepetition', () => {
         startDate: '2019-03-25T10:00:00.000Z',
         endDate: '2019-03-25T11:00:00.000Z',
         auxiliary: '1234567890',
-        _id: '654321',
-        type: INTERVENTION,
       },
-      payload,
       events[2],
       companyId,
       sectorId
     );
-    sinon.assert.calledWithExactly(
-      updateRepetitions,
-      payload,
-      'qwertyuiop'
-    );
+    sinon.assert.calledWithExactly(updateRepetitions, payload, parentId);
   });
 
   it('should update repetition if event is an internalHour', async () => {
@@ -964,9 +983,9 @@ describe('updateRepetition', () => {
     const credentials = { company: { _id: companyId } };
     const auxiliaryId = new ObjectId();
     const sectorId = new ObjectId();
-    const repetitionId = new ObjectId();
+    const parentId = new ObjectId();
     const event = {
-      repetition: { parentId: repetitionId, frequency: 'every_day' },
+      repetition: { parentId, frequency: 'every_day' },
       startDate: '2019-03-23T09:00:00.000Z',
       type: INTERNAL_HOUR,
       sector: sectorId,
@@ -979,25 +998,25 @@ describe('updateRepetition', () => {
     };
     const events = [
       {
-        repetition: { parentId: repetitionId, frequency: 'every_day' },
+        repetition: { parentId, frequency: 'every_day' },
         startDate: '2019-03-23T09:00:00.000Z',
-        endDate: '2019-03-23T11:00:00.000Z',
+        endDate: '2019-03-23T10:00:00.000Z',
         _id: 'asdfghj',
         type: INTERNAL_HOUR,
         internalHour: 'planning',
       },
       {
-        repetition: { parentId: repetitionId, frequency: 'every_day' },
+        repetition: { parentId, frequency: 'every_day' },
         startDate: '2019-03-24T09:00:00.000Z',
-        endDate: '2019-03-24T11:00:00.000Z',
+        endDate: '2019-03-24T10:00:00.000Z',
         type: INTERNAL_HOUR,
         _id: '12345',
         internalHour: 'planning',
       },
       {
-        repetition: { parentId: repetitionId, frequency: 'every_day' },
+        repetition: { parentId, frequency: 'every_day' },
         startDate: '2019-03-25T09:00:00.000Z',
-        endDate: '2019-03-25T11:00:00.000Z',
+        endDate: '2019-03-25T10:00:00.000Z',
         type: INTERNAL_HOUR,
         internalHour: 'planning',
         _id: '65432',
@@ -1014,7 +1033,7 @@ describe('updateRepetition', () => {
         {
           query: 'find',
           args: [{
-            'repetition.parentId': repetitionId,
+            'repetition.parentId': parentId,
             'repetition.frequency': { $not: { $eq: 'never' } },
             startDate: { $gt: '2019-03-23T09:00:00.000Z' },
             company: credentials.company._id,
@@ -1028,11 +1047,8 @@ describe('updateRepetition', () => {
       {
         startDate: '2019-03-23T09:00:00.000Z',
         endDate: '2019-03-23T11:00:00.000Z',
-        _id: 'asdfghj',
-        type: INTERNAL_HOUR,
         internalHour: 'reunion',
       },
-      payload,
       events[0],
       companyId,
       sectorId
@@ -1042,11 +1058,8 @@ describe('updateRepetition', () => {
       {
         startDate: '2019-03-24T09:00:00.000Z',
         endDate: '2019-03-24T11:00:00.000Z',
-        _id: '12345',
-        type: INTERNAL_HOUR,
         internalHour: 'reunion',
       },
-      payload,
       events[1],
       companyId,
       sectorId
@@ -1056,20 +1069,13 @@ describe('updateRepetition', () => {
       {
         startDate: '2019-03-25T09:00:00.000Z',
         endDate: '2019-03-25T11:00:00.000Z',
-        _id: '65432',
-        type: INTERNAL_HOUR,
         internalHour: 'reunion',
       },
-      payload,
       events[2],
       companyId,
       sectorId
     );
-    sinon.assert.calledWithExactly(
-      updateRepetitions,
-      payload,
-      repetitionId
-    );
+    sinon.assert.calledWithExactly(updateRepetitions, payload, parentId);
   });
 
   it('should update repetition if event is an unavailability', async () => {
@@ -1077,9 +1083,9 @@ describe('updateRepetition', () => {
     const credentials = { company: { _id: companyId } };
     const auxiliaryId = new ObjectId();
     const sectorId = new ObjectId();
-    const repetitionId = new ObjectId();
+    const parentId = new ObjectId();
     const event = {
-      repetition: { parentId: repetitionId, frequency: 'every_day' },
+      repetition: { parentId, frequency: 'every_day' },
       startDate: '2019-03-23T12:00:00.000Z',
       type: UNAVAILABILITY,
       auxiliary: auxiliaryId,
@@ -1090,21 +1096,21 @@ describe('updateRepetition', () => {
     };
     const events = [
       {
-        repetition: { parentId: repetitionId, frequency: 'every_day' },
+        repetition: { parentId, frequency: 'every_day' },
         startDate: '2019-03-23T12:00:00.000Z',
         endDate: '2019-03-23T13:00:00.000Z',
         _id: 'asdfghj',
         type: UNAVAILABILITY,
       },
       {
-        repetition: { parentId: repetitionId, frequency: 'every_day' },
+        repetition: { parentId, frequency: 'every_day' },
         startDate: '2019-03-24T12:00:00.000Z',
         endDate: '2019-03-24T13:00:00.000Z',
         type: UNAVAILABILITY,
         _id: '12345',
       },
       {
-        repetition: { parentId: repetitionId, frequency: 'every_day' },
+        repetition: { parentId, frequency: 'every_day' },
         startDate: '2019-03-25T12:00:00.000Z',
         endDate: '2019-03-25T13:00:00.000Z',
         type: UNAVAILABILITY,
@@ -1122,7 +1128,7 @@ describe('updateRepetition', () => {
         {
           query: 'find',
           args: [{
-            'repetition.parentId': repetitionId,
+            'repetition.parentId': parentId,
             'repetition.frequency': { $not: { $eq: 'never' } },
             startDate: { $gt: '2019-03-23T12:00:00.000Z' },
             company: credentials.company._id,
@@ -1133,48 +1139,26 @@ describe('updateRepetition', () => {
     );
     sinon.assert.calledWithExactly(
       updateEventBelongingToRepetition.getCall(0),
-      {
-        startDate: '2019-03-23T12:30:00.000Z',
-        endDate: '2019-03-23T13:00:00.000Z',
-        _id: 'asdfghj',
-        type: UNAVAILABILITY,
-      },
-      payload,
+      { startDate: '2019-03-23T12:30:00.000Z', endDate: '2019-03-23T13:00:00.000Z' },
       events[0],
       companyId,
       sectorId
     );
     sinon.assert.calledWithExactly(
       updateEventBelongingToRepetition.getCall(1),
-      {
-        startDate: '2019-03-24T12:30:00.000Z',
-        endDate: '2019-03-24T13:00:00.000Z',
-        _id: '12345',
-        type: UNAVAILABILITY,
-      },
-      payload,
+      { startDate: '2019-03-24T12:30:00.000Z', endDate: '2019-03-24T13:00:00.000Z' },
       events[1],
       companyId,
       sectorId
     );
     sinon.assert.calledWithExactly(
       updateEventBelongingToRepetition.getCall(2),
-      {
-        startDate: '2019-03-25T12:30:00.000Z',
-        endDate: '2019-03-25T13:00:00.000Z',
-        _id: '65432',
-        type: UNAVAILABILITY,
-      },
-      payload,
+      { startDate: '2019-03-25T12:30:00.000Z', endDate: '2019-03-25T13:00:00.000Z' },
       events[2],
       companyId,
       sectorId
     );
-    sinon.assert.calledWithExactly(
-      updateRepetitions,
-      payload,
-      repetitionId
-    );
+    sinon.assert.calledWithExactly(updateRepetitions, payload, parentId);
   });
 });
 


### PR DESCRIPTION
<details open><summary> TESTS  :computer: </summary>

- [ ] J'ai codé les tests unitaires
- [ ] J'ai codé les tests d'intégration
- [ ] C'est une ancienne route utilisée par les apps mobiles.
  - [ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens
</details>

- [ ] Je replie cette section car mes modifications n'ont pas besoin de tests unitaires ou d'intégration

---

<details open><summary> POINTS D'ATTENTION POUR CETTE PR  :warning: </summary>

- [x] J'ai fait des modifications sur une route utilisée sur plusieurs plateformes [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/n3bq2hr9Ia)
- [ ] J'ai modifié un modèle utilisé en mobile [Slite de détail] - np (https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/rqTfwpUib)
- [ ] J'ai ajouté un modèle spécifique à une structure -np
  - [ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés
- [ ] J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile -np
  - [ ] Si oui, j'ai précisé sur le [slite de MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) qu'il faut forcer la mise à jour
- [ ] J'ai ajouté une variable d'environnement -np
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

</details>

- [ ] Je replie cette section car je n'ai pas fait de modifications entrainant un point d'attention

---

<details open><summary> FONCTIONNALITÉS APPS MOBILES  :iphone: </summary>

- [ ] Mes changements impactent l'application formation -np
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours
- [x] Mes changements impactent l'application erp
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours

</details>

- [ ] Je replie cette section car mes modifications n'ont pas d'impact sur les applications mobiles

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : auxiliaire / coach / admin

Cas d'usage : résolution de bugs liés a notre nouvelle gestion des répétitions
- l'edition de l'adresse est applicable a la repetition
- si l'utilisateur modifie des champs liés à la repetition (horaires, service, addresse) et d'autres liés a l'évènement seul (note, déplacement vehiculé avec le beneficiaire et mode de transport), toutes le modifications sont bien appliquées

Comment tester ? :

- édition d'une intervention appartenant a une repetition en appliquant les modifs a la repetition
      - si il y a conflit avec un autre evenement --> l'evennement est sorti de la repetition et passé en A affecter
      - si pas de conflit:
            - editer l'horaire + le champ note + le champ déplacement vehiculé + le champ mode de transport
                  - vérifier que les modifs sur les champs note, déplacement vehiculé et mode de transport ne s'applique que sur le 1er évenement de la repetition
                  - vérifier que toutes les autres modifications se sont appliquées a la repetition
- édition d'une intervention appartenant a une repetition en appliquant les modifs a l'evenemnet seul
      - verifier que les modifs sont bien appliquées et que l'évènement est sorti de la repetition
- edition d'une intervention n'appartenant pas a une repetition
- édition d'une heure interne ou d'une indisponibilité appartenant a une repetititon
      - verifier que l'édition d'un evenemnt seul fonctionne
      - verifier que l'édition de tous les evenements de la repetition fonctionne
      - 
_Si tu as lu cette description, pense a réagir avec un :eye:_
