### PR TITLE
Com 2849

### DIFF
--- a/src/helpers/contracts.js
+++ b/src/helpers/contracts.js
@@ -361,7 +361,7 @@ exports.saveCompletedContract = async (everSignDoc) => {
   );
 };
 
-exports.getContractInfo = (versions, query, monthRatio) => {
+exports.getContractInfo = (versions, query, monthRatio, shouldPayHolidays) => {
   let contractHours = 0;
   let workedDays = 0;
   let holidaysHours = 0;
@@ -373,7 +373,7 @@ exports.getContractInfo = (versions, query, monthRatio) => {
     const endDate = version.endDate && moment(version.endDate).isBefore(query.endDate)
       ? moment(version.endDate).endOf('d').toDate()
       : moment(query.endDate).toDate();
-    const ratio = UtilsHelper.getDaysRatioBetweenTwoDates(startDate, endDate);
+    const ratio = UtilsHelper.getDaysRatioBetweenTwoDates(startDate, endDate, shouldPayHolidays);
 
     const versionDays = ratio.businessDays + ratio.holidays;
     workedDays += versionDays;

--- a/src/helpers/contracts.js
+++ b/src/helpers/contracts.js
@@ -361,11 +361,11 @@ exports.saveCompletedContract = async (everSignDoc) => {
   );
 };
 
-exports.getContractInfo = (versions, query, monthRatio, shouldPayHolidays) => {
+exports.getContractInfo = (versions, query, periodRatio, shouldPayHolidays) => {
   let contractHours = 0;
   let workedDays = 0;
   let holidaysHours = 0;
-  const monthDays = monthRatio.businessDays + monthRatio.holidays;
+  const periodDays = periodRatio.businessDays + periodRatio.holidays;
   for (const version of versions) {
     const startDate = moment(version.startDate).isBefore(query.startDate)
       ? moment(query.startDate).toDate()
@@ -377,11 +377,11 @@ exports.getContractInfo = (versions, query, monthRatio, shouldPayHolidays) => {
 
     const versionDays = ratio.businessDays + ratio.holidays;
     workedDays += versionDays;
-    contractHours += version.weeklyHours * (versionDays / monthDays);
+    contractHours += version.weeklyHours * (versionDays / periodDays);
     holidaysHours += (version.weeklyHours / 6) * ratio.holidays;
   }
 
-  return { contractHours, holidaysHours, workedDaysRatio: workedDays / monthDays };
+  return { contractHours, holidaysHours, workedDaysRatio: workedDays / periodDays };
 };
 
 exports.getMatchingVersionsList = (versions, query) => versions.filter((ver) => {

--- a/src/helpers/draftFinalPay.js
+++ b/src/helpers/draftFinalPay.js
@@ -1,6 +1,5 @@
 const moment = require('moment');
 const get = require('lodash/get');
-const { WEEKS_PER_MONTH } = require('./constants');
 const Company = require('../models/Company');
 const Surcharge = require('../models/Surcharge');
 const DistanceMatrix = require('../models/DistanceMatrix');
@@ -8,19 +7,6 @@ const ContractRepository = require('../repositories/ContractRepository');
 const EventRepository = require('../repositories/EventRepository');
 const DraftPayHelper = require('./draftPay');
 const UtilsHelper = require('./utils');
-const ContractHelper = require('./contracts');
-
-exports.getContractMonthInfo = (contract, query) => {
-  const start = moment(query.startDate).startOf('M').toDate();
-  const end = moment(query.startDate).endOf('M').toDate();
-  const versions = contract.versions.filter(ver => (moment(ver.startDate).isSameOrBefore(query.endDate) &&
-    ver.endDate && moment(ver.endDate).isSameOrAfter(query.startDate)));
-  const monthBusinessDays = UtilsHelper.getDaysRatioBetweenTwoDates(start, end);
-
-  const info = ContractHelper.getContractInfo(versions, query, monthBusinessDays);
-
-  return { contractHours: info.contractHours * WEEKS_PER_MONTH, workedDaysRatio: info.workedDaysRatio };
-};
 
 exports.computeAuxiliaryDraftFinalPay = async (
   auxiliary,

--- a/src/helpers/draftPay.js
+++ b/src/helpers/draftPay.js
@@ -386,7 +386,7 @@ const getPhoneFees = (auxiliary, contractInfo, company) => {
 };
 
 exports.computeBalance = async (auxiliary, contract, eventsToPay, subscriptions, company, query, dm, surcharges) => {
-  const shouldPayHolidays = get(company.rhConfig, 'shouldPayHolidays');
+  const shouldPayHolidays = get(company, 'rhConfig.shouldPayHolidays');
   const contractInfo = exports.getContractMonthInfo(contract, query, shouldPayHolidays);
 
   const contractEvents = filterEvents(eventsToPay, contract);

--- a/src/helpers/draftPay.js
+++ b/src/helpers/draftPay.js
@@ -32,13 +32,13 @@ const ContractHelper = require('./contracts');
 const DatesHelper = require('./dates');
 const { CompaniDate } = require('./dates/companiDates');
 
-exports.getContractMonthInfo = (contract, query) => {
+exports.getContractMonthInfo = (contract, query, shouldPayHolidays) => {
   const start = moment(query.startDate).startOf('M').toDate();
   const end = moment(query.startDate).endOf('M').toDate();
-  const monthBusinessDays = UtilsHelper.getDaysRatioBetweenTwoDates(start, end);
+  const monthBusinessDays = UtilsHelper.getDaysRatioBetweenTwoDates(start, end, shouldPayHolidays);
   const versions = ContractHelper.getMatchingVersionsList(contract.versions || [], query);
 
-  const info = ContractHelper.getContractInfo(versions, query, monthBusinessDays);
+  const info = ContractHelper.getContractInfo(versions, query, monthBusinessDays, shouldPayHolidays);
 
   return {
     contractHours: info.contractHours * WEEKS_PER_MONTH,
@@ -386,7 +386,8 @@ const getPhoneFees = (auxiliary, contractInfo, company) => {
 };
 
 exports.computeBalance = async (auxiliary, contract, eventsToPay, subscriptions, company, query, dm, surcharges) => {
-  const contractInfo = exports.getContractMonthInfo(contract, query);
+  const shouldPayHolidays = get(company.rhConfig, 'shouldPayHolidays');
+  const contractInfo = exports.getContractMonthInfo(contract, query, shouldPayHolidays);
 
   const contractEvents = filterEvents(eventsToPay, contract);
   const hours = await exports.getPayFromEvents(contractEvents, auxiliary, subscriptions, dm, surcharges, query);
@@ -545,7 +546,12 @@ exports.computeDraftPay = async (auxiliaries, query, credentials) => {
   const [company, surcharges, dm] = await Promise.all([
     Company.findOne(
       { _id: companyId },
-      { 'rhConfig.phoneFeeAmount': 1, 'rhConfig.transportSubs': 1, 'rhConfig.amountPerKm': 1 }
+      {
+        'rhConfig.phoneFeeAmount': 1,
+        'rhConfig.transportSubs': 1,
+        'rhConfig.amountPerKm': 1,
+        'rhConfig.shouldPayHolidays': 1,
+      }
     )
       .lean(),
     Surcharge.find({ company: companyId }, { createdAt: 0, updatedAt: 0, company: 0, __v: 0 }).lean(),

--- a/src/helpers/events.js
+++ b/src/helpers/events.js
@@ -454,13 +454,13 @@ exports.deleteEventsAndRepetition = async (query, shouldDeleteRepetitions, crede
   await Event.deleteMany({ _id: { $in: events.map(ev => ev._id) } });
 };
 
-exports.getContractWeekInfo = (contract, query) => {
+exports.getContractWeekInfo = (contract, query, shouldPayHolidays) => {
   const start = moment(query.startDate).startOf('w').toDate();
   const end = moment(query.startDate).endOf('w').toDate();
-  const weekRatio = UtilsHelper.getDaysRatioBetweenTwoDates(start, end);
+  const weekRatio = UtilsHelper.getDaysRatioBetweenTwoDates(start, end, shouldPayHolidays);
   const versions = ContractHelper.getMatchingVersionsList(contract.versions || [], query);
 
-  return ContractHelper.getContractInfo(versions, query, weekRatio);
+  return ContractHelper.getContractInfo(versions, query, weekRatio, shouldPayHolidays);
 };
 
 exports.getContract = (contracts, startDate, endDate) => contracts.find((cont) => {
@@ -471,7 +471,8 @@ exports.getContract = (contracts, startDate, endDate) => contracts.find((cont) =
 });
 
 exports.workingStats = async (query, credentials) => {
-  const companyId = get(credentials, 'company._id', null);
+  const companyId = get(credentials.company, '_id');
+  const shouldPayHolidays = get(credentials.company.rhConfig, 'shouldPayHolidays');
   let auxiliaryIds = [];
 
   if (query.auxiliary) {
@@ -497,7 +498,7 @@ exports.workingStats = async (query, credentials) => {
     const contract = exports.getContract(contracts, query.startDate, query.endDate);
     if (!contract) continue;
 
-    const contractInfo = exports.getContractWeekInfo(contract, query);
+    const contractInfo = exports.getContractWeekInfo(contract, query, shouldPayHolidays);
     const hours =
       await DraftPayHelper.getPayFromEvents(eventsToPay.events, auxiliary, subscriptions, distanceMatrix, [], query);
     const absencesHours = DraftPayHelper.getPayFromAbsences(eventsToPay.absences, contract, query);

--- a/src/helpers/events.js
+++ b/src/helpers/events.js
@@ -471,8 +471,8 @@ exports.getContract = (contracts, startDate, endDate) => contracts.find((cont) =
 });
 
 exports.workingStats = async (query, credentials) => {
-  const companyId = get(credentials.company, '_id');
-  const shouldPayHolidays = get(credentials.company.rhConfig, 'shouldPayHolidays');
+  const companyId = get(credentials, 'company._id');
+  const shouldPayHolidays = get(credentials, 'company.rhConfig.shouldPayHolidays');
   let auxiliaryIds = [];
 
   if (query.auxiliary) {

--- a/src/helpers/pay.js
+++ b/src/helpers/pay.js
@@ -130,7 +130,7 @@ const updateVersionsWithSectorDates = (version, sector) => {
   return returnedVersion;
 };
 
-exports.computeHoursToWork = (month, contracts) => {
+exports.computeHoursToWork = (month, contracts, shouldPayHolidays) => {
   const contractsInfoSum = { contractHours: 0, holidaysHours: 0, absencesHours: 0 };
 
   for (const contract of contracts) {
@@ -145,7 +145,7 @@ exports.computeHoursToWork = (month, contracts) => {
     versions = versions.map(version => updateVersionsWithSectorDates(version, contract.sector));
     const contractWithSectorDates = { ...contract, versions };
 
-    const contractInfo = DraftPayHelper.getContractMonthInfo(contractWithSectorDates, contractQuery);
+    const contractInfo = DraftPayHelper.getContractMonthInfo(contractWithSectorDates, contractQuery, shouldPayHolidays);
     contractsInfoSum.contractHours += contractInfo.contractHours;
     contractsInfoSum.holidaysHours += contractInfo.holidaysHours;
 
@@ -164,6 +164,7 @@ exports.computeHoursToWork = (month, contracts) => {
 exports.getHoursToWorkBySector = async (query, credentials) => {
   const hoursToWorkBySector = [];
   const sectors = UtilsHelper.formatObjectIdsArray(query.sector);
+  const shouldPayHolidays = get(credentials.company.rhConfig, 'shouldPayHolidays');
 
   const contractsAndAbsencesBySector = await SectorHistoryRepository.getContractsAndAbsencesBySector(
     query.month,
@@ -174,7 +175,7 @@ exports.getHoursToWorkBySector = async (query, credentials) => {
   for (const sector of contractsAndAbsencesBySector) {
     hoursToWorkBySector.push({
       sector: sector._id,
-      hoursToWork: exports.computeHoursToWork(query.month, sector.contracts),
+      hoursToWork: exports.computeHoursToWork(query.month, sector.contracts, shouldPayHolidays),
     });
   }
 

--- a/src/helpers/pay.js
+++ b/src/helpers/pay.js
@@ -164,7 +164,7 @@ exports.computeHoursToWork = (month, contracts, shouldPayHolidays) => {
 exports.getHoursToWorkBySector = async (query, credentials) => {
   const hoursToWorkBySector = [];
   const sectors = UtilsHelper.formatObjectIdsArray(query.sector);
-  const shouldPayHolidays = get(credentials.company.rhConfig, 'shouldPayHolidays');
+  const shouldPayHolidays = get(credentials, 'company.rhConfig.shouldPayHolidays');
 
   const contractsAndAbsencesBySector = await SectorHistoryRepository.getContractsAndAbsencesBySector(
     query.month,

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -135,7 +135,7 @@ exports.capitalize = (s) => {
   return s.charAt(0).toUpperCase() + s.slice(1);
 };
 
-exports.getDaysRatioBetweenTwoDates = (start, end) => {
+exports.getDaysRatioBetweenTwoDates = (start, end, shouldPayHolidays) => {
   let holidays = 0;
   let sundays = 0;
   let businessDays = 0;
@@ -144,7 +144,7 @@ exports.getDaysRatioBetweenTwoDates = (start, end) => {
   const range = Array.from(moment().range(start, end).by('days'));
   for (const day of range) {
     // startOf('day') is necessery to check fr holidays in business day
-    if (day.startOf('d').isHoliday() && day.day() !== 0) holidays += 1;
+    if (shouldPayHolidays && day.startOf('d').isHoliday() && day.day() !== 0) holidays += 1;
     else if (day.day() !== 0) businessDays += 1;
     else sundays += 1;
   }

--- a/tests/seed/authCompaniesSeed.js
+++ b/tests/seed/authCompaniesSeed.js
@@ -33,6 +33,7 @@ const authCompany = {
   rhConfig: {
     amountPerKm: 0.22,
     phoneFeeAmount: 18,
+    shouldPayHolidays: true,
   },
 };
 

--- a/tests/unit/helpers/contracts.test.js
+++ b/tests/unit/helpers/contracts.test.js
@@ -1434,7 +1434,8 @@ describe('getContractInfo', () => {
     const query = { startDate: '2019-06-03', endDate: '2019-06-07' };
     getDaysRatioBetweenTwoDates.returns({ businessDays: 4, sundays: 0, holidays: 0 });
 
-    const result = ContractHelper.getContractInfo(versions, query, { businessDays: 10, sundays: 0, holidays: 0 });
+    const result = ContractHelper
+      .getContractInfo(versions, query, { businessDays: 10, sundays: 0, holidays: 0 }, false);
 
     expect(result).toBeDefined();
     expect(result.contractHours).toBe(8);
@@ -1443,7 +1444,8 @@ describe('getContractInfo', () => {
     sinon.assert.calledWithExactly(
       getDaysRatioBetweenTwoDates,
       moment('2019-06-03').toDate(),
-      moment('2019-06-07').toDate()
+      moment('2019-06-07').toDate(),
+      false
     );
   });
 
@@ -1452,13 +1454,15 @@ describe('getContractInfo', () => {
     const query = { startDate: '2019-06-03', endDate: '2019-06-09' };
     getDaysRatioBetweenTwoDates.returns({ businessDays: 4, sundays: 1, holidays: 0 });
 
-    const result = ContractHelper.getContractInfo(versions, query, { businessDays: 10, sundays: 0, holidays: 0 });
+    const result = ContractHelper
+      .getContractInfo(versions, query, { businessDays: 10, sundays: 0, holidays: 0 }, false);
 
     expect(result).toBeDefined();
     sinon.assert.calledWithExactly(
       getDaysRatioBetweenTwoDates,
       moment('2019-06-03').startOf('d').toDate(),
-      moment('2019-06-09').toDate()
+      moment('2019-06-09').toDate(),
+      false
     );
   });
 
@@ -1470,7 +1474,8 @@ describe('getContractInfo', () => {
     const query = { startDate: '2019-06-27', endDate: '2019-07-05' };
     getDaysRatioBetweenTwoDates.returns({ businessDays: 4, sundays: 1, holidays: 0 });
 
-    const result = ContractHelper.getContractInfo(versions, query, { businessDays: 10, sundays: 0, holidays: 0 });
+    const result = ContractHelper
+      .getContractInfo(versions, query, { businessDays: 10, sundays: 0, holidays: 0 }, false);
 
     expect(result).toBeDefined();
     sinon.assert.calledTwice(getDaysRatioBetweenTwoDates);
@@ -1481,7 +1486,7 @@ describe('getContractInfo', () => {
     const query = { startDate: '2019-05-04', endDate: '2019-05-10' };
     getDaysRatioBetweenTwoDates.returns({ businessDays: 4, sundays: 0, holidays: 1 });
 
-    const result = ContractHelper.getContractInfo(versions, query, { businessDays: 10, sundays: 0, holidays: 0 });
+    const result = ContractHelper.getContractInfo(versions, query, { businessDays: 10, sundays: 0, holidays: 0 }, true);
 
     expect(result).toBeDefined();
     expect(result.contractHours).toBe(12);
@@ -1492,7 +1497,8 @@ describe('getContractInfo', () => {
       moment('2019-05-04')
         .startOf('d')
         .toDate(),
-      moment('2019-05-10').toDate()
+      moment('2019-05-10').toDate(),
+      true
     );
   });
 });

--- a/tests/unit/helpers/draftFinalPay.test.js
+++ b/tests/unit/helpers/draftFinalPay.test.js
@@ -4,8 +4,6 @@ const moment = require('moment');
 const { ObjectId } = require('mongodb');
 const DraftFinalPayHelper = require('../../../src/helpers/draftFinalPay');
 const DraftPayHelper = require('../../../src/helpers/draftPay');
-const ContractHelper = require('../../../src/helpers/contracts');
-const UtilsHelper = require('../../../src/helpers/utils');
 const Company = require('../../../src/models/Company');
 const Surcharge = require('../../../src/models/Surcharge');
 const DistanceMatrix = require('../../../src/models/DistanceMatrix');
@@ -13,47 +11,6 @@ const FinalPay = require('../../../src/models/FinalPay');
 const ContractRepository = require('../../../src/repositories/ContractRepository');
 const EventRepository = require('../../../src/repositories/EventRepository');
 const SinonMongoose = require('../sinonMongoose');
-
-describe('getContractMonthInfo', () => {
-  let getDaysRatioBetweenTwoDates;
-  let getContractInfo;
-  beforeEach(() => {
-    getDaysRatioBetweenTwoDates = sinon.stub(UtilsHelper, 'getDaysRatioBetweenTwoDates');
-    getContractInfo = sinon.stub(ContractHelper, 'getContractInfo');
-  });
-  afterEach(() => {
-    getDaysRatioBetweenTwoDates.restore();
-    getContractInfo.restore();
-  });
-
-  it('should get contract month info', () => {
-    const versions = [
-      { startDate: '2019-01-01', endDate: '2019-05-04', weeklyHours: 18 },
-      { endDate: '2019-05-17', startDate: '2019-05-04', weeklyHours: 24 },
-    ];
-    const contract = { versions, endDate: '2019-05-16' };
-    const query = { startDate: '2019-05-06', endDate: '2019-05-10' };
-    getDaysRatioBetweenTwoDates.returns(4);
-    getContractInfo.returns({ contractHours: 12, workedDaysRatio: 1 / 4 });
-
-    const result = DraftFinalPayHelper.getContractMonthInfo(contract, query);
-
-    expect(result).toBeDefined();
-    expect(result.contractHours).toBe(52);
-    expect(result.workedDaysRatio).toBe(1 / 4);
-    sinon.assert.calledWithExactly(
-      getDaysRatioBetweenTwoDates,
-      moment('2019-05-06').startOf('M').toDate(),
-      moment('2019-05-06').endOf('M').toDate()
-    );
-    sinon.assert.calledWithExactly(
-      getContractInfo,
-      [{ endDate: '2019-05-17', startDate: '2019-05-04', weeklyHours: 24 }],
-      query,
-      4
-    );
-  });
-});
 
 describe('computeAuxiliaryDraftFinalPay', () => {
   let computeBalance;

--- a/tests/unit/helpers/events.test.js
+++ b/tests/unit/helpers/events.test.js
@@ -1987,7 +1987,7 @@ describe('getContractWeekInfo', () => {
     getContractInfo.returns({ contractHours: 26, workedDaysRatio: 1 / 4 });
     getMatchingVersionsList.returns(versions[1]);
 
-    const result = EventHelper.getContractWeekInfo(contract, query);
+    const result = EventHelper.getContractWeekInfo(contract, query, true);
 
     expect(result).toBeDefined();
     expect(result.contractHours).toBe(26);
@@ -1995,9 +1995,10 @@ describe('getContractWeekInfo', () => {
     sinon.assert.calledOnceWithExactly(
       getDaysRatioBetweenTwoDates,
       moment('2019-11-20').startOf('w').toDate(),
-      moment('2019-11-20').endOf('w').toDate()
+      moment('2019-11-20').endOf('w').toDate(),
+      true
     );
-    sinon.assert.calledOnceWithExactly(getContractInfo, versions[1], query, 4);
+    sinon.assert.calledOnceWithExactly(getContractInfo, versions[1], query, 4, true);
   });
 });
 
@@ -2009,7 +2010,7 @@ describe('workingStats', () => {
     status: 200,
   };
   const companyId = new ObjectId();
-  const credentials = { company: { _id: companyId } };
+  const credentials = { company: { _id: companyId, rhConfig: { shouldPayHolidays: false } } };
   let findUser;
   let findUserCompany;
   let findDistanceMatrix;
@@ -2074,7 +2075,7 @@ describe('workingStats', () => {
     sinon.assert.notCalled(findUserCompany);
     sinon.assert.calledOnceWithExactly(getEventsToPayStub, query.startDate, query.endDate, [auxiliaryId], companyId);
     sinon.assert.calledOnceWithExactly(getContractStub, contracts, query.startDate, query.endDate);
-    sinon.assert.calledOnceWithExactly(getContractWeekInfoStub, contract, query);
+    sinon.assert.calledOnceWithExactly(getContractWeekInfoStub, contract, query, false);
     sinon.assert.calledOnceWithExactly(
       getPayFromEventsStub,
       [],
@@ -2132,7 +2133,7 @@ describe('workingStats', () => {
     expect(result).toEqual(expectedResult);
     sinon.assert.calledOnceWithExactly(getEventsToPayStub, query.startDate, query.endDate, [auxiliaryId], companyId);
     sinon.assert.calledOnceWithExactly(getContractStub, contracts, query.startDate, query.endDate);
-    sinon.assert.calledOnceWithExactly(getContractWeekInfoStub, contract, queryWithoutAuxiliary);
+    sinon.assert.calledOnceWithExactly(getContractWeekInfoStub, contract, queryWithoutAuxiliary, false);
     sinon.assert.calledOnceWithExactly(
       getPayFromEventsStub,
       [],

--- a/tests/unit/helpers/pay.test.js
+++ b/tests/unit/helpers/pay.test.js
@@ -785,9 +785,9 @@ describe('computeHoursToWork', () => {
     getContractMonthInfoStub.returns({ contractHours: 85, holidaysHours: 5 });
     getPayFromAbsences.returns(6);
 
-    const result = PayHelper.computeHoursToWork('122019', contracts);
+    const result = PayHelper.computeHoursToWork('122019', contracts, false);
     expect(result).toBe(74);
-    sinon.assert.calledWithExactly(getContractMonthInfoStub, contracts[0], contractQuery);
+    sinon.assert.calledWithExactly(getContractMonthInfoStub, contracts[0], contractQuery, false);
     sinon.assert.calledWithExactly(getPayFromAbsences, contracts[0].absences, contracts[0], contractQuery);
     sinon.assert.calledWithExactly(getMatchingVersionsListStub, contracts[0].versions, contractQuery);
   });
@@ -802,10 +802,10 @@ describe('computeHoursToWork', () => {
     getMatchingVersionsListStub.onCall(0).returns(contracts[0].versions);
     getMatchingVersionsListStub.onCall(1).returns(contracts[1].versions);
 
-    const result = PayHelper.computeHoursToWork('122019', contracts);
+    const result = PayHelper.computeHoursToWork('122019', contracts, false);
     expect(result).toBe(175);
-    sinon.assert.calledWithExactly(getContractMonthInfoStub.getCall(0), contracts[0], contractQuery);
-    sinon.assert.calledWithExactly(getContractMonthInfoStub.getCall(1), contracts[1], contractQuery);
+    sinon.assert.calledWithExactly(getContractMonthInfoStub.getCall(0), contracts[0], contractQuery, false);
+    sinon.assert.calledWithExactly(getContractMonthInfoStub.getCall(1), contracts[1], contractQuery, false);
     sinon.assert.calledWithExactly(getMatchingVersionsListStub, contracts[0].versions, contractQuery);
     sinon.assert.notCalled(getPayFromAbsences);
   });
@@ -830,9 +830,9 @@ describe('computeHoursToWork', () => {
     getContractMonthInfoStub.returns({ contractHours: 85, holidaysHours: 5 });
     getMatchingVersionsListStub.returns(contracts[0].versions);
 
-    const result = PayHelper.computeHoursToWork('122019', contracts);
+    const result = PayHelper.computeHoursToWork('122019', contracts, false);
     expect(result).toBe(80);
-    sinon.assert.calledWithExactly(getContractMonthInfoStub, newContract, { ...contractQuery, endDate });
+    sinon.assert.calledWithExactly(getContractMonthInfoStub, newContract, { ...contractQuery, endDate }, false);
     sinon.assert.calledWithExactly(getMatchingVersionsListStub, contracts[0].versions, { ...contractQuery, endDate });
     sinon.assert.notCalled(getPayFromAbsences);
   });
@@ -857,16 +857,16 @@ describe('computeHoursToWork', () => {
     getContractMonthInfoStub.returns({ contractHours: 85, holidaysHours: 5 });
     getMatchingVersionsListStub.returns(contracts[0].versions);
 
-    const result = PayHelper.computeHoursToWork('122019', contracts);
+    const result = PayHelper.computeHoursToWork('122019', contracts, false);
     expect(result).toBe(80);
-    sinon.assert.calledWithExactly(getContractMonthInfoStub, newContract, { ...contractQuery, startDate });
+    sinon.assert.calledWithExactly(getContractMonthInfoStub, newContract, { ...contractQuery, startDate }, false);
     sinon.assert.calledWithExactly(getMatchingVersionsListStub, contracts[0].versions, { ...contractQuery, startDate });
     sinon.assert.notCalled(getPayFromAbsences);
   });
 });
 
 describe('getHoursToWorkBySector', () => {
-  const credentials = { company: { _id: new ObjectId() } };
+  const credentials = { company: { _id: new ObjectId(), rhConfig: { shouldPayHolidays: false } } };
   let getContractsAndAbsencesBySectorStub;
   let computeHoursToWorkStub;
 
@@ -905,8 +905,18 @@ describe('getHoursToWorkBySector', () => {
       query.sector.map(sector => new ObjectId(sector)),
       credentials.company._id
     );
-    sinon.assert.calledWithExactly(computeHoursToWorkStub.getCall(0), query.month, contractAndAbsences[0].contracts);
-    sinon.assert.calledWithExactly(computeHoursToWorkStub.getCall(1), query.month, contractAndAbsences[1].contracts);
+    sinon.assert.calledWithExactly(
+      computeHoursToWorkStub.getCall(0),
+      query.month,
+      contractAndAbsences[0].contracts,
+      false
+    );
+    sinon.assert.calledWithExactly(
+      computeHoursToWorkStub.getCall(1),
+      query.month,
+      contractAndAbsences[1].contracts,
+      false
+    );
   });
 
   it('should return hours to work by sector (sectors as string + no absences)', async () => {
@@ -931,6 +941,6 @@ describe('getHoursToWorkBySector', () => {
       [new ObjectId(query.sector)],
       credentials.company._id
     );
-    sinon.assert.calledWithExactly(computeHoursToWorkStub, query.month, contractAndAbsences[0].contracts);
+    sinon.assert.calledWithExactly(computeHoursToWorkStub, query.month, contractAndAbsences[0].contracts, false);
   });
 });

--- a/tests/unit/helpers/utils.test.js
+++ b/tests/unit/helpers/utils.test.js
@@ -248,7 +248,7 @@ describe('getDaysRatioBetweenTwoDates', () => {
   it('Case 1. No sundays nor holidays in range', () => {
     const start = new Date('2019/05/21');
     const end = new Date('2019/05/23');
-    const result = UtilsHelper.getDaysRatioBetweenTwoDates(start, end);
+    const result = UtilsHelper.getDaysRatioBetweenTwoDates(start, end, true);
 
     expect(result).toBeDefined();
     expect(result).toEqual({ holidays: 0, sundays: 0, businessDays: 3 });
@@ -257,19 +257,28 @@ describe('getDaysRatioBetweenTwoDates', () => {
   it('Case 2. Sundays in range', () => {
     const start = new Date('2019/05/18');
     const end = new Date('2019/05/23');
-    const result = UtilsHelper.getDaysRatioBetweenTwoDates(start, end);
+    const result = UtilsHelper.getDaysRatioBetweenTwoDates(start, end, true);
 
     expect(result).toBeDefined();
     expect(result).toEqual({ holidays: 0, sundays: 1, businessDays: 5 });
   });
 
-  it('Case 3. Holidays in range', () => {
+  it('Case 3. Holidays in range and shouldPayHolidays', () => {
     const start = new Date('2022/04/17');
     const end = new Date('2022/04/19');
-    const result = UtilsHelper.getDaysRatioBetweenTwoDates(start, end);
+    const result = UtilsHelper.getDaysRatioBetweenTwoDates(start, end, true);
 
     expect(result).toBeDefined();
     expect(result).toEqual({ holidays: 1, sundays: 1, businessDays: 1 });
+  });
+
+  it('Case 4. Holidays in range and shouldPayHolidays', () => {
+    const start = new Date('2022/04/17');
+    const end = new Date('2022/04/19');
+    const result = UtilsHelper.getDaysRatioBetweenTwoDates(start, end, false);
+
+    expect(result).toBeDefined();
+    expect(result).toEqual({ holidays: 0, sundays: 1, businessDays: 2 });
   });
 });
 

--- a/tests/unit/helpers/utils.test.js
+++ b/tests/unit/helpers/utils.test.js
@@ -263,7 +263,7 @@ describe('getDaysRatioBetweenTwoDates', () => {
     expect(result).toEqual({ holidays: 0, sundays: 1, businessDays: 5 });
   });
 
-  it('Case 3. Holidays in range and shouldPayHolidays', () => {
+  it('Case 3. Holidays in range and company should pay holidays', () => {
     const start = new Date('2022/04/17');
     const end = new Date('2022/04/19');
     const result = UtilsHelper.getDaysRatioBetweenTwoDates(start, end, true);
@@ -272,7 +272,7 @@ describe('getDaysRatioBetweenTwoDates', () => {
     expect(result).toEqual({ holidays: 1, sundays: 1, businessDays: 1 });
   });
 
-  it('Case 4. Holidays in range and shouldPayHolidays', () => {
+  it('Case 4. Holidays in range and company should not pay holidays', () => {
     const start = new Date('2022/04/17');
     const end = new Date('2022/04/19');
     const result = UtilsHelper.getDaysRatioBetweenTwoDates(start, end, false);


### PR DESCRIPTION
<details open><summary> TESTS  :computer: </summary>

- [x] J'ai codé les tests unitaires
- [x] J'ai codé les tests d'intégration
- [ ] C'est une ancienne route utilisée par les apps mobiles.
  - [ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens
</details>

- [ ] Je replie cette section car mes modifications n'ont pas besoin de tests unitaires ou d'intégration

---

<details open><summary> POINTS D'ATTENTION POUR CETTE PR  :warning: </summary>

- [ ] J'ai fait des modifications sur une route utilisée sur plusieurs plateformes [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/n3bq2hr9Ia)
- [ ] J'ai modifié un modèle utilisé en mobile [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/rqTfwpUib)
- [ ] J'ai ajouté un modèle spécifique à une structure 
  - [ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés
- [ ] J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile
  - [ ] Si oui, j'ai précisé sur le [slite de MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) qu'il faut forcer la mise à jour
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

</details>

- [x] Je replie cette section car je n'ai pas fait de modifications entrainant un point d'attention

---

<details open><summary> FONCTIONNALITÉS APPS MOBILES  :iphone: </summary>

- [ ] Mes changements impactent l'application formation
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours
- [ ] Mes changements impactent l'application erp
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours

</details>

- [x] Je replie cette section car mes modifications n'ont pas d'impact sur les applications mobiles

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : admin client / coach / auxiliaire

- Cas d'usage : si les jours fériés ne sont pas travaillés (ils sont payés par ma structure), je vois l'impact dans la paie et sur les compteurs

- Comment tester ? :
   - lancer le script mep63.js pour avoir la bdd a jour (pour avoir le champ shouldPayHolidays)
   - creer un.e auxiliaire avec un contrat 
   - dans configuration RH, vérifier que la checkbox 'les jours fériés ne sont pas travaillés' est cochée
       - sur la planning de l'auxiliaire : 
          - sur cette semaine, le compteur d'heure est de: nb heure du contrat 
          - sur la semaine prochaine, avec 1 jour ferié le compteur d'heure est de : nb heure du contrat - (nb heure du contrat / 6)
          - ouvrir le tableau de bord de l'auxiliaire
             - sur le mois de Mai: 1 jour férié (qui n'est pas un dimanche) donc dans la colonne heure a travailler, verifier qu'est affiché : nb heure du contrat * 4.33 - (nb heure du contrat / 6) 
       - sur le tableau de bord de l'équipe: 
          - verifier que le tableau de bord de l'auxiliaire tient compte du jour férié
       - dans le tableau paie mensuelle:
         - vérifier que dans la colonnes Heures a travailler, la valeur est : nb heure du contrat * 4.33 - (nb heure du contrat / 6) 
         - verifier que la colonne Solde vaut `Heures travaillées - heures a travailler`
     - mettre fin au contrat de l'auxiliaire
        - dans STC, verifier que:
           - vérifier que dans la colonnes Heures a travailler, la valeur est : nb heure du contrat * 4.33 - (nb heure du contrat / 6)
           - verifier que la colonne solde vaut `Heures travaillées - heures a travailler`
  - dans configuration RH, décocher la checkbox 'les jours fériés ne sont pas travaillés' 
     - sur la planning de l'auxiliaire : 
          - sur cette semaine, le compteur d'heure est de: nb heure du contrat 
          - sur la semaine prochaine, le compteur d'heure est de: nb heure du contrat. Le jour férié est considéré comme travaillé
          - ouvrir le tableau de bord de l'auxiliaire
             - sur le mois de Mai: 1 jour férié mais il est travaillé donc heure a travailler = nb heure du contrat * 4.33
     - sur le tableau de bord de l'équipe: 
          - verifier que le tableau de bord de l'auxiliaire ne tient pas compte du jour férié:  heure a travailler = nb heure du contrat * 4.33
    - dans le tableau paie mensuelle:
         - vérifier que dans la colonnes Heures a travailler, la valeur est : nb heure du contrat
         - verifier que la colonne solde vaut `Heures travaillées - heures a travailler`
     - dans STC, verifier que:
           - vérifier que dans la colonnes Heures a travailler, la valeur est : nb heure du contrat )
           - verifier que la colonne solde vaut `Heures travaillées - heures a travailler`

_Si tu as lu cette description, pense a réagir avec un :eye:_
