### PR TITLE
Com 2834

### DIFF
--- a/src/helpers/billSlips.js
+++ b/src/helpers/billSlips.js
@@ -18,18 +18,16 @@ exports.getBillSlips = async (credentials) => {
 
   for (const billSlip of billSlipList) {
     const billSlipMonth = billSlip.month;
-    const billSlipTppId = billSlip.thirdPartyPayer._id.toHexString();
     const creditNote = creditNoteList.find(cn => cn.month === billSlipMonth &&
-      cn.thirdPartyPayer._id.toHexString() === billSlipTppId);
+      UtilsHelper.areObjectIdsEquals(cn.thirdPartyPayer._id, billSlip.thirdPartyPayer._id));
     if (!creditNote) continue;
-    billSlip.netInclTaxes -= creditNote.netInclTaxes;
+    billSlip.netInclTaxes = NumbersHelper.subtract(billSlip.netInclTaxes, creditNote.netInclTaxes);
   }
 
   for (const creditNote of creditNoteList) {
     const creditNoteMonth = creditNote.month;
-    const creditNoteTppId = creditNote.thirdPartyPayer._id.toHexString();
     const bill = billSlipList.find(bs => creditNoteMonth === bs.month &&
-      creditNoteTppId === bs.thirdPartyPayer._id.toHexString());
+      UtilsHelper.areObjectIdsEquals(creditNote.thirdPartyPayer._id, bs.thirdPartyPayer._id));
     if (bill) continue;
     billSlipList.push({ ...creditNote, netInclTaxes: -creditNote.netInclTaxes });
   }

--- a/src/helpers/billSlips.js
+++ b/src/helpers/billSlips.js
@@ -113,9 +113,9 @@ exports.formatBillingDataForFile = (billList, creditNoteList) => {
         }
         billingData[event.fundingId].billedCareHours =
           NumbersHelper.add(billingData[event.fundingId].billedCareHours, event.careHours);
-
         billingData[event.fundingId].netInclTaxes =
           NumbersHelper.add(billingData[event.fundingId].netInclTaxes, event.inclTaxesTpp);
+        if (subscription.discount) billingData[event.fundingId].discount = subscription.discount;
       }
       billsAndCreditNotes = billsAndCreditNotes.concat(Object.values(billingData));
     }
