### PR TITLE
Com 2805

### DIFF
--- a/src/helpers/draftBills.js
+++ b/src/helpers/draftBills.js
@@ -1,4 +1,5 @@
 const get = require('lodash/get');
+const pick = require('lodash/get');
 const { ObjectId } = require('mongodb');
 const moment = require('../extensions/moment');
 const EventRepository = require('../repositories/EventRepository');
@@ -357,14 +358,10 @@ exports.formatBillingItems = (eventsByBillingItemBySubscriptions, billingItems, 
       unitExclTaxes,
       unitInclTaxes: bddBillingItem.defaultUnitAmount,
       vat: bddBillingItem.vat,
-      eventsList: eventsList.map(event => (
-        {
-          event: event._id,
-          startDate: event.startDate,
-          endDate: event.endDate,
-          auxiliary: event.auxiliary,
-        }
-      )),
+      eventsList: eventsList.map(event => ({
+        event: event._id,
+        ...pick(event, ['startDate', 'endDate', 'auxiliary']),
+      })),
       exclTaxes: NumbersHelper.oldMultiply(unitExclTaxes, eventsList.length),
       inclTaxes: NumbersHelper.oldMultiply(bddBillingItem.defaultUnitAmount, eventsList.length),
       startDate,

--- a/src/helpers/draftBills.js
+++ b/src/helpers/draftBills.js
@@ -376,13 +376,19 @@ exports.formatCustomerBills = (customerBills, tppBills, query, customer) => {
   const groupedByCustomerBills = {
     customer,
     endDate: query.endDate,
-    customerBills: { bills: customerBills, total: UtilsHelper.sumReduce(customerBills, 'inclTaxes') },
+    customerBills: {
+      bills: customerBills,
+      total: NumbersHelper.toFixed(UtilsHelper.sumReduce(customerBills, 'inclTaxes')),
+    },
   };
 
   if (Object.values(tppBills).length) {
     groupedByCustomerBills.thirdPartyPayerBills = [];
     for (const bills of Object.values(tppBills)) {
-      groupedByCustomerBills.thirdPartyPayerBills.push({ bills, total: UtilsHelper.sumReduce(bills, 'inclTaxes') });
+      groupedByCustomerBills.thirdPartyPayerBills.push({
+        bills,
+        total: NumbersHelper.toFixed(UtilsHelper.sumReduce(bills, 'inclTaxes'))
+      });
     }
   }
 

--- a/src/helpers/draftBills.js
+++ b/src/helpers/draftBills.js
@@ -69,21 +69,19 @@ exports.populateFundings = async (fundings, endDate, tppList, companyId) => {
 
 // returns a string
 exports.getSurchargedPrice = (event, eventSurcharges, price) => {
-  let coeff = NumbersHelper.toString(1);
   const eventDuration = moment(event.endDate).diff(event.startDate, 'm');
+  let coeff = NumbersHelper.multiply(eventDuration, 100);
 
   for (const surcharge of eventSurcharges) {
-    const percentage = NumbersHelper.divide(surcharge.percentage, 100);
     if (surcharge.startHour) {
       const surchargedDuration = moment(surcharge.endHour).diff(surcharge.startHour, 'm');
-      const surchargedRatio = NumbersHelper.divide(surchargedDuration, eventDuration);
-      coeff = NumbersHelper.add(coeff, NumbersHelper.multiply(surchargedRatio, percentage));
+      coeff = NumbersHelper.add(coeff, NumbersHelper.multiply(surchargedDuration, surcharge.percentage));
     } else {
-      coeff = NumbersHelper.add(coeff, percentage);
+      coeff = NumbersHelper.add(coeff, NumbersHelper.multiply(surcharge.percentage, eventDuration));
     }
   }
 
-  return NumbersHelper.multiply(coeff, price);
+  return NumbersHelper.divide(NumbersHelper.multiply(coeff, price), NumbersHelper.multiply(eventDuration, 100));
 };
 
 // returns a string

--- a/src/helpers/draftBills.js
+++ b/src/helpers/draftBills.js
@@ -1,5 +1,5 @@
 const get = require('lodash/get');
-const pick = require('lodash/get');
+const pick = require('lodash/pick');
 const { ObjectId } = require('mongodb');
 const moment = require('../extensions/moment');
 const EventRepository = require('../repositories/EventRepository');
@@ -67,7 +67,13 @@ exports.populateFundings = async (fundings, endDate, tppList, companyId) => {
   return populatedFundings;
 };
 
-// returns a string
+/**
+ *
+ * @param {object} event
+ * @param {array} eventSurcharges
+ * @param {string} price
+ * @returns string
+ */
 exports.getSurchargedPrice = (event, eventSurcharges, price) => {
   const eventDuration = moment(event.endDate).diff(event.startDate, 'm');
   let coeff = NumbersHelper.multiply(eventDuration, 100);
@@ -84,7 +90,13 @@ exports.getSurchargedPrice = (event, eventSurcharges, price) => {
   return NumbersHelper.divide(NumbersHelper.multiply(coeff, price), NumbersHelper.multiply(eventDuration, 100));
 };
 
-// returns a string
+/**
+ *
+ * @param {string} time
+ * @param {number} fundingInclTaxes
+ * @param {number} customerParticipationRate
+ * @returns string
+ */
 exports.getThirdPartyPayerPrice = (time, fundingInclTaxes, customerParticipationRate) => {
   const tppParticipationRate = NumbersHelper.subtract(1, NumbersHelper.divide(customerParticipationRate, 100));
 
@@ -108,6 +120,13 @@ exports.getMatchingHistory = (event, funding) => {
   return history;
 };
 
+/**
+ *
+ * @param {object} event
+ * @param {object} funding
+ * @param {string} price
+ * @returns object
+ */
 exports.getHourlyFundingSplit = (event, funding, price) => {
   let thirdPartyPayerPrice = NumbersHelper.toString(0);
   const time = moment(event.endDate).diff(moment(event.startDate), 'm');
@@ -144,6 +163,13 @@ exports.getHourlyFundingSplit = (event, funding, price) => {
   };
 };
 
+/**
+ *
+ * @param {object} event
+ * @param {object} funding
+ * @param {string} price
+ * @returns object
+ */
 exports.getFixedFundingSplit = (event, funding, price) => {
   let thirdPartyPayerPrice = NumbersHelper.toString(0);
   if (funding.history && funding.history[0].amountTTC < funding.amountTTC) {

--- a/src/helpers/draftBills.js
+++ b/src/helpers/draftBills.js
@@ -63,31 +63,34 @@ exports.populateFundings = async (fundings, endDate, tppList, companyId) => {
     }
     populatedFundings.push(funding);
   }
+
   return populatedFundings;
 };
 
+// returns a string
 exports.getSurchargedPrice = (event, eventSurcharges, price) => {
-  let coeff = 1;
+  let coeff = NumbersHelper.toString(1);
   const eventDuration = moment(event.endDate).diff(event.startDate, 'm');
 
   for (const surcharge of eventSurcharges) {
-    const percentage = NumbersHelper.oldDivide(surcharge.percentage, 100);
+    const percentage = NumbersHelper.divide(surcharge.percentage, 100);
     if (surcharge.startHour) {
       const surchargedDuration = moment(surcharge.endHour).diff(surcharge.startHour, 'm');
-      const surchargedRatio = NumbersHelper.oldDivide(surchargedDuration, eventDuration);
-      coeff = NumbersHelper.oldAdd(coeff, NumbersHelper.oldMultiply(surchargedRatio, percentage));
+      const surchargedRatio = NumbersHelper.divide(surchargedDuration, eventDuration);
+      coeff = NumbersHelper.add(coeff, NumbersHelper.multiply(surchargedRatio, percentage));
     } else {
-      coeff = NumbersHelper.oldAdd(coeff, percentage);
+      coeff = NumbersHelper.add(coeff, percentage);
     }
   }
 
-  return NumbersHelper.oldMultiply(coeff, price);
+  return NumbersHelper.multiply(coeff, price);
 };
 
+// returns a string
 exports.getThirdPartyPayerPrice = (time, fundingInclTaxes, customerParticipationRate) => {
-  const tppParticipationRate = NumbersHelper.oldSubtract(1, NumbersHelper.oldDivide(customerParticipationRate, 100));
+  const tppParticipationRate = NumbersHelper.subtract(1, NumbersHelper.divide(customerParticipationRate, 100));
 
-  return NumbersHelper.oldMultiply(NumbersHelper.oldDivide(time, 60), fundingInclTaxes, tppParticipationRate);
+  return NumbersHelper.multiply(NumbersHelper.divide(time, 60), fundingInclTaxes, tppParticipationRate);
 };
 
 exports.getMatchingHistory = (event, funding) => {
@@ -103,35 +106,36 @@ exports.getMatchingHistory = (event, funding) => {
     month: moment(event.startDate).format('MM/YYYY'),
   });
   history = funding.history.find(his => his.month === moment(event.startDate).format('MM/YYYY'));
+
   return history;
 };
 
 exports.getHourlyFundingSplit = (event, funding, price) => {
-  let thirdPartyPayerPrice = 0;
+  let thirdPartyPayerPrice = NumbersHelper.toString(0);
   const time = moment(event.endDate).diff(moment(event.startDate), 'm');
   const history = exports.getMatchingHistory(event, funding);
 
-  let chargedTime = 0;
+  let chargedTime = NumbersHelper.toString(0);
   if (history && history.careHours < funding.careHours) {
-    const totalCareHours = NumbersHelper.oldAdd(history.careHours, NumbersHelper.oldDivide(time, 60));
-    chargedTime = totalCareHours > funding.careHours
-      ? NumbersHelper.oldMultiply(NumbersHelper.oldSubtract(funding.careHours, history.careHours), 60)
-      : time;
+    const totalCareHours = NumbersHelper.add(history.careHours, NumbersHelper.divide(time, 60));
+    chargedTime = NumbersHelper.isGreaterThan(totalCareHours, funding.careHours)
+      ? NumbersHelper.multiply(NumbersHelper.subtract(funding.careHours, history.careHours), 60)
+      : NumbersHelper.toString(time);
     thirdPartyPayerPrice = exports.getThirdPartyPayerPrice(
       chargedTime,
       funding.unitTTCRate,
       funding.customerParticipationRate
     );
-    history.careHours = totalCareHours > funding.careHours
+    history.careHours = NumbersHelper.isGreaterThan(totalCareHours, funding.careHours)
       ? funding.careHours
-      : NumbersHelper.oldAdd(history.careHours, NumbersHelper.oldDivide(chargedTime, 60));
+      : parseFloat(NumbersHelper.add(history.careHours, NumbersHelper.divide(chargedTime, 60)));
   }
 
   return {
-    customerPrice: NumbersHelper.oldSubtract(price, thirdPartyPayerPrice),
+    customerPrice: NumbersHelper.subtract(price, thirdPartyPayerPrice),
     thirdPartyPayerPrice,
     history: {
-      careHours: NumbersHelper.oldDivide(chargedTime, 60),
+      careHours: NumbersHelper.divide(chargedTime, 60),
       fundingId: funding._id,
       nature: funding.nature,
       ...(funding.frequency === MONTHLY && { month: moment(event.startDate).format('MM/YYYY') }),
@@ -143,14 +147,14 @@ exports.getHourlyFundingSplit = (event, funding, price) => {
 };
 
 exports.getFixedFundingSplit = (event, funding, price) => {
-  let thirdPartyPayerPrice = 0;
+  let thirdPartyPayerPrice = NumbersHelper.toString(0);
   if (funding.history && funding.history[0].amountTTC < funding.amountTTC) {
     const history = funding.history[0];
-    if (NumbersHelper.oldAdd(history.amountTTC, price) < funding.amountTTC) {
+    if (NumbersHelper.isLessThan(NumbersHelper.add(history.amountTTC, price), funding.amountTTC)) {
       thirdPartyPayerPrice = price;
-      history.amountTTC = NumbersHelper.oldAdd(history.amountTTC, thirdPartyPayerPrice);
+      history.amountTTC = parseFloat(NumbersHelper.add(history.amountTTC, thirdPartyPayerPrice));
     } else {
-      thirdPartyPayerPrice = NumbersHelper.oldSubtract(funding.amountTTC, history.amountTTC);
+      thirdPartyPayerPrice = NumbersHelper.subtract(funding.amountTTC, history.amountTTC);
       history.amountTTC = funding.amountTTC;
     }
   }
@@ -158,7 +162,7 @@ exports.getFixedFundingSplit = (event, funding, price) => {
   const chargedTime = moment(event.endDate).diff(moment(event.startDate), 'm');
 
   return {
-    customerPrice: NumbersHelper.oldSubtract(price, thirdPartyPayerPrice),
+    customerPrice: NumbersHelper.subtract(price, thirdPartyPayerPrice),
     thirdPartyPayerPrice,
     history: { amountTTC: thirdPartyPayerPrice, fundingId: funding._id, nature: funding.nature },
     fundingId: funding._id,
@@ -169,8 +173,10 @@ exports.getFixedFundingSplit = (event, funding, price) => {
 
 exports.getEventBilling = (event, unitTTCRate, service, funding) => {
   const billing = {};
-  const eventDuration = NumbersHelper.oldDivide(moment(event.endDate).diff(moment(event.startDate), 'm'), 60);
-  let price = service.nature === HOURLY ? NumbersHelper.oldMultiply(eventDuration, unitTTCRate) : unitTTCRate;
+  const eventDuration = NumbersHelper.divide(moment(event.endDate).diff(moment(event.startDate), 'm'), 60);
+  let price = service.nature === HOURLY
+    ? NumbersHelper.multiply(eventDuration, unitTTCRate)
+    : NumbersHelper.toString(unitTTCRate);
 
   if (service.surcharge && service.nature === HOURLY) {
     const surcharges = SurchargesHelper.getEventSurcharges(event, service.surcharge);
@@ -188,7 +194,7 @@ exports.getEventBilling = (event, unitTTCRate, service, funding) => {
     return { ...billing, ...fundingBilling };
   }
 
-  return { ...billing, customerPrice: price, thirdPartyPayerPrice: 0 };
+  return { ...billing, customerPrice: price, thirdPartyPayerPrice: NumbersHelper.toString(0) };
 };
 
 exports.formatDraftBillsForCustomer = (customerPrices, event, eventPrice, service) => {
@@ -214,14 +220,20 @@ exports.formatDraftBillsForCustomer = (customerPrices, event, eventPrice, servic
 
   return {
     eventsList: [...customerPrices.eventsList, { ...prices }],
-    hours: NumbersHelper.oldAdd(customerPrices.hours, NumbersHelper.oldDivide(eventDuration, 60)),
-    exclTaxes: NumbersHelper.oldAdd(customerPrices.exclTaxes, exclTaxesCustomer),
-    inclTaxes: NumbersHelper.oldAdd(customerPrices.inclTaxes, eventPrice.customerPrice),
+    hours: NumbersHelper.add(customerPrices.hours, NumbersHelper.divide(eventDuration, 60)),
+    exclTaxes: NumbersHelper.add(customerPrices.exclTaxes, exclTaxesCustomer),
+    inclTaxes: NumbersHelper.add(customerPrices.inclTaxes, eventPrice.customerPrice),
   };
 };
 
 exports.formatDraftBillsForTPP = (tppPrices, tpp, event, eventPrice, service) => {
-  const currentTppPrices = tppPrices[tpp._id] || { exclTaxes: 0, inclTaxes: 0, hours: 0, eventsList: [] };
+  const currentTppPrices = tppPrices[tpp._id] ||
+    {
+      exclTaxes: NumbersHelper.toString(0),
+      inclTaxes: NumbersHelper.toString(0),
+      hours: NumbersHelper.toString(0),
+      eventsList: [],
+    };
 
   const exclTaxesTpp = UtilsHelper.getExclTaxes(eventPrice.thirdPartyPayerPrice, service.vat);
   const prices = {
@@ -242,16 +254,21 @@ exports.formatDraftBillsForTPP = (tppPrices, tpp, event, eventPrice, service) =>
   return {
     ...tppPrices,
     [tpp._id]: {
-      exclTaxes: NumbersHelper.oldAdd(currentTppPrices.exclTaxes, exclTaxesTpp),
-      inclTaxes: NumbersHelper.oldAdd(currentTppPrices.inclTaxes, eventPrice.thirdPartyPayerPrice),
-      hours: NumbersHelper.oldAdd(currentTppPrices.hours, NumbersHelper.oldDivide(eventPrice.chargedTime, 60)),
+      exclTaxes: NumbersHelper.add(currentTppPrices.exclTaxes, exclTaxesTpp),
+      inclTaxes: NumbersHelper.add(currentTppPrices.inclTaxes, eventPrice.thirdPartyPayerPrice),
+      hours: NumbersHelper.add(currentTppPrices.hours, NumbersHelper.divide(eventPrice.chargedTime, 60)),
       eventsList: [...currentTppPrices.eventsList, { ...prices }],
     },
   };
 };
 
 exports.computeBillingInfoForEvents = (events, service, fundings, billingStartDate, unitTTCRate) => {
-  let customerPrices = { exclTaxes: 0, inclTaxes: 0, hours: 0, eventsList: [] };
+  let customerPrices = {
+    exclTaxes: NumbersHelper.toString(0),
+    inclTaxes: NumbersHelper.toString(0),
+    hours: NumbersHelper.toString(0),
+    eventsList: [],
+  };
   let thirdPartyPayerPrices = {};
   let startDate = moment(billingStartDate);
   const eventsByBillingItem = {};
@@ -302,12 +319,14 @@ exports.getDraftBillsPerSubscription = (events, subscription, fundings, billingS
     startDate: startDate.toDate(),
     endDate: moment(endDate, 'YYYYMMDD').toDate(),
     unitExclTaxes: UtilsHelper.getExclTaxes(unitTTCRate, serviceMatchingVersion.vat),
-    unitInclTaxes: unitTTCRate,
+    unitInclTaxes: NumbersHelper.toString(unitTTCRate),
     vat: serviceMatchingVersion.vat || 0,
   };
 
   const draftBillsPerSubscription = {};
-  if (customerPrices.exclTaxes !== 0) draftBillsPerSubscription.customer = { ...draftBillInfo, ...customerPrices };
+  if (!NumbersHelper.isEqualTo(customerPrices.exclTaxes, 0)) {
+    draftBillsPerSubscription.customer = { ...draftBillInfo, ...customerPrices };
+  }
   if (fundings && Object.keys(thirdPartyPayerPrices).length !== 0) {
     draftBillsPerSubscription.thirdPartyPayer = Object.keys(thirdPartyPayerPrices).reduce(
       (acc, tppId) => ({
@@ -356,14 +375,11 @@ exports.formatBillingItems = (eventsByBillingItemBySubscriptions, billingItems, 
       billingItem: { _id: new ObjectId(billingItemId), name: bddBillingItem.name },
       discount: 0,
       unitExclTaxes,
-      unitInclTaxes: bddBillingItem.defaultUnitAmount,
+      unitInclTaxes: NumbersHelper.toString(bddBillingItem.defaultUnitAmount),
       vat: bddBillingItem.vat,
-      eventsList: eventsList.map(event => ({
-        event: event._id,
-        ...pick(event, ['startDate', 'endDate', 'auxiliary']),
-      })),
-      exclTaxes: NumbersHelper.oldMultiply(unitExclTaxes, eventsList.length),
-      inclTaxes: NumbersHelper.oldMultiply(bddBillingItem.defaultUnitAmount, eventsList.length),
+      eventsList: eventsList.map(ev => ({ event: ev._id, ...pick(ev, ['startDate', 'endDate', 'auxiliary']) })),
+      exclTaxes: NumbersHelper.multiply(unitExclTaxes, eventsList.length),
+      inclTaxes: NumbersHelper.multiply(bddBillingItem.defaultUnitAmount, eventsList.length),
       startDate,
       endDate,
     });
@@ -387,7 +403,7 @@ exports.formatCustomerBills = (customerBills, tppBills, query, customer) => {
     for (const bills of Object.values(tppBills)) {
       groupedByCustomerBills.thirdPartyPayerBills.push({
         bills,
-        total: NumbersHelper.toFixed(UtilsHelper.sumReduce(bills, 'inclTaxes'))
+        total: NumbersHelper.toFixed(UtilsHelper.sumReduce(bills, 'inclTaxes')),
       });
     }
   }

--- a/src/helpers/numbers.js
+++ b/src/helpers/numbers.js
@@ -1,7 +1,5 @@
 const { BigNumber } = require('bignumber.js');
 
-exports.toBN = a => BigNumber(a);
-
 exports.toString = a => BigNumber(a).toString();
 
 exports.toFixed = (a, decimalPlaces = 2) => parseFloat(BigNumber(a).toFixed(decimalPlaces));

--- a/src/helpers/numbers.js
+++ b/src/helpers/numbers.js
@@ -1,9 +1,19 @@
 const { BigNumber } = require('bignumber.js');
 
+exports.toBN = a => BigNumber(a);
+
 exports.oldMultiply = (...nums) => nums.reduce((acc, n) => BigNumber(acc).multipliedBy(n).toNumber(), 1);
+
+exports.multiply = (...nums) => nums.reduce((acc, n) => BigNumber(acc).multipliedBy(n).toString(), 1);
 
 exports.oldDivide = (a, b) => BigNumber(a).dividedBy(b).toNumber();
 
+exports.divide = (a, b) => BigNumber(a).dividedBy(b).toString();
+
 exports.oldAdd = (...nums) => nums.reduce((acc, n) => BigNumber(acc).plus(n).toNumber(), 0);
 
+exports.add = (...nums) => nums.reduce((acc, n) => BigNumber(acc).plus(n).toString(), 0);
+
 exports.oldSubtract = (a, b) => BigNumber(a).minus(b).toNumber();
+
+exports.subtract = (a, b) => BigNumber(a).minus(b).toString();

--- a/src/helpers/numbers.js
+++ b/src/helpers/numbers.js
@@ -2,6 +2,8 @@ const { BigNumber } = require('bignumber.js');
 
 exports.toBN = a => BigNumber(a);
 
+exports.toFixed = (a, decimalPlaces = 2) => parseFloat(BigNumber(a).toFixed(decimalPlaces));
+
 exports.oldMultiply = (...nums) => nums.reduce((acc, n) => BigNumber(acc).multipliedBy(n).toNumber(), 1);
 
 exports.multiply = (...nums) => nums.reduce((acc, n) => BigNumber(acc).multipliedBy(n).toString(), 1);

--- a/src/helpers/numbers.js
+++ b/src/helpers/numbers.js
@@ -2,6 +2,8 @@ const { BigNumber } = require('bignumber.js');
 
 exports.toBN = a => BigNumber(a);
 
+exports.toString = a => BigNumber(a).toString();
+
 exports.toFixed = (a, decimalPlaces = 2) => parseFloat(BigNumber(a).toFixed(decimalPlaces));
 
 exports.oldMultiply = (...nums) => nums.reduce((acc, n) => BigNumber(acc).multipliedBy(n).toNumber(), 1);
@@ -19,3 +21,9 @@ exports.add = (...nums) => nums.reduce((acc, n) => BigNumber(acc).plus(n).toStri
 exports.oldSubtract = (a, b) => BigNumber(a).minus(b).toNumber();
 
 exports.subtract = (a, b) => BigNumber(a).minus(b).toString();
+
+exports.isGreaterThan = (a, b) => BigNumber(a).isGreaterThan(b);
+
+exports.isLessThan = (a, b) => BigNumber(a).isLessThan(b);
+
+exports.isEqualTo = (a, b) => BigNumber(a).isEqualTo(b);

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -193,7 +193,7 @@ exports.getExclTaxes = (inclTaxes, vat) => {
   return NumbersHelper.divide(inclTaxes, decimalVat);
 };
 
-exports.sumReduce = (array, key) => array.reduce((sum, b) => NumbersHelper.oldAdd(sum, (b[key] || 0)), 0);
+exports.sumReduce = (array, key) => array.reduce((sum, b) => NumbersHelper.add(sum, (b[key] || 0)), 0);
 
 exports.computeExclTaxesWithDiscount = (exclTaxes, discount, vat) => {
   if (!discount) return exclTaxes;

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -184,20 +184,13 @@ exports.computeHoursWithDiff = (pay, key) => {
   return hours + diff;
 };
 
+// Returns a string
 exports.getExclTaxes = (inclTaxes, vat) => {
   if (!vat) return inclTaxes;
 
-  const decimalVat = NumbersHelper.oldAdd(1, NumbersHelper.oldDivide(vat, 100));
+  const decimalVat = NumbersHelper.add(1, NumbersHelper.divide(vat, 100));
 
-  return NumbersHelper.oldDivide(inclTaxes, decimalVat);
-};
-
-exports.getInclTaxes = (exclTaxes, vat) => {
-  if (!vat) return exclTaxes;
-
-  const decimalVat = NumbersHelper.oldAdd(1, NumbersHelper.oldDivide(vat, 100));
-
-  return NumbersHelper.oldMultiply(exclTaxes, decimalVat);
+  return NumbersHelper.divide(inclTaxes, decimalVat);
 };
 
 exports.sumReduce = (array, key) => array.reduce((sum, b) => NumbersHelper.oldAdd(sum, (b[key] || 0)), 0);

--- a/tests/unit/helpers/bills.test.js
+++ b/tests/unit/helpers/bills.test.js
@@ -2241,20 +2241,20 @@ describe('formatBillDetailsForPdf', () => {
   let computeSurcharge;
   let formatPrice;
   let formatHour;
-  let getExclTaxes;
+  let computeExclTaxesWithDiscount;
   beforeEach(() => {
     getUnitInclTaxes = sinon.stub(BillHelper, 'getUnitInclTaxes');
     computeSurcharge = sinon.stub(BillHelper, 'computeSurcharge');
     formatPrice = sinon.stub(UtilsHelper, 'formatPrice');
     formatHour = sinon.stub(UtilsHelper, 'formatHour');
-    getExclTaxes = sinon.stub(UtilsHelper, 'getExclTaxes');
+    computeExclTaxesWithDiscount = sinon.stub(UtilsHelper, 'computeExclTaxesWithDiscount');
   });
   afterEach(() => {
     getUnitInclTaxes.restore();
     computeSurcharge.restore();
     formatPrice.restore();
     formatHour.restore();
-    getExclTaxes.restore();
+    computeExclTaxesWithDiscount.restore();
   });
 
   it('should return formatted details if service.nature is hourly', () => {
@@ -2276,7 +2276,7 @@ describe('formatBillDetailsForPdf', () => {
     computeSurcharge.returns(0);
     formatPrice.onCall(0).returns('430,54 €');
     formatPrice.onCall(1).returns('23,68 €');
-    getExclTaxes.returns(0);
+    computeExclTaxesWithDiscount.returns(430.5444);
 
     const formattedBillDetails = BillHelper.formatBillDetailsForPdf(bill);
 
@@ -2339,9 +2339,9 @@ describe('formatBillDetailsForPdf', () => {
     computeSurcharge.returns(12.24);
     formatPrice.onCall(0).returns('20,30 €');
     formatPrice.onCall(1).returns('1,70 €');
-    getExclTaxes.onCall(0).returns(4.739336);
-    getExclTaxes.onCall(1).returns(9.090909);
-    getExclTaxes.onCall(2).returns(0);
+    computeExclTaxesWithDiscount.onCall(0).returns(15.560664);
+    computeExclTaxesWithDiscount.onCall(1).returns(18.179091);
+    computeExclTaxesWithDiscount.onCall(2).returns(8.33);
 
     const formattedBillDetails = BillHelper.formatBillDetailsForPdf(bill);
 

--- a/tests/unit/helpers/draftbills.test.js
+++ b/tests/unit/helpers/draftbills.test.js
@@ -583,14 +583,14 @@ describe('formatDraftBillsForCustomer', () => {
     const service = { vat: 20 };
     const eventPrice = { customerPrice: 21 };
 
-    getExclTaxes.returns(17.5);
+    getExclTaxes.returns('17.5');
 
     const result = DraftBillsHelper.formatDraftBillsForCustomer(customerPrices, event, eventPrice, service);
 
     expect(result).toMatchObject({
       eventsList: [
         { event: '123456' },
-        { event: 'abc', inclTaxesCustomer: 21, exclTaxesCustomer: 17.5 },
+        { event: 'abc', inclTaxesCustomer: 21, exclTaxesCustomer: '17.5' },
       ],
       hours: 5,
       exclTaxes: 37.5,
@@ -605,14 +605,14 @@ describe('formatDraftBillsForCustomer', () => {
     const service = { vat: 20 };
     const eventPrice = { customerPrice: 21, surcharges: [{ name: 'test' }] };
 
-    getExclTaxes.returns(17.5);
+    getExclTaxes.returns('17.5');
 
     const result = DraftBillsHelper.formatDraftBillsForCustomer(customerPrices, event, eventPrice, service);
 
     expect(result).toMatchObject({
       eventsList: [
         { event: '123456' },
-        { event: 'abc', inclTaxesCustomer: 21, exclTaxesCustomer: 17.5, surcharges: [{ name: 'test' }] },
+        { event: 'abc', inclTaxesCustomer: 21, exclTaxesCustomer: '17.5', surcharges: [{ name: 'test' }] },
       ],
       hours: 5,
       exclTaxes: 37.5,
@@ -626,8 +626,8 @@ describe('formatDraftBillsForCustomer', () => {
     const event = { _id: 'abc', startDate: '2019-02-12T08:00:00.000Z', endDate: '2019-02-12T10:00:00.000Z' };
     const service = { vat: 20 };
     const eventPrice = { customerPrice: 21, thirdPartyPayerPrice: 15, thirdPartyPayer: 'tpp' };
-    getExclTaxes.onCall(0).returns(17.5);
-    getExclTaxes.onCall(1).returns(12.5);
+    getExclTaxes.onCall(0).returns('17.5');
+    getExclTaxes.onCall(1).returns('12.5');
 
     const result = DraftBillsHelper.formatDraftBillsForCustomer(customerPrices, event, eventPrice, service);
 
@@ -637,8 +637,8 @@ describe('formatDraftBillsForCustomer', () => {
         {
           event: 'abc',
           inclTaxesCustomer: 21,
-          exclTaxesCustomer: 17.5,
-          exclTaxesTpp: 12.5,
+          exclTaxesCustomer: '17.5',
+          exclTaxesTpp: '12.5',
           inclTaxesTpp: 15,
           thirdPartyPayer: 'tpp',
         },
@@ -905,8 +905,8 @@ describe('formatDraftBillsForTPP', () => {
       chargedTime: 120,
     };
     const service = { vat: 20 };
-    getExclTaxes.onCall(0).returns(10);
-    getExclTaxes.onCall(1).returns(17.5);
+    getExclTaxes.onCall(0).returns('10');
+    getExclTaxes.onCall(1).returns('17.5');
 
     const result = DraftBillsHelper.formatDraftBillsForTPP(tppPrices, tpp, event, eventPrice, service);
 
@@ -918,10 +918,10 @@ describe('formatDraftBillsForTPP', () => {
       {
         event: 'abc',
         inclTaxesTpp: 12.5,
-        exclTaxesTpp: 10,
+        exclTaxesTpp: '10',
         thirdPartyPayer: tppId,
         inclTaxesCustomer: 21,
-        exclTaxesCustomer: 17.5,
+        exclTaxesCustomer: '17.5',
       },
     ]);
   });
@@ -962,7 +962,7 @@ describe('getDraftBillsPerSubscription', () => {
 
     getLastVersion.returns({ startDate: new Date('2019/01/01'), unitTTCRate: 21 });
     getMatchingVersion.returns({ startDate: new Date('2019/01/01'), vat: 20 });
-    getExclTaxes.returns(70);
+    getExclTaxes.returns('70');
     computeBillingInfoForEvents.returns({
       prices: {
         customerPrices: { exclTaxes: 35 },
@@ -976,7 +976,7 @@ describe('getDraftBillsPerSubscription', () => {
       DraftBillsHelper.getDraftBillsPerSubscription(events, subscription, fundings, '2019/02/01', '2019/03/01');
 
     expect(result.customer.exclTaxes).toEqual(35);
-    expect(result.customer.unitExclTaxes).toEqual(70);
+    expect(result.customer.unitExclTaxes).toEqual('70');
     expect(result.customer.unitInclTaxes).toEqual(21);
     expect(result.thirdPartyPayer[tppId].hours).toEqual(3);
     expect(result.eventsByBillingItem).toEqual([{ d00000000000000000000001: [events[0]._id] }]);
@@ -1008,7 +1008,7 @@ describe('getDraftBillsPerSubscription', () => {
 
     getLastVersion.returns({ startDate: new Date('2019/01/01'), unitTTCRate: 21 });
     getMatchingVersion.returns({ startDate: new Date('2019/01/01'), vat: 20 });
-    getExclTaxes.returns(70);
+    getExclTaxes.returns('70');
     computeBillingInfoForEvents.returns({
       prices: { customerPrices: { exclTaxes: 35 }, startDate: moment('2019/02/01', 'YY/MM/DD') },
       eventsByBillingItem: [],
@@ -1018,7 +1018,7 @@ describe('getDraftBillsPerSubscription', () => {
       DraftBillsHelper.getDraftBillsPerSubscription(events, subscription, null, '2019/02/01', '2019/03/01');
 
     expect(result.customer.exclTaxes).toEqual(35);
-    expect(result.customer.unitExclTaxes).toEqual(70);
+    expect(result.customer.unitExclTaxes).toEqual('70');
     expect(result.customer.unitInclTaxes).toEqual(21);
     expect(result.eventsByBillingItem).toEqual([]);
     sinon.assert.calledOnceWithExactly(
@@ -1051,7 +1051,7 @@ describe('getDraftBillsPerSubscription', () => {
 
     getLastVersion.returns({ startDate: new Date('2019/01/01'), unitTTCRate: 21 });
     getMatchingVersion.returns({ startDate: new Date('2019/01/01'), vat: 20 });
-    getExclTaxes.returns(70);
+    getExclTaxes.returns('70');
     computeBillingInfoForEvents.returns({
       prices: {
         customerPrices: { exclTaxes: 0 },
@@ -1140,7 +1140,7 @@ describe('formatBillingItems', () => {
       expect.objectContaining({
         billingItem: { _id: new ObjectId('d00000000000000000000001'), name: 'FI' },
         discount: 0,
-        unitExclTaxes: 0.9090909090909091,
+        unitExclTaxes: '0.90909090909090909091',
         unitInclTaxes: 1,
         vat: 10,
         eventsList: [{ event: eventId1 }, { event: eventId2 }, { event: eventId3 }],
@@ -1152,7 +1152,7 @@ describe('formatBillingItems', () => {
       expect.objectContaining({
         billingItem: { _id: new ObjectId('d00000000000000000000002'), name: 'EPI' },
         discount: 0,
-        unitExclTaxes: 4.545454545454546,
+        unitExclTaxes: '4.54545454545454545455',
         unitInclTaxes: 5,
         vat: 10,
         eventsList: [{ event: eventId1 }, { event: eventId2 }],

--- a/tests/unit/helpers/draftbills.test.js
+++ b/tests/unit/helpers/draftbills.test.js
@@ -225,15 +225,19 @@ describe('populateFundings', () => {
 });
 
 describe('getSurchargedPrice', () => {
-  const event = { startDate: '2019-06-29T10:00:00', endDate: '2019-06-29T16:00:00' };
+  const event = { startDate: '2019-06-29T10:00:00.000Z', endDate: '2019-06-29T16:00:00.000Z' };
 
   it('should return the price if there is no surcharge', () => {
-    expect(DraftBillsHelper.getSurchargedPrice(event, [], 11)).toBe('11');
+    const result = DraftBillsHelper.getSurchargedPrice(event, [], 11);
+
+    expect(result).toBe('11');
   });
 
   it('should return the price surcharged globally', () => {
     const surcharges = [{ percentage: 25 }];
-    expect(DraftBillsHelper.getSurchargedPrice(event, surcharges, 10)).toBe('12.5');
+    const result = DraftBillsHelper.getSurchargedPrice(event, surcharges, 10);
+
+    expect(result).toBe('12.5');
   });
 
   it('should return the price surcharged once', () => {
@@ -242,15 +246,19 @@ describe('getSurchargedPrice', () => {
       startHour: moment(event.startDate).add(1, 'h'),
       endHour: moment(event.startDate).add(2, 'h'),
     }];
-    expect(DraftBillsHelper.getSurchargedPrice(event, surcharges, 24)).toBe('25');
+    const result = DraftBillsHelper.getSurchargedPrice(event, surcharges, 24);
+
+    expect(result).toBe('25');
   });
 
-  it('should return the price surcharged twice #tag', () => {
+  it('should return the price surcharged twice', () => {
     const surcharges = [
       { percentage: 25, startHour: '2019-06-29T11:00:00', endHour: '2019-06-29T12:00:00' },
       { percentage: 20, startHour: '2019-06-29T12:00:00', endHour: '2019-06-29T14:00:00' },
     ];
-    expect(DraftBillsHelper.getSurchargedPrice(event, surcharges, 24)).toBe('26.6');
+    const result = DraftBillsHelper.getSurchargedPrice(event, surcharges, 24);
+
+    expect(result).toBe('26.6');
   });
 });
 
@@ -1105,7 +1113,7 @@ describe('formatBillingItems', () => {
     const eventsByBillingItemBySubscriptions = [
       {
         d00000000000000000000001: [{ _id: eventId1, fieldToOmit: 'test' }, { _id: eventId2 }],
-        d00000000000000000000002: [{ _id: eventId1 }, { _id: eventId2 }],
+        d00000000000000000000002: [{ _id: eventId1, auxiliary: '1234567' }, { _id: eventId2 }],
       },
       { d00000000000000000000001: [{ _id: eventId3 }] },
     ];
@@ -1158,7 +1166,7 @@ describe('formatBillingItems', () => {
         unitExclTaxes: '4.54545454545454545455',
         unitInclTaxes: '5',
         vat: 10,
-        eventsList: [{ event: eventId1 }, { event: eventId2 }],
+        eventsList: [{ event: eventId1, auxiliary: '1234567' }, { event: eventId2 }],
         exclTaxes: '9.0909090909090909091',
         inclTaxes: '10',
         startDate: '2019-12-31T07:00:00',

--- a/tests/unit/helpers/draftbills.test.js
+++ b/tests/unit/helpers/draftbills.test.js
@@ -225,18 +225,15 @@ describe('populateFundings', () => {
 });
 
 describe('getSurchargedPrice', () => {
-  const event = {
-    startDate: '2019-06-29T10:00:00.000+02:00',
-    endDate: '2019-06-29T16:00:00.000+02:00',
-  };
+  const event = { startDate: '2019-06-29T10:00:00', endDate: '2019-06-29T16:00:00' };
 
   it('should return the price if there is no surcharge', () => {
-    expect(DraftBillsHelper.getSurchargedPrice(event, [], 11)).toBe(11);
+    expect(DraftBillsHelper.getSurchargedPrice(event, [], 11)).toBe('11');
   });
 
   it('should return the price surcharged globally', () => {
     const surcharges = [{ percentage: 25 }];
-    expect(DraftBillsHelper.getSurchargedPrice(event, surcharges, 10)).toBe(12.5);
+    expect(DraftBillsHelper.getSurchargedPrice(event, surcharges, 10)).toBe('12.5');
   });
 
   it('should return the price surcharged once', () => {
@@ -245,26 +242,21 @@ describe('getSurchargedPrice', () => {
       startHour: moment(event.startDate).add(1, 'h'),
       endHour: moment(event.startDate).add(2, 'h'),
     }];
-    expect(DraftBillsHelper.getSurchargedPrice(event, surcharges, 24)).toBe(25);
+    expect(DraftBillsHelper.getSurchargedPrice(event, surcharges, 24)).toBe('25');
   });
 
-  it('should return the price surcharged twice', () => {
-    const surcharges = [{
-      percentage: 25,
-      startHour: moment(event.startDate).add(1, 'h'),
-      endHour: moment(event.startDate).add(2, 'h'),
-    }, {
-      percentage: 20,
-      startHour: moment(event.startDate).add(2, 'h'),
-      endHour: moment(event.startDate).add(4, 'h'),
-    }];
-    expect(DraftBillsHelper.getSurchargedPrice(event, surcharges, 24)).toBe(26.6);
+  it('should return the price surcharged twice #tag', () => {
+    const surcharges = [
+      { percentage: 25, startHour: '2019-06-29T11:00:00', endHour: '2019-06-29T12:00:00' },
+      { percentage: 20, startHour: '2019-06-29T12:00:00', endHour: '2019-06-29T14:00:00' },
+    ];
+    expect(DraftBillsHelper.getSurchargedPrice(event, surcharges, 24)).toBe('26.6');
   });
 });
 
 describe('getThirdPartyPayerPrice', () => {
   it('should compute tpp price', () => {
-    expect(DraftBillsHelper.getThirdPartyPayerPrice(180, 10, 20)).toEqual(24);
+    expect(DraftBillsHelper.getThirdPartyPayerPrice(180, 10, 20)).toEqual('24');
   });
 });
 
@@ -308,7 +300,7 @@ describe('getMatchingHistory', () => {
 });
 
 describe('getHourlyFundingSplit', () => {
-  const price = 50;
+  const price = '50';
   const event = { startDate: '2019-02-12T08:00:00.000Z', endDate: '2019-02-12T10:00:00.000Z' };
   let getMatchingHistory;
   let getThirdPartyPayerPrice;
@@ -334,13 +326,14 @@ describe('getHourlyFundingSplit', () => {
     };
 
     getMatchingHistory.returns({ careHours: 1 });
-    getThirdPartyPayerPrice.returns(28);
+    getThirdPartyPayerPrice.returns('28');
 
     const result = DraftBillsHelper.getHourlyFundingSplit(event, funding, price);
-    expect(result.customerPrice).toEqual(22);
-    expect(result.thirdPartyPayerPrice).toEqual(28);
-    expect(result.history.careHours).toEqual(2);
-    sinon.assert.calledWithExactly(getThirdPartyPayerPrice, 120, 21, 20);
+
+    expect(result.customerPrice).toEqual('22');
+    expect(result.thirdPartyPayerPrice).toEqual('28');
+    expect(result.history.careHours).toEqual('2');
+    sinon.assert.calledWithExactly(getThirdPartyPayerPrice, '120', 21, 20);
   });
 
   it('case 2. Event partially invoiced to TPP', () => {
@@ -355,19 +348,19 @@ describe('getHourlyFundingSplit', () => {
     };
 
     getMatchingHistory.returns({ careHours: 3 });
-    getThirdPartyPayerPrice.returns(14);
+    getThirdPartyPayerPrice.returns('14');
 
     const result = DraftBillsHelper.getHourlyFundingSplit(event, funding, price);
 
-    expect(result.customerPrice).toEqual(36);
-    expect(result.thirdPartyPayerPrice).toEqual(14);
-    expect(result.history.careHours).toEqual(1);
-    sinon.assert.calledWithExactly(getThirdPartyPayerPrice, 60, 21, 20);
+    expect(result.customerPrice).toEqual('36');
+    expect(result.thirdPartyPayerPrice).toEqual('14');
+    expect(result.history.careHours).toEqual('1');
+    sinon.assert.calledWithExactly(getThirdPartyPayerPrice, '60', 21, 20);
   });
 });
 
 describe('getFixedFundingSplit', () => {
-  const price = 50;
+  const price = '50';
   const event = { startDate: '2019-02-12T08:00:00.000Z', endDate: '2019-02-12T10:00:00.000Z' };
 
   it('Case 1. Event fully invoiced to TPP', () => {
@@ -379,9 +372,9 @@ describe('getFixedFundingSplit', () => {
 
     const result = DraftBillsHelper.getFixedFundingSplit(event, funding, price);
 
-    expect(result.customerPrice).toEqual(0);
-    expect(result.thirdPartyPayerPrice).toEqual(50);
-    expect(result.history.amountTTC).toEqual(50);
+    expect(result.customerPrice).toEqual('0');
+    expect(result.thirdPartyPayerPrice).toEqual('50');
+    expect(result.history.amountTTC).toEqual('50');
   });
 
   it('Case 2. Event partially invoiced to TPP', () => {
@@ -393,9 +386,9 @@ describe('getFixedFundingSplit', () => {
 
     const result = DraftBillsHelper.getFixedFundingSplit(event, funding, price);
 
-    expect(result.customerPrice).toEqual(29);
-    expect(result.thirdPartyPayerPrice).toEqual(21);
-    expect(result.history.amountTTC).toEqual(21);
+    expect(result.customerPrice).toEqual('29');
+    expect(result.thirdPartyPayerPrice).toEqual('21');
+    expect(result.history.amountTTC).toEqual('21');
   });
 });
 
@@ -425,7 +418,7 @@ describe('getEventBilling', () => {
 
     const result = DraftBillsHelper.getEventBilling(event, unitTTCRate, service);
 
-    expect(result).toEqual({ customerPrice: 21, thirdPartyPayerPrice: 0 });
+    expect(result).toEqual({ customerPrice: '21', thirdPartyPayerPrice: '0' });
     sinon.assert.notCalled(getHourlyFundingSplit);
     sinon.assert.notCalled(getFixedFundingSplit);
     sinon.assert.notCalled(getEventSurcharges);
@@ -437,7 +430,7 @@ describe('getEventBilling', () => {
 
     const result = DraftBillsHelper.getEventBilling(event, unitTTCRate, service);
 
-    expect(result).toEqual({ customerPrice: 42, thirdPartyPayerPrice: 0 });
+    expect(result).toEqual({ customerPrice: '42', thirdPartyPayerPrice: '0' });
     sinon.assert.notCalled(getHourlyFundingSplit);
     sinon.assert.notCalled(getFixedFundingSplit);
     sinon.assert.notCalled(getEventSurcharges);
@@ -446,14 +439,14 @@ describe('getEventBilling', () => {
 
   it('should return event prices with surcharge', () => {
     const service = { vat: 20, nature: 'hourly', surcharge: { publicHoliday: 10 } };
-    getSurchargedPrice.returns(46.2);
+    getSurchargedPrice.returns('46.2');
     getEventSurcharges.returns([{ percentage: 10 }]);
 
     const result = DraftBillsHelper.getEventBilling(event, unitTTCRate, service);
 
-    expect(result).toEqual({ customerPrice: 46.2, thirdPartyPayerPrice: 0, surcharges: [{ percentage: 10 }] });
+    expect(result).toEqual({ customerPrice: '46.2', thirdPartyPayerPrice: '0', surcharges: [{ percentage: 10 }] });
     sinon.assert.calledOnce(getEventSurcharges);
-    sinon.assert.calledWithExactly(getSurchargedPrice, event, [{ percentage: 10 }], 42);
+    sinon.assert.calledWithExactly(getSurchargedPrice, event, [{ percentage: 10 }], '42');
     sinon.assert.notCalled(getHourlyFundingSplit);
     sinon.assert.notCalled(getFixedFundingSplit);
   });
@@ -469,12 +462,12 @@ describe('getEventBilling', () => {
       history: { careHours: 1 },
       thirdPartyPayer: { _id: new ObjectId() },
     };
-    getHourlyFundingSplit.returns({ customerPrice: 0, thirdPartyPayerPrice: 42 });
+    getHourlyFundingSplit.returns({ customerPrice: '0', thirdPartyPayerPrice: '42' });
 
     const result = DraftBillsHelper.getEventBilling(event, unitTTCRate, service, funding);
 
-    expect(result).toEqual({ customerPrice: 0, thirdPartyPayerPrice: 42 });
-    sinon.assert.calledWithExactly(getHourlyFundingSplit, event, funding, 21);
+    expect(result).toEqual({ customerPrice: '0', thirdPartyPayerPrice: '42' });
+    sinon.assert.calledWithExactly(getHourlyFundingSplit, event, funding, '21');
     sinon.assert.notCalled(getFixedFundingSplit);
     sinon.assert.notCalled(getEventSurcharges);
     sinon.assert.notCalled(getSurchargedPrice);
@@ -488,12 +481,12 @@ describe('getEventBilling', () => {
       amountTTC: 100,
       thirdPartyPayer: { _id: new ObjectId() },
     };
-    getFixedFundingSplit.returns({ customerPrice: 0, thirdPartyPayerPrice: 42 });
+    getFixedFundingSplit.returns({ customerPrice: '0', thirdPartyPayerPrice: '42' });
 
     const result = DraftBillsHelper.getEventBilling(event, unitTTCRate, service, funding);
 
-    expect(result).toEqual({ customerPrice: 0, thirdPartyPayerPrice: 42 });
-    sinon.assert.calledWithExactly(getFixedFundingSplit, event, funding, 42);
+    expect(result).toEqual({ customerPrice: '0', thirdPartyPayerPrice: '42' });
+    sinon.assert.calledWithExactly(getFixedFundingSplit, event, funding, '42');
     sinon.assert.notCalled(getHourlyFundingSplit);
     sinon.assert.notCalled(getEventSurcharges);
     sinon.assert.notCalled(getSurchargedPrice);
@@ -511,14 +504,14 @@ describe('getEventBilling', () => {
       thirdPartyPayer: { _id: new ObjectId() },
     };
 
-    getHourlyFundingSplit.returns({ customerPrice: 21.2, thirdPartyPayerPrice: 25 });
-    getSurchargedPrice.returns(46.2);
+    getHourlyFundingSplit.returns({ customerPrice: '21.2', thirdPartyPayerPrice: '25' });
+    getSurchargedPrice.returns('46.2');
     getEventSurcharges.returns([{ percentage: 10 }]);
 
     const result = DraftBillsHelper.getEventBilling(event, unitTTCRate, service, funding);
 
-    expect(result).toEqual({ customerPrice: 21.2, thirdPartyPayerPrice: 25, surcharges: [{ percentage: 10 }] });
-    sinon.assert.calledWithExactly(getHourlyFundingSplit, event, funding, 46.2);
+    expect(result).toEqual({ customerPrice: '21.2', thirdPartyPayerPrice: '25', surcharges: [{ percentage: 10 }] });
+    sinon.assert.calledWithExactly(getHourlyFundingSplit, event, funding, '46.2');
     sinon.assert.notCalled(getFixedFundingSplit);
     sinon.assert.calledOnce(getEventSurcharges);
     sinon.assert.calledOnce(getSurchargedPrice);
@@ -533,14 +526,14 @@ describe('getEventBilling', () => {
       thirdPartyPayer: { _id: new ObjectId() },
     };
 
-    getFixedFundingSplit.returns({ customerPrice: 0, thirdPartyPayerPrice: 46.2 });
-    getSurchargedPrice.returns(46.2);
+    getFixedFundingSplit.returns({ customerPrice: '0', thirdPartyPayerPrice: '46.2' });
+    getSurchargedPrice.returns('46.2');
     getEventSurcharges.returns([{ percentage: 10 }]);
 
     const result = DraftBillsHelper.getEventBilling(event, unitTTCRate, service, funding);
 
-    expect(result).toEqual({ customerPrice: 0, thirdPartyPayerPrice: 46.2, surcharges: [{ percentage: 10 }] });
-    sinon.assert.calledWithExactly(getFixedFundingSplit, event, funding, 46.2);
+    expect(result).toEqual({ customerPrice: '0', thirdPartyPayerPrice: '46.2', surcharges: [{ percentage: 10 }] });
+    sinon.assert.calledWithExactly(getFixedFundingSplit, event, funding, '46.2');
     sinon.assert.notCalled(getHourlyFundingSplit);
     sinon.assert.calledOnce(getEventSurcharges);
     sinon.assert.calledOnce(getSurchargedPrice);
@@ -558,7 +551,7 @@ describe('getEventBilling', () => {
 
     const result = DraftBillsHelper.getEventBilling(cancelledEvent, unitTTCRate, service, funding);
 
-    expect(result).toEqual({ customerPrice: 42, thirdPartyPayerPrice: 0 });
+    expect(result).toEqual({ customerPrice: '42', thirdPartyPayerPrice: '0' });
     sinon.assert.notCalled(getHourlyFundingSplit);
     sinon.assert.notCalled(getFixedFundingSplit);
     sinon.assert.notCalled(getEventSurcharges);
@@ -592,18 +585,18 @@ describe('formatDraftBillsForCustomer', () => {
         { event: '123456' },
         { event: 'abc', inclTaxesCustomer: 21, exclTaxesCustomer: '17.5' },
       ],
-      hours: 5,
-      exclTaxes: 37.5,
-      inclTaxes: 46,
+      hours: '5',
+      exclTaxes: '37.5',
+      inclTaxes: '46',
     });
     sinon.assert.calledOnceWithExactly(getExclTaxes, 21, 20);
   });
 
   it('should format bill for customer with surcharge', () => {
-    const customerPrices = { exclTaxes: 20, inclTaxes: 25, hours: 3, eventsList: [{ event: '123456' }] };
+    const customerPrices = { exclTaxes: '20', inclTaxes: '25', hours: '3', eventsList: [{ event: '123456' }] };
     const event = { _id: 'abc', startDate: '2019-02-12T08:00:00.000Z', endDate: '2019-02-12T10:00:00.000Z' };
     const service = { vat: 20 };
-    const eventPrice = { customerPrice: 21, surcharges: [{ name: 'test' }] };
+    const eventPrice = { customerPrice: '21', surcharges: [{ name: 'test' }] };
 
     getExclTaxes.returns('17.5');
 
@@ -612,20 +605,20 @@ describe('formatDraftBillsForCustomer', () => {
     expect(result).toMatchObject({
       eventsList: [
         { event: '123456' },
-        { event: 'abc', inclTaxesCustomer: 21, exclTaxesCustomer: '17.5', surcharges: [{ name: 'test' }] },
+        { event: 'abc', inclTaxesCustomer: '21', exclTaxesCustomer: '17.5', surcharges: [{ name: 'test' }] },
       ],
-      hours: 5,
-      exclTaxes: 37.5,
-      inclTaxes: 46,
+      hours: '5',
+      exclTaxes: '37.5',
+      inclTaxes: '46',
     });
-    sinon.assert.calledOnceWithExactly(getExclTaxes, 21, 20);
+    sinon.assert.calledOnceWithExactly(getExclTaxes, '21', 20);
   });
 
   it('should format bill for customer with tpp info', () => {
     const customerPrices = { exclTaxes: 20, inclTaxes: 25, hours: 3, eventsList: [{ event: '123456' }] };
     const event = { _id: 'abc', startDate: '2019-02-12T08:00:00.000Z', endDate: '2019-02-12T10:00:00.000Z' };
     const service = { vat: 20 };
-    const eventPrice = { customerPrice: 21, thirdPartyPayerPrice: 15, thirdPartyPayer: 'tpp' };
+    const eventPrice = { customerPrice: '21', thirdPartyPayerPrice: '15', thirdPartyPayer: 'tpp' };
     getExclTaxes.onCall(0).returns('17.5');
     getExclTaxes.onCall(1).returns('12.5');
 
@@ -636,19 +629,19 @@ describe('formatDraftBillsForCustomer', () => {
         { event: '123456' },
         {
           event: 'abc',
-          inclTaxesCustomer: 21,
+          inclTaxesCustomer: '21',
           exclTaxesCustomer: '17.5',
           exclTaxesTpp: '12.5',
-          inclTaxesTpp: 15,
+          inclTaxesTpp: '15',
           thirdPartyPayer: 'tpp',
         },
       ],
-      hours: 5,
-      exclTaxes: 37.5,
-      inclTaxes: 46,
+      hours: '5',
+      exclTaxes: '37.5',
+      inclTaxes: '46',
     });
-    sinon.assert.calledWithExactly(getExclTaxes.getCall(0), 21, 20);
-    sinon.assert.calledWithExactly(getExclTaxes.getCall(1), 15, 20);
+    sinon.assert.calledWithExactly(getExclTaxes.getCall(0), '21', 20);
+    sinon.assert.calledWithExactly(getExclTaxes.getCall(1), '15', 20);
   });
 });
 
@@ -710,16 +703,21 @@ describe('computeBillingInfoForEvents', () => {
 
     getMatchingVersion.onCall(0).returns(matchingService1);
     getMatchingVersion.onCall(1).returns(matchingService2);
-    getEventBilling.onCall(0).returns({ customerPrice: 20 });
-    getEventBilling.onCall(1).returns({ customerPrice: 15 });
-    formatDraftBillsForCustomer.onCall(0).returns({ exclTaxes: 12, inclTaxes: 15, hours: 2, eventsList: [events[0]] });
-    formatDraftBillsForCustomer.onCall(1).returns({ exclTaxes: 45, inclTaxes: 50, hours: 6, eventsList: events });
+    getEventBilling.onCall(0).returns({ customerPrice: '20' });
+    getEventBilling.onCall(1).returns({ customerPrice: '15' });
+    formatDraftBillsForCustomer.onCall(0).returns({
+      exclTaxes: '12',
+      inclTaxes: '15',
+      hours: '2',
+      eventsList: [events[0]],
+    });
+    formatDraftBillsForCustomer.onCall(1).returns({ exclTaxes: '45', inclTaxes: '50', hours: '6', eventsList: events });
 
     const result = DraftBillsHelper.computeBillingInfoForEvents(events, service, fundings, startDate, 12);
 
     expect(result).toEqual({
       prices: {
-        customerPrices: { exclTaxes: 45, inclTaxes: 50, hours: 6, eventsList: events },
+        customerPrices: { exclTaxes: '45', inclTaxes: '50', hours: '6', eventsList: events },
         thirdPartyPayerPrices: {},
         startDate: moment('2021-02-04T12:00:00.000Z'),
       },
@@ -737,16 +735,16 @@ describe('computeBillingInfoForEvents', () => {
     sinon.assert.calledWithExactly(getEventBilling.getCall(1), events[1], 12, matchingService2, null);
     sinon.assert.calledWithExactly(
       formatDraftBillsForCustomer.getCall(0),
-      { exclTaxes: 0, inclTaxes: 0, hours: 0, eventsList: [] },
+      { exclTaxes: '0', inclTaxes: '0', hours: '0', eventsList: [] },
       events[0],
-      { customerPrice: 20 },
+      { customerPrice: '20' },
       matchingService1
     );
     sinon.assert.calledWithExactly(
       formatDraftBillsForCustomer.getCall(1),
-      { exclTaxes: 12, inclTaxes: 15, hours: 2, eventsList: [events[0]] },
+      { exclTaxes: '12', inclTaxes: '15', hours: '2', eventsList: [events[0]] },
       events[1],
-      { customerPrice: 15 },
+      { customerPrice: '15' },
       matchingService2
     );
     sinon.assert.notCalled(getMatchingFunding);
@@ -778,31 +776,36 @@ describe('computeBillingInfoForEvents', () => {
     getMatchingFunding.onCall(0).returns(null);
     getMatchingFunding.onCall(1).returns(matchingFunding);
     getMatchingFunding.onCall(2).returns(matchingFunding);
-    getEventBilling.onCall(0).returns({ customerPrice: 20 });
-    getEventBilling.onCall(1).returns({ customerPrice: 15, thirdPartyPayerPrice: 12 });
-    getEventBilling.onCall(2).returns({ customerPrice: 17, thirdPartyPayerPrice: 15 });
-    formatDraftBillsForCustomer.onCall(0).returns({ exclTaxes: 12, inclTaxes: 15, hours: 2, eventsList: [events[0]] });
+    getEventBilling.onCall(0).returns({ customerPrice: '20' });
+    getEventBilling.onCall(1).returns({ customerPrice: '15', thirdPartyPayerPrice: '12' });
+    getEventBilling.onCall(2).returns({ customerPrice: '17', thirdPartyPayerPrice: '15' });
+    formatDraftBillsForCustomer.onCall(0).returns({
+      exclTaxes: '12',
+      inclTaxes: '15',
+      hours: '2',
+      eventsList: [events[0]],
+    });
     formatDraftBillsForCustomer.onCall(1).returns({
-      exclTaxes: 45,
-      inclTaxes: 50,
-      hours: 6,
+      exclTaxes: '45',
+      inclTaxes: '50',
+      hours: '6',
       eventsList: [events[0], events[1]],
     });
-    formatDraftBillsForCustomer.onCall(2).returns({ exclTaxes: 60, inclTaxes: 75, hours: 8, eventsList: events });
+    formatDraftBillsForCustomer.onCall(2).returns({ exclTaxes: '60', inclTaxes: '75', hours: '8', eventsList: events });
     formatDraftBillsForTPP.onCall(0).returns({
-      [fundings[0]._id]: { exclTaxes: 21, inclTaxes: 23, hours: 2, eventsList: [events[1]] },
+      [fundings[0]._id]: { exclTaxes: '21', inclTaxes: '23', hours: '2', eventsList: [events[1]] },
     });
     formatDraftBillsForTPP.onCall(1).returns({
-      [fundings[0]._id]: { exclTaxes: 42, inclTaxes: 46, hours: 4, eventsList: [events[1], events[2]] },
+      [fundings[0]._id]: { exclTaxes: '42', inclTaxes: '46', hours: '4', eventsList: [events[1], events[2]] },
     });
 
     const result = DraftBillsHelper.computeBillingInfoForEvents(events, service, fundings, startDate, 12);
 
     expect(result).toEqual({
       prices: {
-        customerPrices: { exclTaxes: 60, inclTaxes: 75, hours: 8, eventsList: events },
+        customerPrices: { exclTaxes: '60', inclTaxes: '75', hours: '8', eventsList: events },
         thirdPartyPayerPrices: {
-          [fundings[0]._id]: { exclTaxes: 42, inclTaxes: 46, hours: 4, eventsList: [events[1], events[2]] },
+          [fundings[0]._id]: { exclTaxes: '42', inclTaxes: '46', hours: '4', eventsList: [events[1], events[2]] },
         },
         startDate,
       },
@@ -825,23 +828,23 @@ describe('computeBillingInfoForEvents', () => {
     sinon.assert.calledWithExactly(getEventBilling.getCall(2), events[2], 12, matchingService, matchingFunding);
     sinon.assert.calledWithExactly(
       formatDraftBillsForCustomer.getCall(0),
-      { exclTaxes: 0, inclTaxes: 0, hours: 0, eventsList: [] },
+      { exclTaxes: '0', inclTaxes: '0', hours: '0', eventsList: [] },
       events[0],
-      { customerPrice: 20 },
+      { customerPrice: '20' },
       matchingService
     );
     sinon.assert.calledWithExactly(
       formatDraftBillsForCustomer.getCall(1),
-      { exclTaxes: 12, inclTaxes: 15, hours: 2, eventsList: [events[0]] },
+      { exclTaxes: '12', inclTaxes: '15', hours: '2', eventsList: [events[0]] },
       events[1],
-      { customerPrice: 15, thirdPartyPayerPrice: 12 },
+      { customerPrice: '15', thirdPartyPayerPrice: '12' },
       matchingService
     );
     sinon.assert.calledWithExactly(
       formatDraftBillsForCustomer.getCall(2),
-      { exclTaxes: 45, inclTaxes: 50, hours: 6, eventsList: [events[0], events[1]] },
+      { exclTaxes: '45', inclTaxes: '50', hours: '6', eventsList: [events[0], events[1]] },
       events[2],
-      { customerPrice: 17, thirdPartyPayerPrice: 15 },
+      { customerPrice: '17', thirdPartyPayerPrice: '15' },
       matchingService
     );
     sinon.assert.calledWithExactly(
@@ -849,15 +852,15 @@ describe('computeBillingInfoForEvents', () => {
       {},
       'tpp',
       events[1],
-      { customerPrice: 15, thirdPartyPayerPrice: 12 },
+      { customerPrice: '15', thirdPartyPayerPrice: '12' },
       matchingService
     );
     sinon.assert.calledWithExactly(
       formatDraftBillsForTPP.getCall(1),
-      { [fundings[0]._id]: { exclTaxes: 21, inclTaxes: 23, hours: 2, eventsList: [events[1]] } },
+      { [fundings[0]._id]: { exclTaxes: '21', inclTaxes: '23', hours: '2', eventsList: [events[1]] } },
       'tpp',
       events[2],
-      { customerPrice: 17, thirdPartyPayerPrice: 15 },
+      { customerPrice: '17', thirdPartyPayerPrice: '15' },
       matchingService
     );
   });
@@ -869,7 +872,7 @@ describe('computeBillingInfoForEvents', () => {
 
     expect(result).toEqual({
       prices: {
-        customerPrices: { exclTaxes: 0, inclTaxes: 0, hours: 0, eventsList: [] },
+        customerPrices: { exclTaxes: '0', inclTaxes: '0', hours: '0', eventsList: [] },
         thirdPartyPayerPrices: {},
         startDate,
       },
@@ -895,14 +898,14 @@ describe('formatDraftBillsForTPP', () => {
   it('should format bill for tpp', () => {
     const tppId = new ObjectId();
     const tpp = { _id: tppId };
-    const tppPrices = { [tppId]: { exclTaxes: 20, inclTaxes: 25, hours: 3, eventsList: [{ event: '123456' }] } };
+    const tppPrices = { [tppId]: { exclTaxes: '20', inclTaxes: '25', hours: '3', eventsList: [{ event: '123456' }] } };
     const event = { _id: 'abc', startDate: '2019-02-12T08:00:00.000Z', endDate: '2019-02-12T10:00:00.000Z' };
     const eventPrice = {
-      customerPrice: 21,
-      thirdPartyPayerPrice: 12.5,
+      customerPrice: '21',
+      thirdPartyPayerPrice: '12.5',
       thirdPartyPayer: tppId,
       history: {},
-      chargedTime: 120,
+      chargedTime: '120',
     };
     const service = { vat: 20 };
     getExclTaxes.onCall(0).returns('10');
@@ -910,17 +913,17 @@ describe('formatDraftBillsForTPP', () => {
 
     const result = DraftBillsHelper.formatDraftBillsForTPP(tppPrices, tpp, event, eventPrice, service);
 
-    expect(result[tppId].exclTaxes).toEqual(30);
-    expect(result[tppId].inclTaxes).toEqual(37.5);
-    expect(result[tppId].hours).toEqual(5);
+    expect(result[tppId].exclTaxes).toEqual('30');
+    expect(result[tppId].inclTaxes).toEqual('37.5');
+    expect(result[tppId].hours).toEqual('5');
     expect(result[tppId].eventsList).toMatchObject([
       { event: '123456' },
       {
         event: 'abc',
-        inclTaxesTpp: 12.5,
+        inclTaxesTpp: '12.5',
         exclTaxesTpp: '10',
         thirdPartyPayer: tppId,
-        inclTaxesCustomer: 21,
+        inclTaxesCustomer: '21',
         exclTaxesCustomer: '17.5',
       },
     ]);
@@ -965,8 +968,8 @@ describe('getDraftBillsPerSubscription', () => {
     getExclTaxes.returns('70');
     computeBillingInfoForEvents.returns({
       prices: {
-        customerPrices: { exclTaxes: 35 },
-        thirdPartyPayerPrices: { [tppId]: { hours: 3 } },
+        customerPrices: { exclTaxes: '35' },
+        thirdPartyPayerPrices: { [tppId]: { hours: '3' } },
         startDate: moment('2019/02/01', 'YY/MM/DD'),
       },
       eventsByBillingItem: [{ d00000000000000000000001: [events[0]._id] }],
@@ -975,10 +978,10 @@ describe('getDraftBillsPerSubscription', () => {
     const result =
       DraftBillsHelper.getDraftBillsPerSubscription(events, subscription, fundings, '2019/02/01', '2019/03/01');
 
-    expect(result.customer.exclTaxes).toEqual(35);
+    expect(result.customer.exclTaxes).toEqual('35');
     expect(result.customer.unitExclTaxes).toEqual('70');
-    expect(result.customer.unitInclTaxes).toEqual(21);
-    expect(result.thirdPartyPayer[tppId].hours).toEqual(3);
+    expect(result.customer.unitInclTaxes).toEqual('21');
+    expect(result.thirdPartyPayer[tppId].hours).toEqual('3');
     expect(result.eventsByBillingItem).toEqual([{ d00000000000000000000001: [events[0]._id] }]);
     sinon.assert.calledOnceWithExactly(
       getLastVersion,
@@ -1010,16 +1013,16 @@ describe('getDraftBillsPerSubscription', () => {
     getMatchingVersion.returns({ startDate: new Date('2019/01/01'), vat: 20 });
     getExclTaxes.returns('70');
     computeBillingInfoForEvents.returns({
-      prices: { customerPrices: { exclTaxes: 35 }, startDate: moment('2019/02/01', 'YY/MM/DD') },
+      prices: { customerPrices: { exclTaxes: '35' }, startDate: moment('2019/02/01', 'YY/MM/DD') },
       eventsByBillingItem: [],
     });
 
     const result =
       DraftBillsHelper.getDraftBillsPerSubscription(events, subscription, null, '2019/02/01', '2019/03/01');
 
-    expect(result.customer.exclTaxes).toEqual(35);
+    expect(result.customer.exclTaxes).toEqual('35');
     expect(result.customer.unitExclTaxes).toEqual('70');
-    expect(result.customer.unitInclTaxes).toEqual(21);
+    expect(result.customer.unitInclTaxes).toEqual('21');
     expect(result.eventsByBillingItem).toEqual([]);
     sinon.assert.calledOnceWithExactly(
       getLastVersion,
@@ -1054,8 +1057,8 @@ describe('getDraftBillsPerSubscription', () => {
     getExclTaxes.returns('70');
     computeBillingInfoForEvents.returns({
       prices: {
-        customerPrices: { exclTaxes: 0 },
-        thirdPartyPayerPrices: { [tppId]: { hours: 3 } },
+        customerPrices: { exclTaxes: '0' },
+        thirdPartyPayerPrices: { [tppId]: { hours: '3' } },
         startDate: moment('2019/02/01', 'YY/MM/DD'),
       },
       eventsByBillingItem: [],
@@ -1065,7 +1068,7 @@ describe('getDraftBillsPerSubscription', () => {
       DraftBillsHelper.getDraftBillsPerSubscription(events, subscription, fundings, '2019/02/01', '2019/03/01');
 
     expect(result.customer).toBeUndefined();
-    expect(result.thirdPartyPayer[tppId].hours).toEqual(3);
+    expect(result.thirdPartyPayer[tppId].hours).toEqual('3');
     expect(result.eventsByBillingItem).toEqual([]);
     sinon.assert.calledOnceWithExactly(
       getLastVersion,
@@ -1141,11 +1144,11 @@ describe('formatBillingItems', () => {
         billingItem: { _id: new ObjectId('d00000000000000000000001'), name: 'FI' },
         discount: 0,
         unitExclTaxes: '0.90909090909090909091',
-        unitInclTaxes: 1,
+        unitInclTaxes: '1',
         vat: 10,
         eventsList: [{ event: eventId1 }, { event: eventId2 }, { event: eventId3 }],
-        exclTaxes: 2.7272727272727275,
-        inclTaxes: 3,
+        exclTaxes: '2.72727272727272727273',
+        inclTaxes: '3',
         startDate: '2019-12-31T07:00:00',
         endDate: '2019-12-25T07:00:00',
       }),
@@ -1153,11 +1156,11 @@ describe('formatBillingItems', () => {
         billingItem: { _id: new ObjectId('d00000000000000000000002'), name: 'EPI' },
         discount: 0,
         unitExclTaxes: '4.54545454545454545455',
-        unitInclTaxes: 5,
+        unitInclTaxes: '5',
         vat: 10,
         eventsList: [{ event: eventId1 }, { event: eventId2 }],
-        exclTaxes: 9.090909090909092,
-        inclTaxes: 10,
+        exclTaxes: '9.0909090909090909091',
+        inclTaxes: '10',
         startDate: '2019-12-31T07:00:00',
         endDate: '2019-12-25T07:00:00',
       }),
@@ -1167,7 +1170,7 @@ describe('formatBillingItems', () => {
 
 describe('formatCustomerBills', () => {
   it('should format customer bills', () => {
-    const customerBills = [{ inclTaxes: 20 }, { inclTaxes: 21 }];
+    const customerBills = [{ inclTaxes: '20.127' }, { inclTaxes: '21' }];
     const tppBills = [];
     const query = { endDate: '2019-12-25T07:00:00' };
     const customer = { _id: 'ghjk', identity: { firstname: 'Toto' } };
@@ -1177,13 +1180,13 @@ describe('formatCustomerBills', () => {
     expect(result).toEqual({
       customer: { _id: 'ghjk', identity: { firstname: 'Toto' } },
       endDate: '2019-12-25T07:00:00',
-      customerBills: { bills: [{ inclTaxes: 20 }, { inclTaxes: 21 }], total: 41 },
+      customerBills: { bills: [{ inclTaxes: '20.127' }, { inclTaxes: '21' }], total: 41.13 },
     });
   });
 
   it('should format customer and tpp bills', () => {
-    const customerBills = [{ inclTaxes: 20 }, { inclTaxes: 21 }];
-    const tppBills = { tpp1: [{ inclTaxes: 13 }, { inclTaxes: 24 }], tpp2: [{ inclTaxes: 20 }] };
+    const customerBills = [{ inclTaxes: '20' }, { inclTaxes: '21' }];
+    const tppBills = { tpp1: [{ inclTaxes: '13' }, { inclTaxes: '24' }], tpp2: [{ inclTaxes: '20' }] };
     const query = { endDate: '2019-12-25T07:00:00' };
     const customer = { _id: 'ghjk', identity: { firstname: 'Toto' } };
 
@@ -1192,10 +1195,10 @@ describe('formatCustomerBills', () => {
     expect(result).toEqual({
       customer: { _id: 'ghjk', identity: { firstname: 'Toto' } },
       endDate: '2019-12-25T07:00:00',
-      customerBills: { bills: [{ inclTaxes: 20 }, { inclTaxes: 21 }], total: 41 },
+      customerBills: { bills: [{ inclTaxes: '20' }, { inclTaxes: '21' }], total: 41 },
       thirdPartyPayerBills: [
-        { bills: [{ inclTaxes: 13 }, { inclTaxes: 24 }], total: 37 },
-        { bills: [{ inclTaxes: 20 }], total: 20 },
+        { bills: [{ inclTaxes: '13' }, { inclTaxes: '24' }], total: 37 },
+        { bills: [{ inclTaxes: '20' }], total: 20 },
       ],
     });
   });
@@ -1301,13 +1304,13 @@ describe('getDraftBillsList', () => {
     populateAndFormatSubscription.returnsArg(0);
     populateFundings.returnsArg(0);
     getDraftBillsPerSubscription.onCall(0).returns({
-      customer: { identity: { firstname: 'Toto' }, inclTaxes: 20 },
-      thirdPartyPayer: { tpp: { inclTaxes: 13 } },
+      customer: { identity: { firstname: 'Toto' }, inclTaxes: '20' },
+      thirdPartyPayer: { tpp: { inclTaxes: '13' } },
       billingItems: [],
     });
     getDraftBillsPerSubscription.onCall(1).returns({
-      customer: { identity: { firstname: 'Toto' }, inclTaxes: 21 },
-      thirdPartyPayer: { tpp: { inclTaxes: 24 } },
+      customer: { identity: { firstname: 'Toto' }, inclTaxes: '21' },
+      thirdPartyPayer: { tpp: { inclTaxes: '24' } },
       billingItems: [],
     });
     formatBillingItems.returns([]);
@@ -1316,12 +1319,12 @@ describe('getDraftBillsList', () => {
       endDate: '2019-12-25T07:00:00',
       customerBills: {
         bills: [
-          { identity: { firstname: 'Toto' }, inclTaxes: 20 },
-          { identity: { firstname: 'Toto' }, inclTaxes: 21 },
+          { identity: { firstname: 'Toto' }, inclTaxes: '20' },
+          { identity: { firstname: 'Toto' }, inclTaxes: '21' },
         ],
         total: 41,
       },
-      thirdPartyPayerBills: [{ bills: [{ inclTaxes: 13 }, { inclTaxes: 24 }], total: 37 }],
+      thirdPartyPayerBills: [{ bills: [{ inclTaxes: '13' }, { inclTaxes: '24' }], total: 37 }],
     });
 
     const result = await DraftBillsHelper.getDraftBillsList(query, credentials, null);
@@ -1332,12 +1335,12 @@ describe('getDraftBillsList', () => {
         endDate: '2019-12-25T07:00:00',
         customerBills: {
           bills: [
-            { identity: { firstname: 'Toto' }, inclTaxes: 20 },
-            { identity: { firstname: 'Toto' }, inclTaxes: 21 },
+            { identity: { firstname: 'Toto' }, inclTaxes: '20' },
+            { identity: { firstname: 'Toto' }, inclTaxes: '21' },
           ],
           total: 41,
         },
-        thirdPartyPayerBills: [{ bills: [{ inclTaxes: 13 }, { inclTaxes: 24 }], total: 37 }],
+        thirdPartyPayerBills: [{ bills: [{ inclTaxes: '13' }, { inclTaxes: '24' }], total: 37 }],
       },
     ]);
     sinon.assert.calledWithExactly(getEventsToBill, query, credentials.company._id);
@@ -1385,8 +1388,8 @@ describe('getDraftBillsList', () => {
     );
     sinon.assert.calledOnceWithExactly(
       formatCustomerBills,
-      [{ identity: { firstname: 'Toto' }, inclTaxes: 20 }, { identity: { firstname: 'Toto' }, inclTaxes: 21 }],
-      { tpp: [{ inclTaxes: 13 }, { inclTaxes: 24 }] },
+      [{ identity: { firstname: 'Toto' }, inclTaxes: '20' }, { identity: { firstname: 'Toto' }, inclTaxes: '21' }],
+      { tpp: [{ inclTaxes: '13' }, { inclTaxes: '24' }] },
       query,
       { _id: 'ghjk', identity: { firstname: 'Toto' } }
     );
@@ -1437,20 +1440,20 @@ describe('getDraftBillsList', () => {
     ]);
     populateAndFormatSubscription.returnsArg(0);
     getDraftBillsPerSubscription.onCall(0).returns({
-      customer: { identity: { firstname: 'Toto' }, inclTaxes: 20 },
+      customer: { identity: { firstname: 'Toto' }, inclTaxes: '20' },
       billingItems: { biId1: ['eventId1'] },
     });
     getDraftBillsPerSubscription.onCall(1).returns({
-      customer: { identity: { firstname: 'Toto' }, inclTaxes: 21 },
+      customer: { identity: { firstname: 'Toto' }, inclTaxes: '21' },
       billingItems: { biId2: ['eventId2'] },
     });
     getDraftBillsPerSubscription.onCall(2).returns({
-      customer: { identity: { firstname: 'Tata' }, inclTaxes: 23 },
+      customer: { identity: { firstname: 'Tata' }, inclTaxes: '23' },
       billingItems: [],
     });
     formatBillingItems.onCall(0).returns([
-      { billingItem: { _id: 'biId1', name: 'FI' }, eventsList: [{ event: 'eventId1' }], inclTaxes: 200 },
-      { billingItem: { _id: 'biId2', name: 'EPI' }, eventsList: [{ event: 'eventId2' }], inclTaxes: 100 },
+      { billingItem: { _id: 'biId1', name: 'FI' }, eventsList: [{ event: 'eventId1' }], inclTaxes: '200' },
+      { billingItem: { _id: 'biId2', name: 'EPI' }, eventsList: [{ event: 'eventId2' }], inclTaxes: '100' },
     ]);
     formatBillingItems.onCall(1).returns([]);
     formatCustomerBills.onCall(0).returns({
@@ -1458,10 +1461,10 @@ describe('getDraftBillsList', () => {
       endDate: '2019-12-25T07:00:00',
       customerBills: {
         bills: [
-          { identity: { firstname: 'Toto' }, inclTaxes: 20 },
-          { identity: { firstname: 'Toto' }, inclTaxes: 21 },
-          { billingItem: { _id: 'biId1', name: 'FI' }, eventsList: [{ event: 'eventId1' }], inclTaxes: 200 },
-          { billingItem: { _id: 'biId2', name: 'EPI' }, eventsList: [{ event: 'eventId2' }], inclTaxes: 100 },
+          { identity: { firstname: 'Toto' }, inclTaxes: '20' },
+          { identity: { firstname: 'Toto' }, inclTaxes: '21' },
+          { billingItem: { _id: 'biId1', name: 'FI' }, eventsList: [{ event: 'eventId1' }], inclTaxes: '200' },
+          { billingItem: { _id: 'biId2', name: 'EPI' }, eventsList: [{ event: 'eventId2' }], inclTaxes: '100' },
         ],
         total: 341,
       },
@@ -1469,12 +1472,7 @@ describe('getDraftBillsList', () => {
     formatCustomerBills.onCall(1).returns({
       endDate: '2019-12-25T07:00:00',
       customer: { _id: 'asdf', identity: { firstname: 'Tata' } },
-      customerBills: {
-        bills: [
-          { identity: { firstname: 'Tata' }, inclTaxes: 23 },
-        ],
-        total: 23,
-      },
+      customerBills: { bills: [{ identity: { firstname: 'Tata' }, inclTaxes: '23' }], total: 23 },
     });
 
     const result = await DraftBillsHelper.getDraftBillsList(query, credentials, null);
@@ -1485,10 +1483,10 @@ describe('getDraftBillsList', () => {
         endDate: '2019-12-25T07:00:00',
         customerBills: {
           bills: [
-            { identity: { firstname: 'Toto' }, inclTaxes: 20 },
-            { identity: { firstname: 'Toto' }, inclTaxes: 21 },
-            { billingItem: { _id: 'biId1', name: 'FI' }, eventsList: [{ event: 'eventId1' }], inclTaxes: 200 },
-            { billingItem: { _id: 'biId2', name: 'EPI' }, eventsList: [{ event: 'eventId2' }], inclTaxes: 100 },
+            { identity: { firstname: 'Toto' }, inclTaxes: '20' },
+            { identity: { firstname: 'Toto' }, inclTaxes: '21' },
+            { billingItem: { _id: 'biId1', name: 'FI' }, eventsList: [{ event: 'eventId1' }], inclTaxes: '200' },
+            { billingItem: { _id: 'biId2', name: 'EPI' }, eventsList: [{ event: 'eventId2' }], inclTaxes: '100' },
           ],
           total: 341,
         },
@@ -1498,7 +1496,7 @@ describe('getDraftBillsList', () => {
         customer: { _id: 'asdf', identity: { firstname: 'Tata' } },
         customerBills: {
           bills: [
-            { identity: { firstname: 'Tata' }, inclTaxes: 23 },
+            { identity: { firstname: 'Tata' }, inclTaxes: '23' },
           ],
           total: 23,
         },
@@ -1551,10 +1549,10 @@ describe('getDraftBillsList', () => {
     sinon.assert.calledWithExactly(
       formatCustomerBills.firstCall,
       [
-        { identity: { firstname: 'Toto' }, inclTaxes: 20 },
-        { identity: { firstname: 'Toto' }, inclTaxes: 21 },
-        { billingItem: { _id: 'biId1', name: 'FI' }, eventsList: [{ event: 'eventId1' }], inclTaxes: 200 },
-        { billingItem: { _id: 'biId2', name: 'EPI' }, eventsList: [{ event: 'eventId2' }], inclTaxes: 100 },
+        { identity: { firstname: 'Toto' }, inclTaxes: '20' },
+        { identity: { firstname: 'Toto' }, inclTaxes: '21' },
+        { billingItem: { _id: 'biId1', name: 'FI' }, eventsList: [{ event: 'eventId1' }], inclTaxes: '200' },
+        { billingItem: { _id: 'biId2', name: 'EPI' }, eventsList: [{ event: 'eventId2' }], inclTaxes: '100' },
       ],
       {},
       query,
@@ -1562,7 +1560,7 @@ describe('getDraftBillsList', () => {
     );
     sinon.assert.calledWithExactly(
       formatCustomerBills.secondCall,
-      [{ identity: { firstname: 'Tata' }, inclTaxes: 23 }],
+      [{ identity: { firstname: 'Tata' }, inclTaxes: '23' }],
       {},
       query,
       { _id: 'asdf', identity: { firstname: 'Tata' } }

--- a/tests/unit/helpers/numbers.test.js
+++ b/tests/unit/helpers/numbers.test.js
@@ -1,11 +1,29 @@
+const { BigNumber } = require('bignumber.js');
 const expect = require('expect');
 const NumbersHelper = require('../../../src/helpers/numbers');
+
+describe('toBN', () => {
+  it('should multiply numbers', async () => {
+    const result = NumbersHelper.toBN(0.1);
+
+    expect(BigNumber.isBigNumber(result)).toBeTruthy();
+    expect(result.toString()).toEqual('0.1');
+  });
+});
 
 describe('oldMultiply', () => {
   it('should multiply numbers', async () => {
     const result = NumbersHelper.oldMultiply(0.1, 2, 0.2);
 
     expect(result).toEqual(0.04);
+  });
+});
+
+describe('multiply', () => {
+  it('should multiply number', () => {
+    const result = NumbersHelper.multiply(0.1, 2, 0.2);
+
+    expect(result).toEqual('0.04');
   });
 });
 
@@ -17,6 +35,14 @@ describe('oldDivide', () => {
   });
 });
 
+describe('divide', () => {
+  it('should divide numbers', async () => {
+    const result = NumbersHelper.divide(0.3, 0.2);
+
+    expect(result).toEqual('1.5');
+  });
+});
+
 describe('oldAdd', () => {
   it('should add numbers', async () => {
     const result = NumbersHelper.oldAdd(0.6, 0.3, 1.2);
@@ -25,10 +51,26 @@ describe('oldAdd', () => {
   });
 });
 
+describe('add', () => {
+  it('should add numbers', async () => {
+    const result = NumbersHelper.add(0.6, 0.3, 1.2);
+
+    expect(result).toEqual('2.1');
+  });
+});
+
 describe('oldSubtract', () => {
   it('should subtract numbers', async () => {
     const result = NumbersHelper.oldSubtract(0.7, 0.2);
 
     expect(result).toEqual(0.5);
+  });
+});
+
+describe('subtract', () => {
+  it('should subtract numbers', async () => {
+    const result = NumbersHelper.subtract(0.7, 0.2);
+
+    expect(result).toEqual('0.5');
   });
 });

--- a/tests/unit/helpers/numbers.test.js
+++ b/tests/unit/helpers/numbers.test.js
@@ -2,15 +2,6 @@ const { BigNumber } = require('bignumber.js');
 const expect = require('expect');
 const NumbersHelper = require('../../../src/helpers/numbers');
 
-describe('toBN', () => {
-  it('should return BN object', async () => {
-    const result = NumbersHelper.toBN(0.1);
-
-    expect(BigNumber.isBigNumber(result)).toBeTruthy();
-    expect(result.toString()).toEqual('0.1');
-  });
-});
-
 describe('toString', () => {
   it('should return a string', async () => {
     const result = NumbersHelper.toString(0.1);
@@ -104,8 +95,14 @@ describe('isGreaterThan', () => {
     expect(result).toBeTruthy();
   });
 
-  it('should return false', async () => {
+  it('should return false if less', async () => {
     const result = NumbersHelper.isGreaterThan(0.7, 1.2);
+
+    expect(result).toBeFalsy();
+  });
+
+  it('should return false if equal', async () => {
+    const result = NumbersHelper.isGreaterThan(0.7, 0.7);
 
     expect(result).toBeFalsy();
   });
@@ -118,8 +115,14 @@ describe('isLessThan', () => {
     expect(result).toBeTruthy();
   });
 
-  it('should return false', async () => {
+  it('should return false if greater', async () => {
     const result = NumbersHelper.isLessThan(1.7, 1.2);
+
+    expect(result).toBeFalsy();
+  });
+
+  it('should return false if equal', async () => {
+    const result = NumbersHelper.isLessThan(1.7, 1.7);
 
     expect(result).toBeFalsy();
   });
@@ -131,6 +134,7 @@ describe('isEqualTo', () => {
 
     expect(result).toBeTruthy();
   });
+
   it('should return false', () => {
     const result = NumbersHelper.isEqualTo(1.23, 2.45);
 

--- a/tests/unit/helpers/numbers.test.js
+++ b/tests/unit/helpers/numbers.test.js
@@ -11,6 +11,14 @@ describe('toBN', () => {
   });
 });
 
+describe('toString', () => {
+  it('should return a string', async () => {
+    const result = NumbersHelper.toString(0.1);
+
+    expect(result).toEqual('0.1');
+  });
+});
+
 describe('toFixed', () => {
   it('should round BN', () => {
     const result = NumbersHelper.toFixed(BigNumber(1.234567));
@@ -98,6 +106,20 @@ describe('isGreaterThan', () => {
 
   it('should return false', async () => {
     const result = NumbersHelper.isGreaterThan(0.7, 1.2);
+
+    expect(result).toBeFalsy();
+  });
+});
+
+describe('isLessThan', () => {
+  it('should return true', async () => {
+    const result = NumbersHelper.isLessThan(0.2, 0.7);
+
+    expect(result).toBeTruthy();
+  });
+
+  it('should return false', async () => {
+    const result = NumbersHelper.isLessThan(1.7, 1.2);
 
     expect(result).toBeFalsy();
   });

--- a/tests/unit/helpers/numbers.test.js
+++ b/tests/unit/helpers/numbers.test.js
@@ -3,11 +3,25 @@ const expect = require('expect');
 const NumbersHelper = require('../../../src/helpers/numbers');
 
 describe('toBN', () => {
-  it('should multiply numbers', async () => {
+  it('should return BN object', async () => {
     const result = NumbersHelper.toBN(0.1);
 
     expect(BigNumber.isBigNumber(result)).toBeTruthy();
     expect(result.toString()).toEqual('0.1');
+  });
+});
+
+describe('toFixed', () => {
+  it('should round BN', () => {
+    const result = NumbersHelper.toFixed(BigNumber(1.234567));
+
+    expect(result).toEqual(1.23);
+  });
+
+  it('should round BN up', () => {
+    const result = NumbersHelper.toFixed(BigNumber(1.23987));
+
+    expect(result).toEqual(1.24);
   });
 });
 

--- a/tests/unit/helpers/numbers.test.js
+++ b/tests/unit/helpers/numbers.test.js
@@ -88,3 +88,30 @@ describe('subtract', () => {
     expect(result).toEqual('0.5');
   });
 });
+
+describe('isGreaterThan', () => {
+  it('should return true', async () => {
+    const result = NumbersHelper.isGreaterThan(0.7, 0.2);
+
+    expect(result).toBeTruthy();
+  });
+
+  it('should return false', async () => {
+    const result = NumbersHelper.isGreaterThan(0.7, 1.2);
+
+    expect(result).toBeFalsy();
+  });
+});
+
+describe('isEqualTo', () => {
+  it('should return true', () => {
+    const result = NumbersHelper.isEqualTo(1.23, 1.23);
+
+    expect(result).toBeTruthy();
+  });
+  it('should return false', () => {
+    const result = NumbersHelper.isEqualTo(1.23, 2.45);
+
+    expect(result).toBeFalsy();
+  });
+});

--- a/tests/unit/helpers/utils.test.js
+++ b/tests/unit/helpers/utils.test.js
@@ -349,7 +349,9 @@ describe('getExclTaxes', () => {
 
 describe('sumReduce', () => {
   it('should sum element in array', () => {
-    expect(UtilsHelper.sumReduce([{ incl: 20 }, { incl: 12, excl: 23 }], 'incl')).toEqual(32);
+    const result = UtilsHelper.sumReduce([{ incl: 20 }, { incl: 12, excl: 23 }], 'incl');
+
+    expect(result).toEqual('32');
   });
 });
 

--- a/tests/unit/helpers/utils.test.js
+++ b/tests/unit/helpers/utils.test.js
@@ -3,7 +3,6 @@ const sinon = require('sinon');
 const { ObjectId } = require('mongodb');
 const omit = require('lodash/omit');
 const pick = require('lodash/pick');
-
 const UtilsHelper = require('../../../src/helpers/utils');
 
 describe('getLastVersion', () => {
@@ -342,13 +341,9 @@ describe('isStringedObjectId', () => {
 
 describe('getExclTaxes', () => {
   it('should return excluded taxes price', () => {
-    expect(Number.parseFloat(UtilsHelper.getExclTaxes(20, 2).toFixed(2))).toEqual(19.61);
-  });
-});
+    const result = UtilsHelper.getExclTaxes(20, 25);
 
-describe('getInclTaxes', () => {
-  it('should return excluded taxes price', () => {
-    expect(UtilsHelper.getInclTaxes(20, 2)).toEqual(20.4);
+    expect(result).toEqual('16');
   });
 });
 


### PR DESCRIPTION
<details open><summary> TESTS  :computer: </summary>

- [x] J'ai codé les tests unitaires
- [x] J'ai codé les tests d'intégration
- [ ] C'est une ancienne route utilisée par les apps mobiles.
  - [ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens
</details>

- [ ] Je replie cette section car mes modifications n'ont pas besoin de tests unitaires ou d'intégration

---

<details open><summary> POINTS D'ATTENTION POUR CETTE PR  :warning: </summary>

- [ ] J'ai fait des modifications sur une route utilisée sur plusieurs plateformes [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/n3bq2hr9Ia)
- [ ] J'ai modifié un modèle utilisé en mobile [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/rqTfwpUib)
- [ ] J'ai ajouté un modèle spécifique à une structure 
  - [ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés
- [ ] J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile
  - [ ] Si oui, j'ai précisé sur le [slite de MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) qu'il faut forcer la mise à jour
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

</details>

- [x] Je replie cette section car je n'ai pas fait de modifications entrainant un point d'attention

---

<details open><summary> FONCTIONNALITÉS APPS MOBILES  :iphone: </summary>

- [ ] Mes changements impactent l'application formation
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours
- [ ] Mes changements impactent l'application erp
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours

</details>

- [x] Je replie cette section car mes modifications n'ont pas d'impact sur les applications mobiles

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : Admin client

- Cas d'usage : Sur la page a facturer, il n'y a pas de decalage de centime dans les montants

- Comment tester ? : 
    - Créer un bénéficiaire avec une souscription a 25.45 euros TTC (utiliser un service avec un article de facturation / intervention de 2 euros TTC) 
    - Lui créer 4 interventions : 
        - 16h04 - 17h54
        - 15h38 - 17h17 
        - 13h33 - 15h01
        - 9h50 - 11h11
    - Aller sur la page a facturer
        - sur la branche feature-big-number-bills, il y a `33` centimes
        - sur cette branche, `34` centimes 

_Si tu as lu cette description, pense a réagir avec un :eye:_
