### PR TITLE
Com 2822

### DIFF
--- a/src/helpers/dates.js
+++ b/src/helpers/dates.js
@@ -1,4 +1,5 @@
 const moment = require('moment');
+const { CompaniDate } = require('./dates/companiDates');
 
 exports.isBefore = (date1, date2, ref = '') => {
   let formattedDate1 = date1;
@@ -105,6 +106,6 @@ exports.formatDateAndTime = (date, format = '') => {
     .replace(', ', ' ');
 };
 
-exports.ascendingSort = key => (a, b) => new Date(a[key]) - new Date(b[key]);
+exports.ascendingSort = key => (a, b) => CompaniDate(a[key]).diff(b[key], 'milliseconds').milliseconds;
 
-exports.descendingSort = key => (a, b) => new Date(b[key]) - new Date(a[key]);
+exports.descendingSort = key => (a, b) => CompaniDate(b[key]).diff(a[key], 'milliseconds').milliseconds;

--- a/src/helpers/eventHistories.js
+++ b/src/helpers/eventHistories.js
@@ -17,7 +17,7 @@ const UtilsHelper = require('./utils');
 const EventHistoryRepository = require('../repositories/EventHistoryRepository');
 const { CompaniDate } = require('./dates/companiDates');
 
-exports.PROJECTION_FILEDS = {
+exports.PROJECTION_FIELDS = {
   _id: 1,
   customer: 1,
   startDate: 1,

--- a/src/helpers/eventHistories.js
+++ b/src/helpers/eventHistories.js
@@ -17,6 +17,22 @@ const UtilsHelper = require('./utils');
 const EventHistoryRepository = require('../repositories/EventHistoryRepository');
 const { CompaniDate } = require('./dates/companiDates');
 
+exports.PROJECTION_FILEDS = {
+  _id: 1,
+  customer: 1,
+  startDate: 1,
+  endDate: 1,
+  type: 1,
+  absence: 1,
+  internalHour: 1,
+  address: 1,
+  misc: 1,
+  repetition: 1,
+  sector: 1,
+  auxiliary: 1,
+  isBilled: 1,
+};
+
 exports.list = async (query, credentials) => {
   if (query.eventId) {
     return EventHistoryRepository.paginate({

--- a/src/helpers/events.js
+++ b/src/helpers/events.js
@@ -433,16 +433,16 @@ exports.createEventHistoryOnDeleteList = async (events, credentials) => {
 };
 
 exports.deleteEventsAndRepetition = async (query, shouldDeleteRepetitions, credentials) => {
-  const events = await Event.find(query).lean();
+  const events = await Event.find(query, EventHistoriesHelper.PROJECTION_FILEDS).lean();
 
   await EventsValidationHelper.checkDeletionIsAllowed(events);
 
   if (!shouldDeleteRepetitions) {
-    await this.createEventHistoryOnDeleteList(events, credentials);
+    await exports.createEventHistoryOnDeleteList(events, credentials);
   } else {
     const eventsGroupedByParentId = groupBy(events, el => get(el, 'repetition.parentId') || '');
     for (const groupId of Object.keys(eventsGroupedByParentId)) {
-      if (!groupId) await this.createEventHistoryOnDeleteList(eventsGroupedByParentId[groupId], credentials);
+      if (!groupId) await exports.createEventHistoryOnDeleteList(eventsGroupedByParentId[groupId], credentials);
       else {
         const firstEvent = UtilsHelper.getFirstVersion(eventsGroupedByParentId[groupId], 'startDate');
         await EventHistoriesHelper.createEventHistoryOnDelete(firstEvent, credentials);

--- a/src/helpers/events.js
+++ b/src/helpers/events.js
@@ -442,10 +442,10 @@ exports.deleteEventsAndRepetition = async (query, shouldDeleteRepetitions, crede
   } else {
     const eventsGroupedByParentId = groupBy(events, el => get(el, 'repetition.parentId') || '');
     for (const groupId of Object.keys(eventsGroupedByParentId)) {
-      if (!groupId) {
-        await this.createEventHistoryOnDeleteList(eventsGroupedByParentId[groupId], credentials);
-      } else {
-        await EventHistoriesHelper.createEventHistoryOnDelete(eventsGroupedByParentId[groupId][0], credentials);
+      if (!groupId) await this.createEventHistoryOnDeleteList(eventsGroupedByParentId[groupId], credentials);
+      else {
+        const firstEvent = UtilsHelper.getFirstVersion(eventsGroupedByParentId[groupId], 'startDate');
+        await EventHistoriesHelper.createEventHistoryOnDelete(firstEvent, credentials);
         await Repetition.deleteOne({ parentId: groupId });
       }
     }

--- a/src/helpers/events.js
+++ b/src/helpers/events.js
@@ -433,7 +433,7 @@ exports.createEventHistoryOnDeleteList = async (events, credentials) => {
 };
 
 exports.deleteEventsAndRepetition = async (query, shouldDeleteRepetitions, credentials) => {
-  const events = await Event.find(query, EventHistoriesHelper.PROJECTION_FILEDS).lean();
+  const events = await Event.find(query, EventHistoriesHelper.PROJECTION_FIELDS).lean();
 
   await EventsValidationHelper.checkDeletionIsAllowed(events);
 

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -12,7 +12,15 @@ const NumbersHelper = require('./numbers');
 exports.getLastVersion = (versions, dateKey) => {
   if (versions.length === 0) return null;
   if (versions.length === 1) return versions[0];
-  return [...versions].sort((a, b) => new Date(b[dateKey]) - new Date(a[dateKey]))[0];
+
+  return [...versions].sort(DatesHelper.descendingSort(dateKey))[0];
+};
+
+exports.getFirstVersion = (versions, dateKey) => {
+  if (versions.length === 0) return null;
+  if (versions.length === 1) return versions[0];
+
+  return [...versions].sort(DatesHelper.ascendingSort(dateKey))[0];
 };
 
 exports.mergeLastVersionWithBaseObject = (baseObj, dateKey) => {

--- a/tests/unit/helpers/events.test.js
+++ b/tests/unit/helpers/events.test.js
@@ -1691,7 +1691,7 @@ describe('deleteEventsAndRepetition', () => {
     sinon.assert.calledOnceWithExactly(checkDeletionIsAllowed, events);
     SinonMongoose.calledOnceWithExactly(
       find,
-      [{ query: 'find', args: [query, EventHistoriesHelper.PROJECTION_FILEDS] }, { query: 'lean' }]
+      [{ query: 'find', args: [query, EventHistoriesHelper.PROJECTION_FIELDS] }, { query: 'lean' }]
     );
   });
 
@@ -1753,7 +1753,7 @@ describe('deleteEventsAndRepetition', () => {
     sinon.assert.calledOnceWithExactly(checkDeletionIsAllowed, events);
     SinonMongoose.calledOnceWithExactly(
       find,
-      [{ query: 'find', args: [query, EventHistoriesHelper.PROJECTION_FILEDS] }, { query: 'lean' }]
+      [{ query: 'find', args: [query, EventHistoriesHelper.PROJECTION_FIELDS] }, { query: 'lean' }]
     );
   });
 
@@ -1784,7 +1784,7 @@ describe('deleteEventsAndRepetition', () => {
       sinon.assert.calledOnceWithExactly(checkDeletionIsAllowed, events);
       SinonMongoose.calledOnceWithExactly(
         find,
-        [{ query: 'find', args: [query, EventHistoriesHelper.PROJECTION_FILEDS] }, { query: 'lean' }]
+        [{ query: 'find', args: [query, EventHistoriesHelper.PROJECTION_FIELDS] }, { query: 'lean' }]
       );
     }
   });
@@ -1816,7 +1816,7 @@ describe('deleteEventsAndRepetition', () => {
       sinon.assert.calledOnceWithExactly(checkDeletionIsAllowed, events);
       SinonMongoose.calledOnceWithExactly(
         find,
-        [{ query: 'find', args: [query, EventHistoriesHelper.PROJECTION_FILEDS] }, { query: 'lean' }]
+        [{ query: 'find', args: [query, EventHistoriesHelper.PROJECTION_FIELDS] }, { query: 'lean' }]
       );
     }
   });

--- a/tests/unit/helpers/events.test.js
+++ b/tests/unit/helpers/events.test.js
@@ -1725,8 +1725,8 @@ describe('deleteEventsAndRepetition', () => {
         customer: customerId,
         type: 'unavailability',
         repetition: { frequency: EVERY_WEEK, parentId },
-        startDate: '2019-10-7T11:30:00.000Z',
-        endDate: '2019-10-7T13:00:00.000Z',
+        startDate: '2019-10-07T11:30:00.000Z',
+        endDate: '2019-10-07T13:00:00.000Z',
         auxiliary: userId,
       },
       {
@@ -1738,17 +1738,13 @@ describe('deleteEventsAndRepetition', () => {
         auxiliary: userId,
       },
     ];
-    const eventsGroupedByParentId = {
-      '': [events[0], events[3]],
-      [parentId]: [events[1], events[2]],
-    };
 
     find.returns(SinonMongoose.stubChainedQueries(events, ['lean']));
 
     await EventHelper.deleteEventsAndRepetition(query, true, credentials);
 
-    sinon.assert.calledOnceWithExactly(createEventHistoryOnDeleteList, eventsGroupedByParentId[''], credentials);
-    sinon.assert.calledOnceWithExactly(createEventHistoryOnDelete, eventsGroupedByParentId[parentId][0], credentials);
+    sinon.assert.calledOnceWithExactly(createEventHistoryOnDeleteList, [events[0], events[3]], credentials);
+    sinon.assert.calledOnceWithExactly(createEventHistoryOnDelete, events[2], credentials);
     sinon.assert.calledOnceWithExactly(repetitionDeleteOne, { parentId });
     sinon.assert.calledOnceWithExactly(deleteMany, { _id: { $in: events.map(ev => ev._id) } });
     sinon.assert.calledOnceWithExactly(checkDeletionIsAllowed, events);

--- a/tests/unit/helpers/events.test.js
+++ b/tests/unit/helpers/events.test.js
@@ -1689,7 +1689,10 @@ describe('deleteEventsAndRepetition', () => {
     sinon.assert.notCalled(createEventHistoryOnDelete);
     sinon.assert.notCalled(repetitionDeleteOne);
     sinon.assert.calledOnceWithExactly(checkDeletionIsAllowed, events);
-    SinonMongoose.calledOnceWithExactly(find, [{ query: 'find', args: [query] }, { query: 'lean' }]);
+    SinonMongoose.calledOnceWithExactly(
+      find,
+      [{ query: 'find', args: [query, EventHistoriesHelper.PROJECTION_FILEDS] }, { query: 'lean' }]
+    );
   });
 
   it('should delete events with repetitions', async () => {
@@ -1748,7 +1751,10 @@ describe('deleteEventsAndRepetition', () => {
     sinon.assert.calledOnceWithExactly(repetitionDeleteOne, { parentId });
     sinon.assert.calledOnceWithExactly(deleteMany, { _id: { $in: events.map(ev => ev._id) } });
     sinon.assert.calledOnceWithExactly(checkDeletionIsAllowed, events);
-    SinonMongoose.calledOnceWithExactly(find, [{ query: 'find', args: [query] }, { query: 'lean' }]);
+    SinonMongoose.calledOnceWithExactly(
+      find,
+      [{ query: 'find', args: [query, EventHistoriesHelper.PROJECTION_FILEDS] }, { query: 'lean' }]
+    );
   });
 
   it('should not delete event if at least one is billed', async () => {
@@ -1776,7 +1782,10 @@ describe('deleteEventsAndRepetition', () => {
       sinon.assert.notCalled(createEventHistoryOnDeleteList);
       sinon.assert.notCalled(deleteMany);
       sinon.assert.calledOnceWithExactly(checkDeletionIsAllowed, events);
-      SinonMongoose.calledOnceWithExactly(find, [{ query: 'find', args: [query] }, { query: 'lean' }]);
+      SinonMongoose.calledOnceWithExactly(
+        find,
+        [{ query: 'find', args: [query, EventHistoriesHelper.PROJECTION_FILEDS] }, { query: 'lean' }]
+      );
     }
   });
 
@@ -1805,7 +1814,10 @@ describe('deleteEventsAndRepetition', () => {
       sinon.assert.notCalled(createEventHistoryOnDeleteList);
       sinon.assert.notCalled(deleteMany);
       sinon.assert.calledOnceWithExactly(checkDeletionIsAllowed, events);
-      SinonMongoose.calledOnceWithExactly(find, [{ query: 'find', args: [query] }, { query: 'lean' }]);
+      SinonMongoose.calledOnceWithExactly(
+        find,
+        [{ query: 'find', args: [query, EventHistoriesHelper.PROJECTION_FILEDS] }, { query: 'lean' }]
+      );
     }
   });
 });

--- a/tests/unit/helpers/utils.test.js
+++ b/tests/unit/helpers/utils.test.js
@@ -34,7 +34,7 @@ describe('getLastVersion', () => {
 });
 
 describe('getFirstVersion', () => {
-  it('should return the last version based on the date key', () => {
+  it('should return the first version based on the date key', () => {
     const versions = [
       { startDate: '2021-09-21T00:00:00', createdAt: '2021-09-21T00:00:00', _id: 1 },
       { startDate: '2021-09-24T00:00:00', createdAt: '2021-09-18T00:00:00', _id: 2 },

--- a/tests/unit/helpers/utils.test.js
+++ b/tests/unit/helpers/utils.test.js
@@ -23,7 +23,7 @@ describe('getLastVersion', () => {
     expect(UtilsHelper.getLastVersion([], 'toto')).toBeNull();
   });
 
-  it('should return the single element is versions only contains one element', () => {
+  it('should return the single element if versions only contains one element', () => {
     const versions = [{ startDate: '2021-09-21T00:00:00', createdAt: '2021-09-21T00:00:00', _id: 1 }];
 
     const result = UtilsHelper.getLastVersion(versions, 'startDate');
@@ -50,7 +50,7 @@ describe('getFirstVersion', () => {
     expect(UtilsHelper.getFirstVersion([], 'toto')).toBeNull();
   });
 
-  it('should return the single element is versions only contains one element', () => {
+  it('should return the single element if versions only contains one element', () => {
     const versions = [{ startDate: '2021-09-21T00:00:00', createdAt: '2021-09-21T00:00:00', _id: 1 }];
 
     const result = UtilsHelper.getFirstVersion(versions, 'startDate');

--- a/tests/unit/helpers/utils.test.js
+++ b/tests/unit/helpers/utils.test.js
@@ -33,6 +33,33 @@ describe('getLastVersion', () => {
   });
 });
 
+describe('getFirstVersion', () => {
+  it('should return the last version based on the date key', () => {
+    const versions = [
+      { startDate: '2021-09-21T00:00:00', createdAt: '2021-09-21T00:00:00', _id: 1 },
+      { startDate: '2021-09-24T00:00:00', createdAt: '2021-09-18T00:00:00', _id: 2 },
+    ];
+
+    expect(UtilsHelper.getFirstVersion(versions, 'startDate')).toBeDefined();
+    expect(UtilsHelper.getFirstVersion(versions, 'startDate')._id).toEqual(1);
+    expect(UtilsHelper.getFirstVersion(versions, 'createdAt')).toBeDefined();
+    expect(UtilsHelper.getFirstVersion(versions, 'createdAt')._id).toEqual(2);
+  });
+
+  it('should return null if versions is empty', () => {
+    expect(UtilsHelper.getFirstVersion([], 'toto')).toBeNull();
+  });
+
+  it('should return the single element is versions only contains one element', () => {
+    const versions = [{ startDate: '2021-09-21T00:00:00', createdAt: '2021-09-21T00:00:00', _id: 1 }];
+
+    const result = UtilsHelper.getFirstVersion(versions, 'startDate');
+
+    expect(result).toBeDefined();
+    expect(result._id).toEqual(1);
+  });
+});
+
 describe('mergeLastVersionWithBaseObject', () => {
   let getLastVersion;
   beforeEach(() => {


### PR DESCRIPTION
<details open><summary> TESTS  :computer: </summary>

- [x] J'ai codé les tests unitaires
- [ ] J'ai codé les tests d'intégration
- [ ] C'est une ancienne route utilisée par les apps mobiles.
  - [ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens
</details>

- [ ] Je replie cette section car mes modifications n'ont pas besoin de tests unitaires ou d'intégration

---

<details><summary> POINTS D'ATTENTION POUR CETTE PR  :warning: </summary>

- [ ] J'ai fait des modifications sur une route utilisée sur plusieurs plateformes [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/n3bq2hr9Ia)
- [ ] J'ai modifié un modèle utilisé en mobile [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/rqTfwpUib)
- [ ] J'ai ajouté un modèle spécifique à une structure 
  - [ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés
- [ ] J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile
  - [ ] Si oui, j'ai précisé sur le [slite de MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) qu'il faut forcer la mise à jour
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

</details>

- [x] Je replie cette section car je n'ai pas fait de modifications entrainant un point d'attention

---

<details><summary> FONCTIONNALITÉS APPS MOBILES  :iphone: </summary>

- [ ] Mes changements impactent l'application formation
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours
- [ ] Mes changements impactent l'application erp
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours

</details>

- [x] Je replie cette section car mes modifications n'ont pas d'impact sur les applications mobiles

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : Auxiliaire et coach

- Cas d'usage : quand je supprime un evenement en repetition et tous les suivants, l'historique est crée avec les bonnes infos

- Comment tester ? : Prendre une repetition existante et la supprimer en ne choississant pas le dernier evenement de cette serie. L'historique doit avoir les bonnes infos

_Si tu as lu cette description, pense a réagir avec un :eye:_