@@ -139,10 +139,11 @@ exports.formatBillingDataForFile = (billList, creditNoteList) => {
   let total = NumbersHelper.toString(0);
   const formattedBills = [];
   for (const bill of billsAndCreditNotes) {
-    total = NumbersHelper.add(total, NumbersHelper.toFixedToFloat(bill.netInclTaxes));
+    const netInclTaxes = bill.discount ? NumbersHelper.subtract(bill.netInclTaxes, bill.discount) : bill.netInclTaxes;
+    total = NumbersHelper.add(total, NumbersHelper.toFixedToFloat(netInclTaxes));
     formattedBills.push({
       ...bill,
-      netInclTaxes: UtilsHelper.formatPrice(bill.netInclTaxes),
+      netInclTaxes: UtilsHelper.formatPrice(netInclTaxes),
       billedCareHours: UtilsHelper.formatHour(bill.billedCareHours),
     });
   }

--- a/src/helpers/billSlips.js
+++ b/src/helpers/billSlips.js
@@ -21,7 +21,9 @@ exports.getBillSlips = async (credentials) => {
     const creditNote = creditNoteList.find(cn => cn.month === billSlipMonth &&
       UtilsHelper.areObjectIdsEquals(cn.thirdPartyPayer._id, billSlip.thirdPartyPayer._id));
     if (!creditNote) continue;
-    billSlip.netInclTaxes = NumbersHelper.subtract(billSlip.netInclTaxes, creditNote.netInclTaxes);
+    billSlip.netInclTaxes = NumbersHelper.toFixedToFloat(
+      NumbersHelper.subtract(billSlip.netInclTaxes, creditNote.netInclTaxes)
+    );
   }
 
   for (const creditNote of creditNoteList) {
@@ -29,10 +31,13 @@ exports.getBillSlips = async (credentials) => {
     const bill = billSlipList.find(bs => creditNoteMonth === bs.month &&
       UtilsHelper.areObjectIdsEquals(creditNote.thirdPartyPayer._id, bs.thirdPartyPayer._id));
     if (bill) continue;
-    billSlipList.push({ ...creditNote, netInclTaxes: NumbersHelper.multiply(-1, creditNote.netInclTaxes) });
+    billSlipList.push({
+      ...creditNote,
+      netInclTaxes: NumbersHelper.toFixedToFloat(NumbersHelper.multiply(-1, creditNote.netInclTaxes)),
+    });
   }
 
-  return billSlipList.map(bs => ({ ...bs, netInclTaxes: NumbersHelper.toFixedToFloat(bs.netInclTaxes) }));
+  return billSlipList;
 };
 
 exports.formatBillSlipNumber = (companyPrefixNumber, prefix, seq) =>

--- a/src/helpers/billSlips.js
+++ b/src/helpers/billSlips.js
@@ -29,7 +29,7 @@ exports.getBillSlips = async (credentials) => {
     const bill = billSlipList.find(bs => creditNoteMonth === bs.month &&
       UtilsHelper.areObjectIdsEquals(creditNote.thirdPartyPayer._id, bs.thirdPartyPayer._id));
     if (bill) continue;
-    billSlipList.push({ ...creditNote, netInclTaxes: -creditNote.netInclTaxes });
+    billSlipList.push({ ...creditNote, netInclTaxes: NumbersHelper.multiply(-1, creditNote.netInclTaxes) });
   }
 
   return billSlipList.map(bs => ({ ...bs, netInclTaxes: NumbersHelper.toFixedToFloat(bs.netInclTaxes) }));

--- a/src/helpers/creditNotes.js
+++ b/src/helpers/creditNotes.js
@@ -207,7 +207,7 @@ const formatEventForPdf = event => ({
 });
 
 const computeCreditNoteEventVat = (creditNote, event) => (
-  creditNote.exclTaxes && !NumbersHelper.isEqualTo(creditNote.exclTaxesTpp, 0)
+  creditNote.exclTaxesTpp && !NumbersHelper.isEqualTo(creditNote.exclTaxesTpp, 0)
     ? NumbersHelper.subtract(event.bills.inclTaxesTpp, event.bills.exclTaxesTpp)
     : NumbersHelper.subtract(event.bills.inclTaxesCustomer, event.bills.exclTaxesCustomer));
 

--- a/tests/unit/helpers/billSlips.test.js
+++ b/tests/unit/helpers/billSlips.test.js
@@ -352,13 +352,13 @@ describe('formatBillingDataForFile', () => {
   it('should format bills for pdf', () => {
     const fundingId = new ObjectId();
     const fundings = [{ _id: fundingId, versions: [{ _id: new ObjectId() }], frequency: 'monthly' }];
-    const event = { fundingId, careHours: 2, inclTaxesTpp: 12 };
+    const event = { fundingId, careHours: 14, inclTaxesTpp: 240 };
     const billList = [
       {
         createdAt: moment('2020-01-01').toDate(),
         number: 'number',
         customer: { fundings, identity: { firstname: 'abc' } },
-        subscriptions: [{ events: [event] }],
+        subscriptions: [{ events: [event], discount: 1.24 }],
       },
     ];
     const eventCreditNote = { bills: { fundingId, inclTaxesTpp: 12, careHours: 2 } };
@@ -403,11 +403,12 @@ describe('formatBillingDataForFile', () => {
 
     const result = BillSlipHelper.formatBillingDataForFile(billList, creditNoteList);
 
-    expect(result.total).toEqual(-10);
+    expect(result.total).toEqual(216.76);
     expect(result.formattedBills).toEqual([
       {
-        billedCareHours: 2,
-        netInclTaxes: 12,
+        billedCareHours: 14,
+        netInclTaxes: 238.76,
+        discount: 1.24,
         number: 'number',
         customer: 'abc',
         createdAt: moment('2020-01-01').toDate(),
@@ -430,10 +431,10 @@ describe('formatBillingDataForFile', () => {
     sinon.assert.calledWithExactly(formatFundingInfo.getCall(0), billList[0], event);
     sinon.assert.calledWithExactly(formatFundingInfo.getCall(1), creditNoteList[0], eventCreditNote.bills);
     sinon.assert.calledWithExactly(formatFundingInfo.getCall(2), creditNoteList[1], creditNoteList[1].events[0].bills);
-    sinon.assert.calledWithExactly(formatPrice.getCall(0), 12);
+    sinon.assert.calledWithExactly(formatPrice.getCall(0), 238.76);
     sinon.assert.calledWithExactly(formatPrice.getCall(1), -12);
     sinon.assert.calledWithExactly(formatPrice.getCall(2), -10);
-    sinon.assert.calledWithExactly(formatHour.getCall(0), 2);
+    sinon.assert.calledWithExactly(formatHour.getCall(0), 14);
     sinon.assert.calledWithExactly(formatHour.getCall(1), 2);
     sinon.assert.calledWithExactly(formatHour.getCall(2), 1);
   });

--- a/tests/unit/helpers/creditNotes.test.js
+++ b/tests/unit/helpers/creditNotes.test.js
@@ -1011,8 +1011,8 @@ describe('formatPdf', () => {
       date: '2019-04-29T22:00:00.000Z',
       exclTaxesCustomer: 221,
       inclTaxesCustomer: 234,
-      exclTaxesTpp: 21,
-      inclTaxesTpp: 34,
+      exclTaxesTpp: 0,
+      inclTaxesTpp: 0,
     };
     const expectedResult = {
       creditNote: {
@@ -1050,6 +1050,9 @@ describe('formatPdf', () => {
     const result = CreditNoteHelper.formatPdf(creditNote, company);
 
     expect(result).toEqual(expectedResult);
+    sinon.assert.calledWithExactly(formatPrice.getCall(0), 13);
+    sinon.assert.calledWithExactly(formatPrice.getCall(1), 221);
+    sinon.assert.calledWithExactly(formatPrice.getCall(2), 234);
     sinon.assert.calledOnceWithExactly(formatEventSurchargesForPdf, [{ percentage: 30 }]);
   });
 
@@ -1074,7 +1077,7 @@ describe('formatPdf', () => {
       date: '2019-04-29T22:00:00.000Z',
       exclTaxesTpp: 21,
       inclTaxesTpp: 34,
-      exclTaxesCustomer: 221,
+      exclTaxesCustomer: 220,
       inclTaxesCustomer: 234,
       thirdPartyPayer: { name: 'tpp', address: { fullAddress: 'j\'habite ici' } },
     };
@@ -1124,6 +1127,9 @@ describe('formatPdf', () => {
 
     expect(result).toBeDefined();
     expect(result).toEqual(expectedResult);
+    sinon.assert.calledWithExactly(formatPrice.getCall(0), 13);
+    sinon.assert.calledWithExactly(formatPrice.getCall(1), 21);
+    sinon.assert.calledWithExactly(formatPrice.getCall(2), 34);
     sinon.assert.notCalled(formatEventSurchargesForPdf);
   });
 


### PR DESCRIPTION
<details open><summary> TESTS  :computer: </summary>

- [x] J'ai codé les tests unitaires
- [ ] J'ai codé les tests d'intégration
- [ ] C'est une ancienne route utilisée par les apps mobiles.
  - [ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens
</details>

- [ ] Je replie cette section car mes modifications n'ont pas besoin de tests unitaires ou d'intégration

---

<details open><summary> POINTS D'ATTENTION POUR CETTE PR  :warning: </summary>

- [ ] J'ai fait des modifications sur une route utilisée sur plusieurs plateformes [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/n3bq2hr9Ia)
- [ ] J'ai modifié un modèle utilisé en mobile [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/rqTfwpUib)
- [ ] J'ai ajouté un modèle spécifique à une structure 
  - [ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés
- [ ] J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile
  - [ ] Si oui, j'ai précisé sur le [slite de MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) qu'il faut forcer la mise à jour
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

</details>

- [x] Je replie cette section car je n'ai pas fait de modifications entrainant un point d'attention

---

<details open><summary> FONCTIONNALITÉS APPS MOBILES  :iphone: </summary>

- [ ] Mes changements impactent l'application formation
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours
- [ ] Mes changements impactent l'application erp
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours

</details>

- [x] Je replie cette section car mes modifications n'ont pas d'impact sur les applications mobiles

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : client admin

- Cas d'usage : 
    - Je peux télécharger les bordereaux tiers-payeur, les montants affichés sont justes et tiennent compte des remises.  (avant on ne prenait pas en compte les remises, il y avait donc un écart entre le montant total figurant sur le bordereau correspond au montant affiché dans la colonne `Montant TTC` de la page bordereau tiers-payeur )
    - Lorsque je telecharge un avoir sur des interventions, les montants sont justes (`total TTC - total HT = tva`)

- Comment tester ? :
   - dumper dev en local
   - faire tourner le script BNTransition.js
   -  télécharger plusieurs bordereaux tiers-payeurs et comparer les données avec dev
   - verifier que la somme des montants est égale au montant total
   - verifier que le montant total figurant sur le bordereau correspond au montant affiché dans la colonne `Montant TTC` de la page bordereau tiers-payeur

   - Tests sur les avoirs:
       - creer un beneficiaire avec
             - souscription: temps de qualité au tarif social
             - financement : 
                 - horaire
                 - pu ttc: 20,20 
                 - prise en charge beneficiaire: 50 % 
       - facturer 3 interventions de 2h
       - verifier que la facture apparait sur le bordereau du tiers-payeur
       - creer un avoir sur 2 d'entre elles pour le TP et le beneficiaire
       - editer l'avoir 
       - les montants sont justes: `total TTC - total HT = tva`
       - verifier que l'avoir apparait sur le bordereau du tiers-payeur

_Si tu as lu cette description, pense a réagir avec un :eye:_
