### PR TITLE
COM-2870 add CRE code for event with no timestamp even cancelled ones

### DIFF
--- a/tests/unit/helpers/delivery.test.js
+++ b/tests/unit/helpers/delivery.test.js
@@ -594,7 +594,7 @@ describe('getTimeStampInfo', () => {
   });
 });
 
-describe('getTypeCode #tag', () => {
+describe('getTypeCode', () => {
   it('should get typeCode for event with both timestamp', () => {
     const typeCode = DeliveryHelper.getTypeCode(true, true, true);
 

--- a/tests/unit/helpers/delivery.test.js
+++ b/tests/unit/helpers/delivery.test.js
@@ -136,7 +136,6 @@ describe('getEventHistories', () => {
             action: { $in: TIME_STAMPING_ACTIONS },
             'event.eventId': { $in: [event1, event2, event3] },
             company: companyId,
-            isCancelled: false,
           }],
         },
         { query: 'lean' },
@@ -508,5 +507,121 @@ describe('getFileName', () => {
       findOne,
       [{ query: 'findOne', args: [{ _id: tppId }, { teletransmissionType: 1, companyCode: 1 }] }, { query: 'lean' }]
     );
+  });
+});
+
+describe('getTimeStampInfo', () => {
+  it('should return info for event with both timestamp', () => {
+    const histories = [
+      { update: { startHour: '2022-05-12T12:22:30.000Z' } },
+      { update: { endHour: '2022-05-12T12:22:30.000Z' } },
+    ];
+
+    const timeStampInfo = DeliveryHelper.getTimeStampInfo({ histories });
+
+    expect(timeStampInfo.isStartTimeStamped).toBe(true);
+    expect(timeStampInfo.isEndTimeStamped).toBe(true);
+    expect(timeStampInfo.hasTimeStamp).toBe(true);
+  });
+
+  it('should return info for event with startDate timestamp only (endDate cancelled)', () => {
+    const histories = [
+      { update: { startHour: '2022-05-12T12:22:30.000Z' } },
+      { update: { endHour: '2022-05-12T12:22:30.000Z' }, isCancelled: true },
+    ];
+
+    const timeStampInfo = DeliveryHelper.getTimeStampInfo({ histories });
+
+    expect(timeStampInfo.isStartTimeStamped).toBe(true);
+    expect(timeStampInfo.isEndTimeStamped).toBe(false);
+    expect(timeStampInfo.hasTimeStamp).toBe(true);
+  });
+
+  it('should return info for event with startDate timestamp only (no endDate)', () => {
+    const histories = [{ update: { startHour: '2022-05-12T12:22:30.000Z' } }];
+
+    const timeStampInfo = DeliveryHelper.getTimeStampInfo({ histories });
+
+    expect(timeStampInfo.isStartTimeStamped).toBe(true);
+    expect(timeStampInfo.isEndTimeStamped).toBe(false);
+    expect(timeStampInfo.hasTimeStamp).toBe(true);
+  });
+
+  it('should return info for event with endDate timestamp only (startDate cancelled)', () => {
+    const histories = [
+      { update: { startHour: '2022-05-12T12:22:30.000Z' }, isCancelled: true },
+      { update: { endHour: '2022-05-12T12:22:30.000Z' } },
+    ];
+
+    const timeStampInfo = DeliveryHelper.getTimeStampInfo({ histories });
+
+    expect(timeStampInfo.isStartTimeStamped).toBe(false);
+    expect(timeStampInfo.isEndTimeStamped).toBe(true);
+    expect(timeStampInfo.hasTimeStamp).toBe(true);
+  });
+
+  it('should return info for event with endDate timestamp only (no startDate)', () => {
+    const histories = [{ update: { endHour: '2022-05-12T12:22:30.000Z' } }];
+
+    const timeStampInfo = DeliveryHelper.getTimeStampInfo({ histories });
+
+    expect(timeStampInfo.isStartTimeStamped).toBe(false);
+    expect(timeStampInfo.isEndTimeStamped).toBe(true);
+    expect(timeStampInfo.hasTimeStamp).toBe(true);
+  });
+
+  it('should return info for event with both timestamp cancelled', () => {
+    const histories = [
+      { update: { startHour: '2022-05-12T12:22:30.000Z' }, isCancelled: true },
+      { update: { endHour: '2022-05-12T12:22:30.000Z' }, isCancelled: true },
+    ];
+
+    const timeStampInfo = DeliveryHelper.getTimeStampInfo({ histories });
+
+    expect(timeStampInfo.isStartTimeStamped).toBe(false);
+    expect(timeStampInfo.isEndTimeStamped).toBe(false);
+    expect(timeStampInfo.hasTimeStamp).toBe(true);
+  });
+
+  it('should return info for event without timestamp', () => {
+    const histories = [];
+
+    const timeStampInfo = DeliveryHelper.getTimeStampInfo({ histories });
+
+    expect(timeStampInfo.isStartTimeStamped).toBe(false);
+    expect(timeStampInfo.isEndTimeStamped).toBe(false);
+    expect(timeStampInfo.hasTimeStamp).toBe(false);
+  });
+});
+
+describe('getTypeCode #tag', () => {
+  it('should get typeCode for event with both timestamp', () => {
+    const typeCode = DeliveryHelper.getTypeCode(true, true, true);
+
+    expect(typeCode).toBe('');
+  });
+
+  it('should get typeCode for event with only startDate timestamp', () => {
+    const typeCode = DeliveryHelper.getTypeCode(true, false, true);
+
+    expect(typeCode).toBe('COD');
+  });
+
+  it('should get typeCode for event with only endDate timestamp', () => {
+    const typeCode = DeliveryHelper.getTypeCode(false, true, true);
+
+    expect(typeCode).toBe('COA');
+  });
+
+  it('should get typeCode for event with both timestamps but cancelled', () => {
+    const typeCode = DeliveryHelper.getTypeCode(false, false, true);
+
+    expect(typeCode).toBe('CO2');
+  });
+
+  it('should get typeCode for event with no timestamps', () => {
+    const typeCode = DeliveryHelper.getTypeCode(false, false, false);
+
+    expect(typeCode).toBe('CRE');
   });
 });


### PR DESCRIPTION
<details open><summary> TESTS  :computer: </summary>

- [x] J'ai codé les tests unitaires
- [ ] J'ai codé les tests d'intégration -np
- [ ] C'est une ancienne route utilisée par les apps mobiles.
  - [ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens
</details>

- [ ] Je replie cette section car mes modifications n'ont pas besoin de tests unitaires ou d'intégration

---

<details><summary> POINTS D'ATTENTION POUR CETTE PR  :warning: </summary>

- [ ] J'ai fait des modifications sur une route utilisée sur plusieurs plateformes [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/n3bq2hr9Ia)
- [ ] J'ai modifié un modèle utilisé en mobile [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/rqTfwpUib)
- [ ] J'ai ajouté un modèle spécifique à une structure 
  - [ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés
- [ ] J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile
  - [ ] Si oui, j'ai précisé sur le [slite de MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) qu'il faut forcer la mise à jour
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

</details>

- [x] Je replie cette section car je n'ai pas fait de modifications entrainant un point d'attention

---

<details><summary> FONCTIONNALITÉS APPS MOBILES  :iphone: </summary>

- [ ] Mes changements impactent l'application formation
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours
- [ ] Mes changements impactent l'application erp
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours

</details>

- [x] Je replie cette section car mes modifications n'ont pas d'impact sur les applications mobiles

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : admin client

- Cas d'usage : quand je telecharge le fichier de teletransmission, les interventions qui n'ont jamais ete horodate ont le code CRE plutot que CO2

- Comment tester ? : 
- Choisir un tiers payeur
- Verifier qu'il est en facturation direct
- Lui ajouter un id de teletransmission
- Ajouter un id de teletransmission a un beneficiaire ayant un plan d'aide avec ce tiers payeurs
- Faire en sorte que le beneficiaire ait des interventions : 
    - facturees
    - non facturees
    - horodates
    - horodates a moitie
    - horodates mais annules
    - non horodates
- Telecharger le doc de teletransmission
- Verifier que les codes correspondent (cf ticket)

_Si tu as lu cette description, pense a réagir avec un :eye:_
