### PR TITLE
COM-2858 - transforms careHours and amountTTC in string

### DIFF
--- a/src/helpers/creditNotes.js
+++ b/src/helpers/creditNotes.js
@@ -55,9 +55,9 @@ exports.updateEventAndFundingHistory = async (eventsToUpdate, isBilled, credenti
       });
 
       if (fundingHistory) {
-        const careHours = parseFloat(isBilled
+        const careHours = isBilled
           ? NumbersHelper.add(fundingHistory.careHours, event.bills.careHours)
-          : NumbersHelper.subtract(fundingHistory.careHours, event.bills.careHours));
+          : NumbersHelper.subtract(fundingHistory.careHours, event.bills.careHours);
 
         await FundingHistory.updateOne({ _id: fundingHistory._id }, { $set: { careHours } });
       } else {
@@ -65,14 +65,14 @@ exports.updateEventAndFundingHistory = async (eventsToUpdate, isBilled, credenti
 
         let payload;
         if (event.bills.nature === HOURLY) {
-          const careHours = parseFloat(isBilled
+          const careHours = isBilled
             ? NumbersHelper.add(fundingHistory.careHours, event.bills.careHours)
-            : NumbersHelper.subtract(fundingHistory.careHours, event.bills.careHours));
+            : NumbersHelper.subtract(fundingHistory.careHours, event.bills.careHours);
           payload = { careHours };
         } else {
-          const amountTTC = parseFloat(isBilled
+          const amountTTC = isBilled
             ? NumbersHelper.add(fundingHistory.amountTTC, event.bills.inclTaxesTpp)
-            : NumbersHelper.subtract(fundingHistory.amountTTC, event.bills.inclTaxesTpp));
+            : NumbersHelper.subtract(fundingHistory.amountTTC, event.bills.inclTaxesTpp);
           payload = { amountTTC };
         }
 

--- a/tests/integration/exports.test.js
+++ b/tests/integration/exports.test.js
@@ -141,7 +141,7 @@ const vendorHistoryExportTypes = [
 ];
 
 clientHistoryExportTypes.forEach(({ exportType, expectedRows, query }) => {
-  describe(`EXPORTS ROUTES - GET /exports/${exportType}/history #tag`, () => {
+  describe(`EXPORTS ROUTES - GET /exports/${exportType}/history`, () => {
     let authToken;
     before(populateDB);
 
@@ -161,6 +161,7 @@ clientHistoryExportTypes.forEach(({ exportType, expectedRows, query }) => {
 
         const rows = response.result.split('\r\n');
         expect(rows.length).toBe(expectedRows.length);
+
         for (let i = 0; i < expectedRows.length; i++) expect(rows.some(r => r === expectedRows[i])).toBeTruthy();
       });
     });

--- a/tests/integration/exports.test.js
+++ b/tests/integration/exports.test.js
@@ -47,25 +47,25 @@ describe('NODE ENV', () => {
 });
 
 const clientHistoryExportTypes = [
-  {
-    exportType: WORKING_EVENT,
-    expectedRows: [
-      '\ufeff"Type";"Heure interne";"Service";"Début planifié";"Début horodaté";"Type d\'horodatage";"Motif";"Fin planifiée";"Fin horodatée";"Type d\'horodatage";"Motif";"Durée";"Répétition";"Déplacement véhiculé avec bénéficiaire";"Mode de transport spécifique";"Équipe";"Id Auxiliaire";"Auxiliaire - Titre";"Auxiliaire - Prénom";"Auxiliaire - Nom";"A affecter";"Id Bénéficiaire";"Bénéficiaire - Titre";"Bénéficiaire - Nom";"Bénéficiaire - Prénom";"Divers";"Facturé";"Annulé";"Statut de l\'annulation";"Raison de l\'annulation"',
-      `"Intervention";;"Service 1";"17/01/2019 15:30:19";"17/01/2019 15:35:19";"Manuel";"QR Code manquant";"17/01/2019 17:30:19";"17/01/2019 17:35:19";"QR Code";;"2,00";"Tous les jours";"23,00";"Transports en commun / À pied";"Etoile";;;;;"Oui";${customersList[3]._id.toHexString()};"M.";"BARDET";"Romain";;"Non";"Non";;`,
-      `"Heure interne";"planning";;"17/01/2019 15:30:19";;;;"17/01/2019 17:30:19";;;;"2,00";;;;"Etoile";${auxiliaryList[0]._id.toHexString()};"M.";"Lulu";"UIUI";"Non";;;;;;"Non";"Non";;`,
-      `"Intervention";;"Service 1";"16/01/2019 10:30:19";;;;"16/01/2019 12:30:21";;;;"2,00";;;;"Etoile";${auxiliaryList[0]._id.toHexString()};"M.";"Lulu";"UIUI";"Non";${customersList[3]._id.toHexString()};"M.";"BARDET";"Romain";"test";"Non";"Oui";"Facturée & payée";"Initiative de l'intervenant(e)"`,
-    ],
-    query: 'startDate=2019-01-15T10:00:00.000Z&endDate=2019-01-20T10:00:00.000Z',
-  },
-  {
-    exportType: ABSENCE,
-    expectedRows: [
-      '\ufeff"Id Auxiliaire";"Auxiliaire - Prénom";"Auxiliaire - Nom";"Auxiliaire - Titre";"Équipe";"Type";"Nature";"Début";"Fin";"Equivalent heures contrat";"Prolongation";"Absence d\'origine";"Divers"',
-      `${auxiliaryList[0]._id.toHexString()};"Lulu";"UIUI";"M.";"Etoile";"Absence injustifiée";"Horaire";"19/01/2019 14:00";"19/01/2019 16:00";"2,00";"non";;"test absence"`,
-      `${auxiliaryList[0]._id.toHexString()};"Lulu";"UIUI";"M.";"Etoile";"Congé";"Journalière";"19/01/2019";"21/01/2019";"4,00";"non";;`,
-    ],
-    query: 'startDate=2019-01-15T10:00:00.000Z&endDate=2019-01-21T10:00:00.000Z',
-  },
+  // {
+  //   exportType: WORKING_EVENT,
+  //   expectedRows: [
+  //     '\ufeff"Type";"Heure interne";"Service";"Début planifié";"Début horodaté";"Type d\'horodatage";"Motif";"Fin planifiée";"Fin horodatée";"Type d\'horodatage";"Motif";"Durée";"Répétition";"Déplacement véhiculé avec bénéficiaire";"Mode de transport spécifique";"Équipe";"Id Auxiliaire";"Auxiliaire - Titre";"Auxiliaire - Prénom";"Auxiliaire - Nom";"A affecter";"Id Bénéficiaire";"Bénéficiaire - Titre";"Bénéficiaire - Nom";"Bénéficiaire - Prénom";"Divers";"Facturé";"Annulé";"Statut de l\'annulation";"Raison de l\'annulation"',
+  //     `"Intervention";;"Service 1";"17/01/2019 15:30:19";"17/01/2019 15:35:19";"Manuel";"QR Code manquant";"17/01/2019 17:30:19";"17/01/2019 17:35:19";"QR Code";;"2,00";"Tous les jours";"23,00";"Transports en commun / À pied";"Etoile";;;;;"Oui";${customersList[3]._id.toHexString()};"M.";"BARDET";"Romain";;"Non";"Non";;`,
+  //     `"Heure interne";"planning";;"17/01/2019 15:30:19";;;;"17/01/2019 17:30:19";;;;"2,00";;;;"Etoile";${auxiliaryList[0]._id.toHexString()};"M.";"Lulu";"UIUI";"Non";;;;;;"Non";"Non";;`,
+  //     `"Intervention";;"Service 1";"16/01/2019 10:30:19";;;;"16/01/2019 12:30:21";;;;"2,00";;;;"Etoile";${auxiliaryList[0]._id.toHexString()};"M.";"Lulu";"UIUI";"Non";${customersList[3]._id.toHexString()};"M.";"BARDET";"Romain";"test";"Non";"Oui";"Facturée & payée";"Initiative de l'intervenant(e)"`,
+  //   ],
+  //   query: 'startDate=2019-01-15T10:00:00.000Z&endDate=2019-01-20T10:00:00.000Z',
+  // },
+  // {
+  //   exportType: ABSENCE,
+  //   expectedRows: [
+  //     '\ufeff"Id Auxiliaire";"Auxiliaire - Prénom";"Auxiliaire - Nom";"Auxiliaire - Titre";"Équipe";"Type";"Nature";"Début";"Fin";"Equivalent heures contrat";"Prolongation";"Absence d\'origine";"Divers"',
+  //     `${auxiliaryList[0]._id.toHexString()};"Lulu";"UIUI";"M.";"Etoile";"Absence injustifiée";"Horaire";"19/01/2019 14:00";"19/01/2019 16:00";"2,00";"non";;"test absence"`,
+  //     `${auxiliaryList[0]._id.toHexString()};"Lulu";"UIUI";"M.";"Etoile";"Congé";"Journalière";"19/01/2019";"21/01/2019";"4,00";"non";;`,
+  //   ],
+  //   query: 'startDate=2019-01-15T10:00:00.000Z&endDate=2019-01-21T10:00:00.000Z',
+  // },
   {
     exportType: BILL,
     expectedRows: [
@@ -76,35 +76,35 @@ const clientHistoryExportTypes = [
     ],
     query: 'startDate=2019-05-25T10:00:00.000Z&endDate=2019-05-29T10:00:00.000Z',
   },
-  {
-    exportType: PAYMENT,
-    expectedRows: [
-      '\ufeff"Nature";"Identifiant";"Date";"Id Bénéficiaire";"Titre";"Nom";"Prénom";"Id tiers payeur";"Tiers payeur";"Moyen de paiement";"Montant TTC en €"',
-      `"Remboursement";"REG-1903203";"27/05/2019";"${paymentsList[0].customer}";"M.";"BARDET";"Romain";"${paymentsList[0].thirdPartyPayer}";"Toto";"Prélèvement";"220,00"`,
-      `"Paiement";"REG-1903201";"26/05/2019";"${paymentsList[1].customer}";"M.";"BARDET";"Romain";"${paymentsList[0].thirdPartyPayer}";"Toto";"Prélèvement";"190,00"`,
-    ],
-    query: 'startDate=2019-05-25T10:00:00.000Z&endDate=2019-05-31T10:00:00.000Z',
-  },
-  {
-    exportType: PAY,
-    expectedRows: [
-      '\ufeff"Id Auxiliaire";"Titre";"Prénom";"Nom";"Equipe";"Date d\'embauche";"Début";"Date de notif";"Motif";"Fin";"Heures contrat";"Heures absences";"Heures à travailler";"Heures travaillées";"Dont exo non majo";"Dont exo et majo";"Détails des majo exo";"Dont non exo et non majo";"Dont non exo et majo";"Détails des majo non exo";"Heures transports";"Solde heures";"Dont diff mois précédent";"Compteur";"Heures sup à payer";"Heures comp à payer";"Mutuelle";"Remboursement transport";"Km payés";"Km parcourus";"Frais téléphoniques";"Prime";"Indemnité"',
-      `${auxiliaryList[0]._id.toHexString()};"M.";"Lulu";"UIUI";"Etoile";"01/01/2018";"01/01/2019";;;"31/01/2019";"151,00";"10,00";"30,00";"143,00";"99,00";"2,00";;"45,00";"5,00";;"6,00";"0,00";"8,00";"-20,00";"0,00";"0,00";"Non";"10,00";"12,00";"14,00";"0,00";"0,00";"0,00"`,
-      `${auxiliaryList[0]._id.toHexString()};"M.";"Lulu";"UIUI";"Etoile";"01/01/2018";"01/01/2019";;;"28/02/2019";"151,00";"10,00";"20,00";"143,00";"99,00";"2,00";;"45,00";"5,00";;"6,00";"0,00";"8,00";"-20,00";"0,00";"0,00";"Non";"10,00";"12,00";"14,00";"0,00";"0,00";"0,00"`,
-      `${auxiliaryList[0]._id.toHexString()};"M.";"Lulu";"UIUI";"Etoile";"01/01/2018";"01/01/2019";"25/01/2019";;"31/01/2019";"151,00";"10,00";"20,00";"143,00";"99,00";"2,00";;"45,00";"5,00";;"6,00";"0,00";"8,00";"-20,00";"0,00";"0,00";"Non";"10,00";"12,00";"14,00";"0,00";"0,00";"10,00"`,
-      `${auxiliaryList[0]._id.toHexString()};"M.";"Lulu";"UIUI";"Etoile";"01/01/2018";"01/01/2019";"25/02/2019";;"28/02/2019";"151,00";"10,00";"20,00";"143,00";"99,00";"2,00";;"45,00";"5,00";;"6,00";"0,00";"8,00";"-20,00";"0,00";"0,00";"Non";"10,00";"12,00";"14,00";"0,00";"0,00";"10,00"`,
-    ],
-    query: 'startDate=2019-01-01T10:00:00.000Z&endDate=2019-05-31T10:00:00.000Z',
-  },
-  {
-    exportType: TRANSPORT,
-    expectedRows: [
-      '\ufeff"Id de l\'auxiliaire";"Prénom de l\'auxiliaire";"Nom de l\'auxiliaire";"Heure de départ du trajet";"Heure d\'arrivée du trajet";"Adresse de départ";"Adresse d\'arrivée";"Distance";"Mode de transport";"Durée du trajet";"Durée inter vacation";"Pause prise en compte";"Durée rémunérée"',
-      `"${auxiliaryList[0]._id}";"Lulu";"Uiui";"11/01/2019 09:30:00";"11/01/2019 10:30:00";"42 Rue de la Procession 75015 Paris";"37 Rue de Ponthieu 75008 Paris";"0,230";"Transports en commun / À pied";"0,0639";"1,0000";"Non";"0,0639"`,
-      `"${auxiliaryList[1]._id}";"Lili";"Lolo";"11/01/2019 11:30:00";"11/01/2019 12:35:00";"42 Rue de la Procession 75015 Paris";"35 Rue du Test 75015 Paris";"0,230";"Véhicule personnel";"1,0833";"1,0833";"Oui";"1,0833"`,
-    ],
-    query: 'startDate=2019-01-01&endDate=2019-01-31',
-  },
+  // {
+  //   exportType: PAYMENT,
+  //   expectedRows: [
+  //     '\ufeff"Nature";"Identifiant";"Date";"Id Bénéficiaire";"Titre";"Nom";"Prénom";"Id tiers payeur";"Tiers payeur";"Moyen de paiement";"Montant TTC en €"',
+  //     `"Remboursement";"REG-1903203";"27/05/2019";"${paymentsList[0].customer}";"M.";"BARDET";"Romain";"${paymentsList[0].thirdPartyPayer}";"Toto";"Prélèvement";"220,00"`,
+  //     `"Paiement";"REG-1903201";"26/05/2019";"${paymentsList[1].customer}";"M.";"BARDET";"Romain";"${paymentsList[0].thirdPartyPayer}";"Toto";"Prélèvement";"190,00"`,
+  //   ],
+  //   query: 'startDate=2019-05-25T10:00:00.000Z&endDate=2019-05-31T10:00:00.000Z',
+  // },
+  // {
+  //   exportType: PAY,
+  //   expectedRows: [
+  //     '\ufeff"Id Auxiliaire";"Titre";"Prénom";"Nom";"Equipe";"Date d\'embauche";"Début";"Date de notif";"Motif";"Fin";"Heures contrat";"Heures absences";"Heures à travailler";"Heures travaillées";"Dont exo non majo";"Dont exo et majo";"Détails des majo exo";"Dont non exo et non majo";"Dont non exo et majo";"Détails des majo non exo";"Heures transports";"Solde heures";"Dont diff mois précédent";"Compteur";"Heures sup à payer";"Heures comp à payer";"Mutuelle";"Remboursement transport";"Km payés";"Km parcourus";"Frais téléphoniques";"Prime";"Indemnité"',
+  //     `${auxiliaryList[0]._id.toHexString()};"M.";"Lulu";"UIUI";"Etoile";"01/01/2018";"01/01/2019";;;"31/01/2019";"151,00";"10,00";"30,00";"143,00";"99,00";"2,00";;"45,00";"5,00";;"6,00";"0,00";"8,00";"-20,00";"0,00";"0,00";"Non";"10,00";"12,00";"14,00";"0,00";"0,00";"0,00"`,
+  //     `${auxiliaryList[0]._id.toHexString()};"M.";"Lulu";"UIUI";"Etoile";"01/01/2018";"01/01/2019";;;"28/02/2019";"151,00";"10,00";"20,00";"143,00";"99,00";"2,00";;"45,00";"5,00";;"6,00";"0,00";"8,00";"-20,00";"0,00";"0,00";"Non";"10,00";"12,00";"14,00";"0,00";"0,00";"0,00"`,
+  //     `${auxiliaryList[0]._id.toHexString()};"M.";"Lulu";"UIUI";"Etoile";"01/01/2018";"01/01/2019";"25/01/2019";;"31/01/2019";"151,00";"10,00";"20,00";"143,00";"99,00";"2,00";;"45,00";"5,00";;"6,00";"0,00";"8,00";"-20,00";"0,00";"0,00";"Non";"10,00";"12,00";"14,00";"0,00";"0,00";"10,00"`,
+  //     `${auxiliaryList[0]._id.toHexString()};"M.";"Lulu";"UIUI";"Etoile";"01/01/2018";"01/01/2019";"25/02/2019";;"28/02/2019";"151,00";"10,00";"20,00";"143,00";"99,00";"2,00";;"45,00";"5,00";;"6,00";"0,00";"8,00";"-20,00";"0,00";"0,00";"Non";"10,00";"12,00";"14,00";"0,00";"0,00";"10,00"`,
+  //   ],
+  //   query: 'startDate=2019-01-01T10:00:00.000Z&endDate=2019-05-31T10:00:00.000Z',
+  // },
+  // {
+  //   exportType: TRANSPORT,
+  //   expectedRows: [
+  //     '\ufeff"Id de l\'auxiliaire";"Prénom de l\'auxiliaire";"Nom de l\'auxiliaire";"Heure de départ du trajet";"Heure d\'arrivée du trajet";"Adresse de départ";"Adresse d\'arrivée";"Distance";"Mode de transport";"Durée du trajet";"Durée inter vacation";"Pause prise en compte";"Durée rémunérée"',
+  //     `"${auxiliaryList[0]._id}";"Lulu";"Uiui";"11/01/2019 09:30:00";"11/01/2019 10:30:00";"42 Rue de la Procession 75015 Paris";"37 Rue de Ponthieu 75008 Paris";"0,230";"Transports en commun / À pied";"0,0639";"1,0000";"Non";"0,0639"`,
+  //     `"${auxiliaryList[1]._id}";"Lili";"Lolo";"11/01/2019 11:30:00";"11/01/2019 12:35:00";"42 Rue de la Procession 75015 Paris";"35 Rue du Test 75015 Paris";"0,230";"Véhicule personnel";"1,0833";"1,0833";"Oui";"1,0833"`,
+  //   ],
+  //   query: 'startDate=2019-01-01&endDate=2019-01-31',
+  // },
 ];
 
 const vendorHistoryExportTypes = [
@@ -141,7 +141,7 @@ const vendorHistoryExportTypes = [
 ];
 
 clientHistoryExportTypes.forEach(({ exportType, expectedRows, query }) => {
-  describe(`EXPORTS ROUTES - GET /exports/${exportType}/history`, () => {
+  describe(`EXPORTS ROUTES - GET /exports/${exportType}/history #tag`, () => {
     let authToken;
     before(populateDB);
 
@@ -161,7 +161,6 @@ clientHistoryExportTypes.forEach(({ exportType, expectedRows, query }) => {
 
         const rows = response.result.split('\r\n');
         expect(rows.length).toBe(expectedRows.length);
-
         for (let i = 0; i < expectedRows.length; i++) expect(rows.some(r => r === expectedRows[i])).toBeTruthy();
       });
     });

--- a/tests/integration/exports.test.js
+++ b/tests/integration/exports.test.js
@@ -47,25 +47,25 @@ describe('NODE ENV', () => {
 });
 
 const clientHistoryExportTypes = [
-  // {
-  //   exportType: WORKING_EVENT,
-  //   expectedRows: [
-  //     '\ufeff"Type";"Heure interne";"Service";"Début planifié";"Début horodaté";"Type d\'horodatage";"Motif";"Fin planifiée";"Fin horodatée";"Type d\'horodatage";"Motif";"Durée";"Répétition";"Déplacement véhiculé avec bénéficiaire";"Mode de transport spécifique";"Équipe";"Id Auxiliaire";"Auxiliaire - Titre";"Auxiliaire - Prénom";"Auxiliaire - Nom";"A affecter";"Id Bénéficiaire";"Bénéficiaire - Titre";"Bénéficiaire - Nom";"Bénéficiaire - Prénom";"Divers";"Facturé";"Annulé";"Statut de l\'annulation";"Raison de l\'annulation"',
-  //     `"Intervention";;"Service 1";"17/01/2019 15:30:19";"17/01/2019 15:35:19";"Manuel";"QR Code manquant";"17/01/2019 17:30:19";"17/01/2019 17:35:19";"QR Code";;"2,00";"Tous les jours";"23,00";"Transports en commun / À pied";"Etoile";;;;;"Oui";${customersList[3]._id.toHexString()};"M.";"BARDET";"Romain";;"Non";"Non";;`,
-  //     `"Heure interne";"planning";;"17/01/2019 15:30:19";;;;"17/01/2019 17:30:19";;;;"2,00";;;;"Etoile";${auxiliaryList[0]._id.toHexString()};"M.";"Lulu";"UIUI";"Non";;;;;;"Non";"Non";;`,
-  //     `"Intervention";;"Service 1";"16/01/2019 10:30:19";;;;"16/01/2019 12:30:21";;;;"2,00";;;;"Etoile";${auxiliaryList[0]._id.toHexString()};"M.";"Lulu";"UIUI";"Non";${customersList[3]._id.toHexString()};"M.";"BARDET";"Romain";"test";"Non";"Oui";"Facturée & payée";"Initiative de l'intervenant(e)"`,
-  //   ],
-  //   query: 'startDate=2019-01-15T10:00:00.000Z&endDate=2019-01-20T10:00:00.000Z',
-  // },
-  // {
-  //   exportType: ABSENCE,
-  //   expectedRows: [
-  //     '\ufeff"Id Auxiliaire";"Auxiliaire - Prénom";"Auxiliaire - Nom";"Auxiliaire - Titre";"Équipe";"Type";"Nature";"Début";"Fin";"Equivalent heures contrat";"Prolongation";"Absence d\'origine";"Divers"',
-  //     `${auxiliaryList[0]._id.toHexString()};"Lulu";"UIUI";"M.";"Etoile";"Absence injustifiée";"Horaire";"19/01/2019 14:00";"19/01/2019 16:00";"2,00";"non";;"test absence"`,
-  //     `${auxiliaryList[0]._id.toHexString()};"Lulu";"UIUI";"M.";"Etoile";"Congé";"Journalière";"19/01/2019";"21/01/2019";"4,00";"non";;`,
-  //   ],
-  //   query: 'startDate=2019-01-15T10:00:00.000Z&endDate=2019-01-21T10:00:00.000Z',
-  // },
+  {
+    exportType: WORKING_EVENT,
+    expectedRows: [
+      '\ufeff"Type";"Heure interne";"Service";"Début planifié";"Début horodaté";"Type d\'horodatage";"Motif";"Fin planifiée";"Fin horodatée";"Type d\'horodatage";"Motif";"Durée";"Répétition";"Déplacement véhiculé avec bénéficiaire";"Mode de transport spécifique";"Équipe";"Id Auxiliaire";"Auxiliaire - Titre";"Auxiliaire - Prénom";"Auxiliaire - Nom";"A affecter";"Id Bénéficiaire";"Bénéficiaire - Titre";"Bénéficiaire - Nom";"Bénéficiaire - Prénom";"Divers";"Facturé";"Annulé";"Statut de l\'annulation";"Raison de l\'annulation"',
+      `"Intervention";;"Service 1";"17/01/2019 15:30:19";"17/01/2019 15:35:19";"Manuel";"QR Code manquant";"17/01/2019 17:30:19";"17/01/2019 17:35:19";"QR Code";;"2,00";"Tous les jours";"23,00";"Transports en commun / À pied";"Etoile";;;;;"Oui";${customersList[3]._id.toHexString()};"M.";"BARDET";"Romain";;"Non";"Non";;`,
+      `"Heure interne";"planning";;"17/01/2019 15:30:19";;;;"17/01/2019 17:30:19";;;;"2,00";;;;"Etoile";${auxiliaryList[0]._id.toHexString()};"M.";"Lulu";"UIUI";"Non";;;;;;"Non";"Non";;`,
+      `"Intervention";;"Service 1";"16/01/2019 10:30:19";;;;"16/01/2019 12:30:21";;;;"2,00";;;;"Etoile";${auxiliaryList[0]._id.toHexString()};"M.";"Lulu";"UIUI";"Non";${customersList[3]._id.toHexString()};"M.";"BARDET";"Romain";"test";"Non";"Oui";"Facturée & payée";"Initiative de l'intervenant(e)"`,
+    ],
+    query: 'startDate=2019-01-15T10:00:00.000Z&endDate=2019-01-20T10:00:00.000Z',
+  },
+  {
+    exportType: ABSENCE,
+    expectedRows: [
+      '\ufeff"Id Auxiliaire";"Auxiliaire - Prénom";"Auxiliaire - Nom";"Auxiliaire - Titre";"Équipe";"Type";"Nature";"Début";"Fin";"Equivalent heures contrat";"Prolongation";"Absence d\'origine";"Divers"',
+      `${auxiliaryList[0]._id.toHexString()};"Lulu";"UIUI";"M.";"Etoile";"Absence injustifiée";"Horaire";"19/01/2019 14:00";"19/01/2019 16:00";"2,00";"non";;"test absence"`,
+      `${auxiliaryList[0]._id.toHexString()};"Lulu";"UIUI";"M.";"Etoile";"Congé";"Journalière";"19/01/2019";"21/01/2019";"4,00";"non";;`,
+    ],
+    query: 'startDate=2019-01-15T10:00:00.000Z&endDate=2019-01-21T10:00:00.000Z',
+  },
   {
     exportType: BILL,
     expectedRows: [
@@ -76,35 +76,35 @@ const clientHistoryExportTypes = [
     ],
     query: 'startDate=2019-05-25T10:00:00.000Z&endDate=2019-05-29T10:00:00.000Z',
   },
-  // {
-  //   exportType: PAYMENT,
-  //   expectedRows: [
-  //     '\ufeff"Nature";"Identifiant";"Date";"Id Bénéficiaire";"Titre";"Nom";"Prénom";"Id tiers payeur";"Tiers payeur";"Moyen de paiement";"Montant TTC en €"',
-  //     `"Remboursement";"REG-1903203";"27/05/2019";"${paymentsList[0].customer}";"M.";"BARDET";"Romain";"${paymentsList[0].thirdPartyPayer}";"Toto";"Prélèvement";"220,00"`,
-  //     `"Paiement";"REG-1903201";"26/05/2019";"${paymentsList[1].customer}";"M.";"BARDET";"Romain";"${paymentsList[0].thirdPartyPayer}";"Toto";"Prélèvement";"190,00"`,
-  //   ],
-  //   query: 'startDate=2019-05-25T10:00:00.000Z&endDate=2019-05-31T10:00:00.000Z',
-  // },
-  // {
-  //   exportType: PAY,
-  //   expectedRows: [
-  //     '\ufeff"Id Auxiliaire";"Titre";"Prénom";"Nom";"Equipe";"Date d\'embauche";"Début";"Date de notif";"Motif";"Fin";"Heures contrat";"Heures absences";"Heures à travailler";"Heures travaillées";"Dont exo non majo";"Dont exo et majo";"Détails des majo exo";"Dont non exo et non majo";"Dont non exo et majo";"Détails des majo non exo";"Heures transports";"Solde heures";"Dont diff mois précédent";"Compteur";"Heures sup à payer";"Heures comp à payer";"Mutuelle";"Remboursement transport";"Km payés";"Km parcourus";"Frais téléphoniques";"Prime";"Indemnité"',
-  //     `${auxiliaryList[0]._id.toHexString()};"M.";"Lulu";"UIUI";"Etoile";"01/01/2018";"01/01/2019";;;"31/01/2019";"151,00";"10,00";"30,00";"143,00";"99,00";"2,00";;"45,00";"5,00";;"6,00";"0,00";"8,00";"-20,00";"0,00";"0,00";"Non";"10,00";"12,00";"14,00";"0,00";"0,00";"0,00"`,
-  //     `${auxiliaryList[0]._id.toHexString()};"M.";"Lulu";"UIUI";"Etoile";"01/01/2018";"01/01/2019";;;"28/02/2019";"151,00";"10,00";"20,00";"143,00";"99,00";"2,00";;"45,00";"5,00";;"6,00";"0,00";"8,00";"-20,00";"0,00";"0,00";"Non";"10,00";"12,00";"14,00";"0,00";"0,00";"0,00"`,
-  //     `${auxiliaryList[0]._id.toHexString()};"M.";"Lulu";"UIUI";"Etoile";"01/01/2018";"01/01/2019";"25/01/2019";;"31/01/2019";"151,00";"10,00";"20,00";"143,00";"99,00";"2,00";;"45,00";"5,00";;"6,00";"0,00";"8,00";"-20,00";"0,00";"0,00";"Non";"10,00";"12,00";"14,00";"0,00";"0,00";"10,00"`,
-  //     `${auxiliaryList[0]._id.toHexString()};"M.";"Lulu";"UIUI";"Etoile";"01/01/2018";"01/01/2019";"25/02/2019";;"28/02/2019";"151,00";"10,00";"20,00";"143,00";"99,00";"2,00";;"45,00";"5,00";;"6,00";"0,00";"8,00";"-20,00";"0,00";"0,00";"Non";"10,00";"12,00";"14,00";"0,00";"0,00";"10,00"`,
-  //   ],
-  //   query: 'startDate=2019-01-01T10:00:00.000Z&endDate=2019-05-31T10:00:00.000Z',
-  // },
-  // {
-  //   exportType: TRANSPORT,
-  //   expectedRows: [
-  //     '\ufeff"Id de l\'auxiliaire";"Prénom de l\'auxiliaire";"Nom de l\'auxiliaire";"Heure de départ du trajet";"Heure d\'arrivée du trajet";"Adresse de départ";"Adresse d\'arrivée";"Distance";"Mode de transport";"Durée du trajet";"Durée inter vacation";"Pause prise en compte";"Durée rémunérée"',
-  //     `"${auxiliaryList[0]._id}";"Lulu";"Uiui";"11/01/2019 09:30:00";"11/01/2019 10:30:00";"42 Rue de la Procession 75015 Paris";"37 Rue de Ponthieu 75008 Paris";"0,230";"Transports en commun / À pied";"0,0639";"1,0000";"Non";"0,0639"`,
-  //     `"${auxiliaryList[1]._id}";"Lili";"Lolo";"11/01/2019 11:30:00";"11/01/2019 12:35:00";"42 Rue de la Procession 75015 Paris";"35 Rue du Test 75015 Paris";"0,230";"Véhicule personnel";"1,0833";"1,0833";"Oui";"1,0833"`,
-  //   ],
-  //   query: 'startDate=2019-01-01&endDate=2019-01-31',
-  // },
+  {
+    exportType: PAYMENT,
+    expectedRows: [
+      '\ufeff"Nature";"Identifiant";"Date";"Id Bénéficiaire";"Titre";"Nom";"Prénom";"Id tiers payeur";"Tiers payeur";"Moyen de paiement";"Montant TTC en €"',
+      `"Remboursement";"REG-1903203";"27/05/2019";"${paymentsList[0].customer}";"M.";"BARDET";"Romain";"${paymentsList[0].thirdPartyPayer}";"Toto";"Prélèvement";"220,00"`,
+      `"Paiement";"REG-1903201";"26/05/2019";"${paymentsList[1].customer}";"M.";"BARDET";"Romain";"${paymentsList[0].thirdPartyPayer}";"Toto";"Prélèvement";"190,00"`,
+    ],
+    query: 'startDate=2019-05-25T10:00:00.000Z&endDate=2019-05-31T10:00:00.000Z',
+  },
+  {
+    exportType: PAY,
+    expectedRows: [
+      '\ufeff"Id Auxiliaire";"Titre";"Prénom";"Nom";"Equipe";"Date d\'embauche";"Début";"Date de notif";"Motif";"Fin";"Heures contrat";"Heures absences";"Heures à travailler";"Heures travaillées";"Dont exo non majo";"Dont exo et majo";"Détails des majo exo";"Dont non exo et non majo";"Dont non exo et majo";"Détails des majo non exo";"Heures transports";"Solde heures";"Dont diff mois précédent";"Compteur";"Heures sup à payer";"Heures comp à payer";"Mutuelle";"Remboursement transport";"Km payés";"Km parcourus";"Frais téléphoniques";"Prime";"Indemnité"',
+      `${auxiliaryList[0]._id.toHexString()};"M.";"Lulu";"UIUI";"Etoile";"01/01/2018";"01/01/2019";;;"31/01/2019";"151,00";"10,00";"30,00";"143,00";"99,00";"2,00";;"45,00";"5,00";;"6,00";"0,00";"8,00";"-20,00";"0,00";"0,00";"Non";"10,00";"12,00";"14,00";"0,00";"0,00";"0,00"`,
+      `${auxiliaryList[0]._id.toHexString()};"M.";"Lulu";"UIUI";"Etoile";"01/01/2018";"01/01/2019";;;"28/02/2019";"151,00";"10,00";"20,00";"143,00";"99,00";"2,00";;"45,00";"5,00";;"6,00";"0,00";"8,00";"-20,00";"0,00";"0,00";"Non";"10,00";"12,00";"14,00";"0,00";"0,00";"0,00"`,
+      `${auxiliaryList[0]._id.toHexString()};"M.";"Lulu";"UIUI";"Etoile";"01/01/2018";"01/01/2019";"25/01/2019";;"31/01/2019";"151,00";"10,00";"20,00";"143,00";"99,00";"2,00";;"45,00";"5,00";;"6,00";"0,00";"8,00";"-20,00";"0,00";"0,00";"Non";"10,00";"12,00";"14,00";"0,00";"0,00";"10,00"`,
+      `${auxiliaryList[0]._id.toHexString()};"M.";"Lulu";"UIUI";"Etoile";"01/01/2018";"01/01/2019";"25/02/2019";;"28/02/2019";"151,00";"10,00";"20,00";"143,00";"99,00";"2,00";;"45,00";"5,00";;"6,00";"0,00";"8,00";"-20,00";"0,00";"0,00";"Non";"10,00";"12,00";"14,00";"0,00";"0,00";"10,00"`,
+    ],
+    query: 'startDate=2019-01-01T10:00:00.000Z&endDate=2019-05-31T10:00:00.000Z',
+  },
+  {
+    exportType: TRANSPORT,
+    expectedRows: [
+      '\ufeff"Id de l\'auxiliaire";"Prénom de l\'auxiliaire";"Nom de l\'auxiliaire";"Heure de départ du trajet";"Heure d\'arrivée du trajet";"Adresse de départ";"Adresse d\'arrivée";"Distance";"Mode de transport";"Durée du trajet";"Durée inter vacation";"Pause prise en compte";"Durée rémunérée"',
+      `"${auxiliaryList[0]._id}";"Lulu";"Uiui";"11/01/2019 09:30:00";"11/01/2019 10:30:00";"42 Rue de la Procession 75015 Paris";"37 Rue de Ponthieu 75008 Paris";"0,230";"Transports en commun / À pied";"0,0639";"1,0000";"Non";"0,0639"`,
+      `"${auxiliaryList[1]._id}";"Lili";"Lolo";"11/01/2019 11:30:00";"11/01/2019 12:35:00";"42 Rue de la Procession 75015 Paris";"35 Rue du Test 75015 Paris";"0,230";"Véhicule personnel";"1,0833";"1,0833";"Oui";"1,0833"`,
+    ],
+    query: 'startDate=2019-01-01&endDate=2019-01-31',
+  },
 ];
 
 const vendorHistoryExportTypes = [

--- a/tests/unit/helpers/creditNotes.test.js
+++ b/tests/unit/helpers/creditNotes.test.js
@@ -172,13 +172,13 @@ describe('updateEventAndFundingHistory', () => {
     const events = [{
       _id: new ObjectId(),
       company: new ObjectId(),
-      bills: { nature: 'hourly', fundingId, thirdPartyPayer: new ObjectId(), careHours: 3 },
+      bills: { nature: 'hourly', fundingId, thirdPartyPayer: new ObjectId(), careHours: '3' },
       startDate: new Date('2019/01/19'),
     }];
 
     find.returns(events);
     findOne.onCall(0).returns(null);
-    findOne.onCall(1).returns({ _id: fundingHistoryId, careHours: 120 });
+    findOne.onCall(1).returns({ _id: fundingHistoryId, careHours: '120' });
     find.returns(SinonMongoose.stubChainedQueries(events, ['lean']));
 
     await CreditNoteHelper.updateEventAndFundingHistory([], false, credentials);
@@ -189,7 +189,7 @@ describe('updateEventAndFundingHistory', () => {
     sinon.assert.calledOnceWithExactly(
       updateOneFundingHistory,
       { _id: fundingHistoryId },
-      { $set: { careHours: 117 } }
+      { $set: { careHours: '117' } }
     );
     SinonMongoose.calledOnceWithExactly(
       find,
@@ -204,17 +204,21 @@ describe('updateEventAndFundingHistory', () => {
     const events = [{
       _id: new ObjectId(),
       company: new ObjectId(),
-      bills: { nature: 'hourly', fundingId, thirdPartyPayer: new ObjectId(), careHours: 3 },
+      bills: { nature: 'hourly', fundingId, thirdPartyPayer: new ObjectId(), careHours: '3' },
       startDate: new Date('2019/01/19'),
     }];
 
     find.returns(SinonMongoose.stubChainedQueries(events, ['lean']));
-    findOne.returns({ _id: fundingHistoryId, careHours: 12 });
+    findOne.returns({ _id: fundingHistoryId, careHours: '12' });
 
     await CreditNoteHelper.updateEventAndFundingHistory([], false, credentials);
 
     sinon.assert.calledOnceWithExactly(findOne, { fundingId, month: '01/2019' });
-    sinon.assert.calledOnceWithExactly(updateOneFundingHistory, { _id: fundingHistoryId }, { $set: { careHours: 9 } });
+    sinon.assert.calledOnceWithExactly(
+      updateOneFundingHistory,
+      { _id: fundingHistoryId },
+      { $set: { careHours: '9' } }
+    );
     sinon.assert.calledOnceWithExactly(updateOneEvent, { _id: events[0]._id }, { isBilled: false });
     SinonMongoose.calledOnceWithExactly(
       find,
@@ -237,7 +241,7 @@ describe('updateEventAndFundingHistory', () => {
 
     find.returns(SinonMongoose.stubChainedQueries(events, ['lean']));
     findOne.onCall(0).returns(null);
-    findOne.onCall(1).returns({ _id: fundingHistoryId, amountTTC: 1000 });
+    findOne.onCall(1).returns({ _id: fundingHistoryId, amountTTC: '1000' });
 
     await CreditNoteHelper.updateEventAndFundingHistory(eventsToUpdate, false, credentials);
 
@@ -246,7 +250,7 @@ describe('updateEventAndFundingHistory', () => {
     sinon.assert.calledOnceWithExactly(
       updateOneFundingHistory,
       { _id: fundingHistoryId },
-      { $set: { amountTTC: 800 } }
+      { $set: { amountTTC: '800' } }
     );
     sinon.assert.calledOnceWithExactly(updateOneEvent, { _id: events[0]._id }, { isBilled: false });
     SinonMongoose.calledOnceWithExactly(
@@ -262,13 +266,13 @@ describe('updateEventAndFundingHistory', () => {
     const events = [{
       _id: new ObjectId(),
       company: new ObjectId(),
-      bills: { nature: 'hourly', fundingId, thirdPartyPayer: new ObjectId(), careHours: 3 },
+      bills: { nature: 'hourly', fundingId, thirdPartyPayer: new ObjectId(), careHours: '3' },
       startDate: new Date('2019/01/19'),
     }];
 
     find.returns(events);
     findOne.onCall(0).returns(null);
-    findOne.onCall(1).returns({ _id: fundingHistoryId, careHours: 120 });
+    findOne.onCall(1).returns({ _id: fundingHistoryId, careHours: '120' });
     find.returns(SinonMongoose.stubChainedQueries(events, ['lean']));
 
     await CreditNoteHelper.updateEventAndFundingHistory([], true, credentials);
@@ -279,7 +283,7 @@ describe('updateEventAndFundingHistory', () => {
     sinon.assert.calledOnceWithExactly(
       updateOneFundingHistory,
       { _id: fundingHistoryId },
-      { $set: { careHours: 123 } }
+      { $set: { careHours: '123' } }
     );
     SinonMongoose.calledOnceWithExactly(
       find,
@@ -294,7 +298,7 @@ describe('updateEventAndFundingHistory', () => {
     const events = [{
       _id: new ObjectId(),
       company: new ObjectId(),
-      bills: { nature: 'hourly', fundingId, thirdPartyPayer: new ObjectId(), careHours: 3 },
+      bills: { nature: 'hourly', fundingId, thirdPartyPayer: new ObjectId(), careHours: '3' },
       startDate: new Date('2019/01/19'),
     }];
 
@@ -304,7 +308,11 @@ describe('updateEventAndFundingHistory', () => {
     await CreditNoteHelper.updateEventAndFundingHistory([], true, credentials);
 
     sinon.assert.calledOnceWithExactly(findOne, { fundingId, month: '01/2019' });
-    sinon.assert.calledOnceWithExactly(updateOneFundingHistory, { _id: fundingHistoryId }, { $set: { careHours: 15 } });
+    sinon.assert.calledOnceWithExactly(
+      updateOneFundingHistory,
+      { _id: fundingHistoryId },
+      { $set: { careHours: '15' } }
+    );
     sinon.assert.calledOnceWithExactly(updateOneEvent, { _id: events[0]._id }, { isBilled: true });
     SinonMongoose.calledOnceWithExactly(
       find,
@@ -327,7 +335,7 @@ describe('updateEventAndFundingHistory', () => {
 
     find.returns(SinonMongoose.stubChainedQueries(events, ['lean']));
     findOne.onCall(0).returns(null);
-    findOne.onCall(1).returns({ _id: fundingHistoryId, amountTTC: 1000 });
+    findOne.onCall(1).returns({ _id: fundingHistoryId, amountTTC: '1000' });
 
     await CreditNoteHelper.updateEventAndFundingHistory(eventsToUpdate, true, credentials);
 
@@ -336,7 +344,7 @@ describe('updateEventAndFundingHistory', () => {
     sinon.assert.calledOnceWithExactly(
       updateOneFundingHistory,
       { _id: fundingHistoryId },
-      { $set: { amountTTC: 1200 } }
+      { $set: { amountTTC: '1200' } }
     );
     sinon.assert.calledOnceWithExactly(updateOneEvent, { _id: events[0]._id }, { isBilled: true });
     SinonMongoose.calledOnceWithExactly(


### PR DESCRIPTION
<details open><summary> TESTS  :computer: </summary>

- [x] J'ai codé les tests unitaires
- [] J'ai codé les tests d'intégration
- [ ] C'est une ancienne route utilisée par les apps mobiles.
  - [ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens
</details>

- [ ] Je replie cette section car mes modifications n'ont pas besoin de tests unitaires ou d'intégration

---

<details open><summary> POINTS D'ATTENTION POUR CETTE PR  :warning: </summary>

- [ ] J'ai fait des modifications sur une route utilisée sur plusieurs plateformes [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/n3bq2hr9Ia)
- [ ] J'ai modifié un modèle utilisé en mobile [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/rqTfwpUib)
- [ ] J'ai ajouté un modèle spécifique à une structure 
  - [ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés
- [ ] J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile
  - [ ] Si oui, j'ai précisé sur le [slite de MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) qu'il faut forcer la mise à jour
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

</details>

- [x] Je replie cette section car je n'ai pas fait de modifications entrainant un point d'attention

---

<details open><summary> FONCTIONNALITÉS APPS MOBILES  :iphone: </summary>

- [ ] Mes changements impactent l'application formation
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours
- [ ] Mes changements impactent l'application erp
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours

</details>

- [x] Je replie cette section car mes modifications n'ont pas d'impact sur les applications mobiles

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : admin client

- Cas d'usage : lorsque l'on cree un avoir pour un tiers-payeur, l'historique de financement est mis a jour et les champs `caerHours` et `amountTTC` sont des string

- Comment tester ? : 
   - lancer le script
   - creer un beneficiaire
   - ajouter 3 souscriptions reliées a 3 services différents 
   - lui ajouter 3 financements chacun relié a une des souscriptions:
       - financement 1: horaire de fréquence mensuelle
       - financement 2: horaire de fréquence en une seule fois
       - financement 3: forfaitaire de fréquence en une seule fois
  - Pour chaque service: 
       - creer des interventions
       - facturer 
       -  en bdd un fundingHistory a ete cree avec 
           - financement 1 : careHours non nul pour le mois correspondant au mois des interventions
           - financement 2: careHours non nul
           - financement 3 : amountTTC non nul
       - creer un avoir relié a des interventions 
       - vérifier que l'historique de financement a bien ete modifie correctement:
          - financement 1 : maj de careHours pour le mois correspondant au mois des interventions
          - financement 2: maj de careHours
          - financement 3 : maj de amountTTC 
       - tester aussi la creation d'un avoir sur la souscription et un autre sur des articles de facturation  

_Si tu as lu cette description, pense a réagir avec un :eye:_
