### PR TITLE
Com 2809-2

### DIFF
--- a/src/helpers/bills.js
+++ b/src/helpers/bills.js
@@ -1,7 +1,6 @@
 const moment = require('moment');
 const get = require('lodash/get');
 const pick = require('lodash/pick');
-const flat = require('flat');
 const Event = require('../models/Event');
 const Bill = require('../models/Bill');
 const BillingItem = require('../models/BillingItem');
@@ -130,11 +129,8 @@ exports.formatThirdPartyPayerBills = (thirdPartyPayerBills, customer, number, co
     for (const draftBill of tpp.bills) {
       tppBill.subscriptions.push(exports.formatSubscriptionData(draftBill));
       for (const ev of draftBill.eventsList) {
-        if (ev.history.nature === HOURLY) {
-          billedEvents[ev.event] = { ...ev, careHours: ev.history.careHours };
-        } else {
-          billedEvents[ev.event] = { ...ev };
-        }
+        if (ev.history.nature === HOURLY) billedEvents[ev.event] = { ...ev, careHours: ev.history.careHours };
+        else billedEvents[ev.event] = { ...ev };
 
         if (ev.history.month) {
           if (!histories[ev.history.fundingId]) histories[ev.history.fundingId] = { [ev.history.month]: ev.history };
@@ -185,14 +181,14 @@ exports.updateFundingHistories = async (histories, companyId) => {
       const newAmountTTC = NumbersHelper.add(get(fundingHistory, 'amountTTC') || 0, histories[id].amountTTC);
       promises.push(FundingHistory.updateOne(
         { fundingId: id, company: companyId },
-        { $set: flat({ amountTTC: newAmountTTC }) },
+        { $set: { amountTTC: newAmountTTC } },
         { new: true, upsert: true, setDefaultsOnInsert: true }
       ));
     } else if (histories[id].careHours && !NumbersHelper.isEqualTo(histories[id].careHours, '0')) {
       const newCareHours = NumbersHelper.add(get(fundingHistory, 'careHours') || 0, histories[id].careHours);
       promises.push(FundingHistory.updateOne(
         { fundingId: id, company: companyId },
-        { $set: flat({ careHours: newCareHours }) },
+        { $set: { careHours: newCareHours } },
         { new: true, upsert: true, setDefaultsOnInsert: true }
       ));
     } else {
@@ -204,7 +200,7 @@ exports.updateFundingHistories = async (histories, companyId) => {
 
         promises.push(FundingHistory.updateOne(
           { fundingId: id, month, company: companyId },
-          { $set: flat({ careHours: newCareHours }) },
+          { $set: { careHours: newCareHours } },
           { new: true, upsert: true, setDefaultsOnInsert: true }
         ));
       }

--- a/src/helpers/bills.js
+++ b/src/helpers/bills.js
@@ -37,7 +37,7 @@ exports.formatSubscriptionData = (bill) => {
 
   return {
     ...pick(bill, ['startDate', 'endDate', 'hours', 'unitInclTaxes', 'exclTaxes']),
-    inclTaxes: parseFloat(UtilsHelper.getFixedNumber(bill.inclTaxes)),
+    inclTaxes: NumbersHelper.toFixedToFloat(bill.inclTaxes),
     subscription: bill.subscription._id,
     service: { serviceId: matchingServiceVersion._id, ...pick(matchingServiceVersion, ['name', 'nature']) },
     vat: matchingServiceVersion.vat,
@@ -48,7 +48,7 @@ exports.formatSubscriptionData = (bill) => {
 
 exports.formatBillingItemData = bill => ({
   ...pick(bill, ['startDate', 'endDate', 'unitInclTaxes', 'exclTaxes', 'vat']),
-  inclTaxes: parseFloat(UtilsHelper.getFixedNumber(bill.inclTaxes)),
+  inclTaxes: NumbersHelper.toFixedToFloat(bill.inclTaxes),
   billingItem: bill.billingItem._id,
   events: bill.eventsList.map(ev => ({ ...pick(ev, ['startDate', 'endDate', 'auxiliary']), eventId: ev.event })),
   name: bill.billingItem.name,

--- a/src/helpers/bills.js
+++ b/src/helpers/bills.js
@@ -35,22 +35,24 @@ exports.formatSubscriptionData = (bill) => {
   const matchingServiceVersion = UtilsHelper.getMatchingVersion(bill.endDate, bill.subscription.service, 'startDate');
 
   return {
-    ...pick(bill, ['startDate', 'endDate', 'hours', 'unitInclTaxes', 'exclTaxes', 'discount']),
+    ...pick(bill, ['startDate', 'endDate', 'hours', 'unitInclTaxes', 'exclTaxes']),
     inclTaxes: parseFloat(UtilsHelper.getFixedNumber(bill.inclTaxes)),
     subscription: bill.subscription._id,
     service: { serviceId: matchingServiceVersion._id, ...pick(matchingServiceVersion, ['name', 'nature']) },
     vat: matchingServiceVersion.vat,
     events: exports.formatBilledEvents(bill),
+    discount: NumbersHelper.toFixedToFloat(bill.discount),
   };
 };
 
 exports.formatBillingItemData = bill => ({
-  ...pick(bill, ['startDate', 'endDate', 'unitInclTaxes', 'exclTaxes', 'vat', 'discount']),
+  ...pick(bill, ['startDate', 'endDate', 'unitInclTaxes', 'exclTaxes', 'vat']),
   inclTaxes: parseFloat(UtilsHelper.getFixedNumber(bill.inclTaxes)),
   billingItem: bill.billingItem._id,
   events: bill.eventsList.map(ev => ({ ...pick(ev, ['startDate', 'endDate', 'auxiliary']), eventId: ev.event })),
   name: bill.billingItem.name,
   count: bill.eventsList.length,
+  discount: NumbersHelper.toFixedToFloat(bill.discount),
 });
 
 exports.formatCustomerBills = (customerBills, customer, number, company) => {

--- a/src/helpers/draftBills.js
+++ b/src/helpers/draftBills.js
@@ -345,7 +345,7 @@ exports.getDraftBillsPerSubscription = (events, subscription, fundings, billingS
     startDate: startDate.toDate(),
     endDate: moment(endDate, 'YYYYMMDD').toDate(),
     unitExclTaxes: UtilsHelper.getExclTaxes(unitTTCRate, serviceMatchingVersion.vat),
-    unitInclTaxes: NumbersHelper.toString(unitTTCRate),
+    unitInclTaxes: unitTTCRate,
     vat: serviceMatchingVersion.vat || 0,
   };
 
@@ -401,7 +401,7 @@ exports.formatBillingItems = (eventsByBillingItemBySubscriptions, billingItems, 
       billingItem: { _id: new ObjectId(billingItemId), name: bddBillingItem.name },
       discount: 0,
       unitExclTaxes,
-      unitInclTaxes: NumbersHelper.toString(bddBillingItem.defaultUnitAmount),
+      unitInclTaxes: bddBillingItem.defaultUnitAmount,
       vat: bddBillingItem.vat,
       eventsList: eventsList.map(ev => ({ event: ev._id, ...pick(ev, ['startDate', 'endDate', 'auxiliary']) })),
       exclTaxes: NumbersHelper.multiply(unitExclTaxes, eventsList.length),

--- a/src/helpers/draftBills.js
+++ b/src/helpers/draftBills.js
@@ -1,4 +1,5 @@
 const get = require('lodash/get');
+const has = require('lodash/has');
 const pick = require('lodash/pick');
 const { ObjectId } = require('mongodb');
 const moment = require('../extensions/moment');

--- a/src/helpers/draftBills.js
+++ b/src/helpers/draftBills.js
@@ -1,5 +1,4 @@
 const get = require('lodash/get');
-const has = require('lodash/has');
 const pick = require('lodash/pick');
 const { ObjectId } = require('mongodb');
 const moment = require('../extensions/moment');

--- a/src/models/Bill.js
+++ b/src/models/Bill.js
@@ -35,7 +35,7 @@ const BillSchema = mongoose.Schema({
       inclTaxesCustomer: { type: String, required() { return !this.fundingId; } },
       exclTaxesTpp: { type: String, required() { return this.fundingId; } },
       inclTaxesTpp: { type: String, required() { return this.fundingId; } },
-      careHours: { type: Number },
+      careHours: { type: String },
     }],
     hours: { type: String, required() { return this.type === AUTOMATIC; } },
     unitInclTaxes: { type: Number, required() { return this.type === AUTOMATIC; } },

--- a/src/models/Bill.js
+++ b/src/models/Bill.js
@@ -41,7 +41,7 @@ const BillSchema = mongoose.Schema({
     unitInclTaxes: { type: String, required() { return this.type === AUTOMATIC; } },
     exclTaxes: { type: String, required() { return this.type === AUTOMATIC; } },
     inclTaxes: { type: Number, required() { return this.type === AUTOMATIC; } },
-    discount: { type: String, default: '0' },
+    discount: { type: Number, default: 0 },
   }],
   origin: { type: String, enum: BILL_ORIGINS, default: COMPANI },
   netInclTaxes: { type: Number, required: true },

--- a/src/models/Bill.js
+++ b/src/models/Bill.js
@@ -38,7 +38,7 @@ const BillSchema = mongoose.Schema({
       careHours: { type: Number },
     }],
     hours: { type: String, required() { return this.type === AUTOMATIC; } },
-    unitInclTaxes: { type: String, required() { return this.type === AUTOMATIC; } },
+    unitInclTaxes: { type: Number, required() { return this.type === AUTOMATIC; } },
     exclTaxes: { type: String, required() { return this.type === AUTOMATIC; } },
     inclTaxes: { type: Number, required() { return this.type === AUTOMATIC; } },
     discount: { type: Number, default: 0 },

--- a/src/models/Event.js
+++ b/src/models/Event.js
@@ -112,7 +112,7 @@ const EventSchema = mongoose.Schema(
       exclTaxesTpp: { type: String },
       fundingId: { type: mongoose.Schema.Types.ObjectId },
       nature: { type: String },
-      careHours: { type: Number },
+      careHours: { type: String },
       surcharges: { type: billEventSurchargesSchemaDefinition, _id: 0 },
       billingItems: { type: billingItemsInEventDefinition, _id: 0 },
     },

--- a/src/models/FundingHistory.js
+++ b/src/models/FundingHistory.js
@@ -4,8 +4,8 @@ const { validateQuery, validateAggregation, formatQuery, formatQueryMiddlewareLi
 const FundingHistorySchema = mongoose.Schema({
   company: { type: mongoose.Schema.Types.ObjectId, ref: 'Company', required: true },
   fundingId: { type: mongoose.Schema.Types.ObjectId },
-  amountTTC: { type: Number, default: 0 },
-  careHours: { type: Number, default: 0 },
+  amountTTC: { type: String, default: '0' },
+  careHours: { type: String, default: '0' },
   month: { type: String },
 }, { timestamps: true });
 

--- a/src/models/schemaDefinitions/billing.js
+++ b/src/models/schemaDefinitions/billing.js
@@ -21,7 +21,7 @@ const billingItemsInCreditNoteDefinition = billingItemsDefinition;
 
 const billingItemsInBillDefinition = {
   ...billingItemsDefinition,
-  discount: { type: String, default: '0' },
+  discount: { type: Number, default: 0 },
   startDate: { type: Date },
   endDate: { type: Date },
   events: [{

--- a/src/routes/bills.js
+++ b/src/routes/bills.js
@@ -80,7 +80,7 @@ exports.plugin = {
                   startDate: Joi.date().required(),
                   endDate: Joi.date().required(),
                   unitExclTaxes: Joi.string().required(),
-                  unitInclTaxes: Joi.string().required(),
+                  unitInclTaxes: Joi.number().required(),
                   eventsList: Joi.array().items(Joi.object({
                     event: Joi.objectId().required(),
                     startDate: Joi.date().required(),
@@ -117,7 +117,7 @@ exports.plugin = {
                   startDate: Joi.date().required(),
                   endDate: Joi.date().required(),
                   unitExclTaxes: Joi.string().required(),
-                  unitInclTaxes: Joi.string().required(),
+                  unitInclTaxes: Joi.number().required(),
                   eventsList: Joi.array().items(Joi.object({
                     event: Joi.objectId().required(),
                     startDate: Joi.date().required(),

--- a/tests/integration/seed/billsSeed.js
+++ b/tests/integration/seed/billsSeed.js
@@ -633,7 +633,7 @@ const customerFromOtherCompany = {
 const fundingHistory = {
   _id: new ObjectId(),
   fundingId: new ObjectId(),
-  amountTTC: 12,
+  amountTTC: '12',
   nature: 'fixed',
   company: authCompany._id,
 };

--- a/tests/unit/helpers/bills.test.js
+++ b/tests/unit/helpers/bills.test.js
@@ -1,6 +1,5 @@
 const expect = require('expect');
 const moment = require('moment');
-const flat = require('flat');
 const sinon = require('sinon');
 const { ObjectId } = require('mongodb');
 const pick = require('lodash/pick');
@@ -1160,7 +1159,7 @@ describe('updateFundingHistories', () => {
     sinon.assert.calledWithExactly(
       updateOne,
       { fundingId: fundingId.toHexString(), company: companyId },
-      { $set: flat({ amountTTC: '14.34' }) },
+      { $set: { amountTTC: '14.34' } },
       { new: true, upsert: true, setDefaultsOnInsert: true }
     );
   });
@@ -1225,13 +1224,13 @@ describe('updateFundingHistories', () => {
     sinon.assert.calledWithExactly(
       updateOne.getCall(0),
       { fundingId: fundingId.toHexString(), company: companyId, month: '11' },
-      { $set: flat({ careHours: '16.33' }) },
+      { $set: { careHours: '16.33' } },
       { new: true, upsert: true, setDefaultsOnInsert: true }
     );
     sinon.assert.calledWithExactly(
       updateOne.getCall(1),
       { fundingId: fundingId.toHexString(), company: companyId, month: '12' },
-      { $set: flat({ careHours: '160' }) },
+      { $set: { careHours: '160' } },
       { new: true, upsert: true, setDefaultsOnInsert: true }
     );
   });
@@ -1329,25 +1328,25 @@ describe('updateFundingHistories', () => {
     sinon.assert.calledWithExactly(
       updateOne.getCall(0),
       { fundingId: '1', company: companyId },
-      { $set: flat({ careHours: '26' }) },
+      { $set: { careHours: '26' } },
       { new: true, upsert: true, setDefaultsOnInsert: true }
     );
     sinon.assert.calledWithExactly(
       updateOne.getCall(1),
       { fundingId: '2', company: companyId },
-      { $set: flat({ amountTTC: '147.67' }) },
+      { $set: { amountTTC: '147.67' } },
       { new: true, upsert: true, setDefaultsOnInsert: true }
     );
     sinon.assert.calledWithExactly(
       updateOne.getCall(2),
       { fundingId: '3', company: companyId, month: '11' },
-      { $set: flat({ careHours: '80' }) },
+      { $set: { careHours: '80' } },
       { new: true, upsert: true, setDefaultsOnInsert: true }
     );
     sinon.assert.calledWithExactly(
       updateOne.getCall(3),
       { fundingId: '3', company: companyId, month: '12' },
-      { $set: flat({ careHours: '100' }) },
+      { $set: { careHours: '100' } },
       { new: true, upsert: true, setDefaultsOnInsert: true }
     );
   });

--- a/tests/unit/helpers/bills.test.js
+++ b/tests/unit/helpers/bills.test.js
@@ -148,7 +148,7 @@ describe('formatBilledEvents', () => {
         fundingId: 'fundingId',
         inclTaxesTpp: 5,
         exclTaxesTpp: 4,
-        careHours: 0.5,
+        careHours: '0.5',
       },
       {
         eventId: '456',
@@ -158,7 +158,7 @@ describe('formatBilledEvents', () => {
         fundingId: 'fundingId',
         inclTaxesTpp: 3,
         exclTaxesTpp: 2,
-        careHours: 2,
+        careHours: '2',
       },
     ]);
   });

--- a/tests/unit/helpers/draftbills.test.js
+++ b/tests/unit/helpers/draftbills.test.js
@@ -131,13 +131,13 @@ describe('populateFundings', () => {
     }];
     const tpps = [{ _id: tppId, billingMode: BILLING_DIRECT }];
     const funding = { ...fundings[0].versions[0], ...omit(fundings[0], ['versions']) };
-    const returnedHistory = { careHours: 4, fundingId };
+    const returnedHistory = { careHours: '4', fundingId };
     mergeLastVersionWithBaseObjectStub.returns(funding);
     findOneFundingHistory.returns(SinonMongoose.stubChainedQueries(returnedHistory, ['lean']));
 
     const result = await DraftBillsHelper.populateFundings(fundings, new Date(), tpps, companyId);
 
-    expect(result[0].history).toMatchObject([{ careHours: 4, fundingId }]);
+    expect(result[0].history).toMatchObject([{ careHours: '4', fundingId }]);
     sinon.assert.called(mergeLastVersionWithBaseObjectStub);
     SinonMongoose.calledOnceWithExactly(findOneFundingHistory, [
       { query: 'findOne', args: [{ fundingId: fundings[0]._id }] },
@@ -162,7 +162,7 @@ describe('populateFundings', () => {
 
     const result = await DraftBillsHelper.populateFundings(fundings, new Date(), tpps, companyId);
 
-    expect(result[0].history).toMatchObject([{ careHours: 0, amountTTC: 0, fundingId }]);
+    expect(result[0].history).toMatchObject([{ careHours: '0', amountTTC: '0', fundingId }]);
     sinon.assert.called(mergeLastVersionWithBaseObjectStub);
     SinonMongoose.calledOnceWithExactly(findOneFundingHistory, [
       { query: 'findOne', args: [{ fundingId: fundings[0]._id }] },
@@ -182,8 +182,8 @@ describe('populateFundings', () => {
     }];
     const tpps = [{ _id: tppId, billingMode: BILLING_DIRECT }];
     const returnedHistories = [
-      { careHours: 3, fundingId, month: '01/2019' },
-      { careHours: 5, fundingId, month: '02/2019' },
+      { careHours: '3', fundingId, month: '01/2019' },
+      { careHours: '5', fundingId, month: '02/2019' },
     ];
     const funding = { ...fundings[0].versions[0], ...omit(fundings[0], ['versions']) };
     mergeLastVersionWithBaseObjectStub.returns(funding);
@@ -193,7 +193,7 @@ describe('populateFundings', () => {
 
     expect(result[0].history.length).toEqual(3);
     const addedHistory = result[0].history.find(hist => hist.month === '03/2019');
-    expect(addedHistory).toMatchObject({ careHours: 0, amountTTC: 0, fundingId, month: '03/2019' });
+    expect(addedHistory).toMatchObject({ careHours: '0', amountTTC: '0', fundingId, month: '03/2019' });
     sinon.assert.called(mergeLastVersionWithBaseObjectStub);
     SinonMongoose.calledOnceWithExactly(findFundingHistory, [
       { query: 'find', args: [{ fundingId: fundings[0]._id, company: companyId }] },
@@ -276,7 +276,7 @@ describe('getThirdPartyPayerPrice', () => {
 describe('getMatchingHistory', () => {
   it('should return history for once frequency', () => {
     const fundingId = new ObjectId();
-    const funding = { _id: fundingId, frequency: 'once', history: [{ fundingId, careHours: 2 }] };
+    const funding = { _id: fundingId, frequency: 'once', history: [{ fundingId, careHours: '2' }] };
 
     const result = DraftBillsHelper.getMatchingHistory({}, funding);
 
@@ -288,13 +288,13 @@ describe('getMatchingHistory', () => {
     const funding = {
       _id: fundingId,
       frequency: 'monthly',
-      history: [{ fundingId, careHours: 2, month: '03/2019' }, { fundingId, careHours: 4, month: '02/2019' }],
+      history: [{ fundingId, careHours: '2', month: '03/2019' }, { fundingId, careHours: '4', month: '02/2019' }],
     };
     const event = { startDate: new Date('2019/03/12') };
 
     const result = DraftBillsHelper.getMatchingHistory(event, funding);
 
-    expect(result).toMatchObject({ fundingId, careHours: 2, month: '03/2019' });
+    expect(result).toMatchObject({ fundingId, careHours: '2', month: '03/2019' });
   });
 
   it('should create history and add to list when missing for monthly frequency', () => {
@@ -302,13 +302,13 @@ describe('getMatchingHistory', () => {
     const funding = {
       _id: fundingId,
       frequency: 'monthly',
-      history: [{ fundingId, careHours: 2, month: '01/2019' }, { fundingId, careHours: 4, month: '02/2019' }],
+      history: [{ fundingId, careHours: '2', month: '01/2019' }, { fundingId, careHours: '4', month: '02/2019' }],
     };
     const event = { startDate: new Date('2019/03/12') };
 
     const result = DraftBillsHelper.getMatchingHistory(event, funding);
 
-    expect(result).toMatchObject({ careHours: 0, amountTTC: 0, fundingId, month: '03/2019' });
+    expect(result).toMatchObject({ careHours: '0', amountTTC: '0', fundingId, month: '03/2019' });
   });
 });
 
@@ -330,15 +330,15 @@ describe('getHourlyFundingSplit', () => {
     const funding = {
       _id: new ObjectId(),
       unitTTCRate: 21,
-      careHours: 4,
+      careHours: '4',
       frequency: 'once',
       nature: 'hourly',
       customerParticipationRate: 20,
-      history: { careHours: 1 },
+      history: { careHours: '1' },
       thirdPartyPayer: { _id: new ObjectId() },
     };
 
-    getMatchingHistory.returns({ careHours: 1 });
+    getMatchingHistory.returns({ careHours: '1' });
     getThirdPartyPayerPrice.returns('28');
 
     const result = DraftBillsHelper.getHourlyFundingSplit(event, funding, price);
@@ -353,14 +353,14 @@ describe('getHourlyFundingSplit', () => {
     const funding = {
       _id: new ObjectId(),
       unitTTCRate: 21,
-      careHours: 4,
+      careHours: '4',
       frequency: 'once',
       customerParticipationRate: 20,
-      history: { careHours: 3 },
+      history: { careHours: '3' },
       thirdPartyPayer: { _id: new ObjectId() },
     };
 
-    getMatchingHistory.returns({ careHours: 3 });
+    getMatchingHistory.returns({ careHours: '3' });
     getThirdPartyPayerPrice.returns('14');
 
     const result = DraftBillsHelper.getHourlyFundingSplit(event, funding, price);
@@ -378,8 +378,8 @@ describe('getFixedFundingSplit', () => {
 
   it('Case 1. Event fully invoiced to TPP', () => {
     const funding = {
-      history: [{ amountTTC: 10 }],
-      amountTTC: 100,
+      history: [{ amountTTC: '10' }],
+      amountTTC: '100',
       thirdPartyPayer: { _id: new ObjectId() },
     };
 
@@ -392,8 +392,8 @@ describe('getFixedFundingSplit', () => {
 
   it('Case 2. Event partially invoiced to TPP', () => {
     const funding = {
-      history: [{ amountTTC: 79 }],
-      amountTTC: 100,
+      history: [{ amountTTC: '79' }],
+      amountTTC: '100',
       thirdPartyPayer: { _id: new ObjectId() },
     };
 
@@ -469,10 +469,10 @@ describe('getEventBilling', () => {
     const funding = {
       nature: 'hourly',
       unitTTCRate: 15,
-      careHours: 4,
+      careHours: '4',
       frequency: 'once',
       customerParticipationRate: 0,
-      history: { careHours: 1 },
+      history: { careHours: '1' },
       thirdPartyPayer: { _id: new ObjectId() },
     };
     getHourlyFundingSplit.returns({ customerPrice: '0', thirdPartyPayerPrice: '42' });
@@ -490,8 +490,8 @@ describe('getEventBilling', () => {
     const service = { vat: 20, nature: 'hourly' };
     const funding = {
       nature: 'fixed',
-      history: { amountTTC: 50 },
-      amountTTC: 100,
+      history: { amountTTC: '50' },
+      amountTTC: '100',
       thirdPartyPayer: { _id: new ObjectId() },
     };
     getFixedFundingSplit.returns({ customerPrice: '0', thirdPartyPayerPrice: '42' });
@@ -510,10 +510,10 @@ describe('getEventBilling', () => {
     const funding = {
       nature: 'hourly',
       unitTTCRate: 15,
-      careHours: 4,
+      careHours: '4',
       frequency: 'once',
       customerParticipationRate: 0,
-      history: { careHours: 1 },
+      history: { careHours: '1' },
       thirdPartyPayer: { _id: new ObjectId() },
     };
 
@@ -534,8 +534,8 @@ describe('getEventBilling', () => {
     const service = { vat: 20, nature: 'hourly', surcharge: { publicHoliday: 10 } };
     const funding = {
       nature: 'fixed',
-      history: { amountTTC: 50 },
-      amountTTC: 100,
+      history: { amountTTC: '50' },
+      amountTTC: '100',
       thirdPartyPayer: { _id: new ObjectId() },
     };
 
@@ -557,8 +557,8 @@ describe('getEventBilling', () => {
     const service = { vat: 20, nature: 'hourly' };
     const funding = {
       nature: 'fixed',
-      history: { amountTTC: 50 },
-      amountTTC: 100,
+      history: { amountTTC: '50' },
+      amountTTC: '100',
       thirdPartyPayer: { _id: new ObjectId() },
     };
 

--- a/tests/unit/helpers/draftbills.test.js
+++ b/tests/unit/helpers/draftbills.test.js
@@ -993,7 +993,7 @@ describe('getDraftBillsPerSubscription', () => {
 
     expect(result.customer.exclTaxes).toEqual('35');
     expect(result.customer.unitExclTaxes).toEqual('70');
-    expect(result.customer.unitInclTaxes).toEqual('21');
+    expect(result.customer.unitInclTaxes).toEqual(21);
     expect(result.thirdPartyPayer[tppId].hours).toEqual('3');
     expect(result.eventsByBillingItem).toEqual([{ d00000000000000000000001: [events[0]._id] }]);
     sinon.assert.calledOnceWithExactly(
@@ -1035,7 +1035,7 @@ describe('getDraftBillsPerSubscription', () => {
 
     expect(result.customer.exclTaxes).toEqual('35');
     expect(result.customer.unitExclTaxes).toEqual('70');
-    expect(result.customer.unitInclTaxes).toEqual('21');
+    expect(result.customer.unitInclTaxes).toEqual(21);
     expect(result.eventsByBillingItem).toEqual([]);
     sinon.assert.calledOnceWithExactly(
       getLastVersion,
@@ -1157,7 +1157,7 @@ describe('formatBillingItems', () => {
         billingItem: { _id: new ObjectId('d00000000000000000000001'), name: 'FI' },
         discount: 0,
         unitExclTaxes: '0.90909090909090909091',
-        unitInclTaxes: '1',
+        unitInclTaxes: 1,
         vat: 10,
         eventsList: [{ event: eventId1 }, { event: eventId2 }, { event: eventId3 }],
         exclTaxes: '2.72727272727272727273',
@@ -1169,7 +1169,7 @@ describe('formatBillingItems', () => {
         billingItem: { _id: new ObjectId('d00000000000000000000002'), name: 'EPI' },
         discount: 0,
         unitExclTaxes: '4.54545454545454545455',
-        unitInclTaxes: '5',
+        unitInclTaxes: 5,
         vat: 10,
         eventsList: [{ event: eventId1, auxiliary: '1234567' }, { event: eventId2 }],
         exclTaxes: '9.0909090909090909091',


### PR DESCRIPTION
<details open><summary> TESTS  :computer: </summary>

- [x] J'ai codé les tests unitaires
- [ ] J'ai codé les tests d'intégration
- [ ] C'est une ancienne route utilisée par les apps mobiles.
  - [ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens
</details>

- [ ] Je replie cette section car mes modifications n'ont pas besoin de tests unitaires ou d'intégration

---

<details open><summary> POINTS D'ATTENTION POUR CETTE PR  :warning: </summary>

- [ ] J'ai fait des modifications sur une route utilisée sur plusieurs plateformes [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/n3bq2hr9Ia)
- [x] J'ai modifié un modèle utilisé en mobile [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/rqTfwpUib)
    - on modifie le type de champs qui ne sont pas envoyés dans les appels des routes cote mobile 
- [ ] J'ai ajouté un modèle spécifique à une structure 
  - [ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés
- [ ] J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile
  - [ ] Si oui, j'ai précisé sur le [slite de MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) qu'il faut forcer la mise à jour
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

</details>

- [ ] Je replie cette section car je n'ai pas fait de modifications entrainant un point d'attention

---

<details open><summary> FONCTIONNALITÉS APPS MOBILES  :iphone: </summary>

- [ ] Mes changements impactent l'application formation
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours
- [ ] Mes changements impactent l'application erp
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours

</details>

- [x] Je replie cette section car mes modifications n'ont pas d'impact sur les applications mobiles

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : admin client

- Cas d'usage : lorsque je cree une facture avec des remises, les champs sont enregistres en bdd avec le bon type.

- Comment tester ? 
  - en front: se mettre sur la branche feature-big-number-bills
  - lancer le script
  - verifier que les pages balances clients, bordereaux tiers-payeur et onglet facture sur la page beneficiaire s'affichent correctement
  - creer un beneficiaire
  - ajouter 3 souscription relié a un service qui a des articles de facturation
  - lui ajouter 3 financement chacun relié a une des souscriptions:
       - financement 1:  horaire de fréquence mensuelle 
       - financement 2:  horaire de fréquence en une seule fois 
       - financement 3:  forfaitaire de fréquence en une seule fois 
  - creer un.e auxiliaire
  - creer des interventions (dont certaines sont majorées)
  - aller sur la page a facturer
  - ajouter des remises
  - verifier que les montants figurant sur les 2 factures (bénéficiaires et tiers-payeur) sont corrects
  - vérifier que l'objet fundingHistories correspondant au financement a bien ete maj en bdd:
       - financement 1 : maj de careHours pour le mois correspondant au mois des interventions 
       - financement 2: maj de careHours 
       - financement 3 : maj de amountTTC 
  - verifier que les pages balances clients, bordereaux tiers-payeur et onglet facture sur la page beneficiaire s'affichent correctement (le téléchargement des bordereaux est cassé)
  - generer une facture manuelle et telechargeer le pdf --> verifier que les montants sont justes (l'affichage sur la page factures manuelles + dans la modale de creation d'une facture manuelle sera gérée dans un autre ticket )
  - en bdd, verifier que:
   - dans les objets de la collection `bills`
      - dans  `Subscriptions`:
          - `hours` , `exclTaxes` sont des string
          - `discount`, `unitInclTaxes` et `inclTaxes` sont des number
          - dans `events`:
               - `exclTaxesCustomer`, `inclTaxesCustomer`, `exclTaxesTpp`, `inclTaxesTpp` et `careHours` sont des string
   - dans les objets de la collection `Events` > dans `bills`:
      -  `inclTaxesCustomer`, `exclTaxesCustomer`, `inclTaxesTpp` `exclTaxesTpp` et `careHours` sont des string
      - dans `billingItems`
         - `inclTaxes` est un nombre et `exclTaxes` est un string
   - dans les objets de la collection `fundinghistories`
        - `careHours` et `amountTTC` sont des string  
   
_Si tu as lu cette description, pense a réagir avec un :eye:_
