### PR TITLE
Com 2864

### DIFF
--- a/src/helpers/contracts.js
+++ b/src/helpers/contracts.js
@@ -20,7 +20,7 @@ const ReferentHistoryHelper = require('./referentHistories');
 const UtilsHelper = require('./utils');
 const DatesHelper = require('./dates');
 const GDriveStorageHelper = require('./gDriveStorage');
-const { AUXILIARY, TIME_STAMPING_ACTIONS } = require('./constants');
+const { AUXILIARY, TIME_STAMPING_ACTIONS, UNAVAILABILITY, INTERNAL_HOUR, INTERVENTION } = require('./constants');
 const { createAndReadFile } = require('./file');
 const ESignHelper = require('./eSign');
 const UserHelper = require('./users');
@@ -315,6 +315,7 @@ exports.deleteVersion = async (contractId, versionId, credentials) => {
     if (eventCount) throw Boom.forbidden();
 
     await Contract.deleteOne({ _id: contractId });
+    await EventHelper.removeRepetitionsOnContractEnd(contract);
     await User.updateOne({ _id: contract.user }, { $pull: { contracts: contract._id } });
     await SectorHistoryHelper.updateHistoryOnContractDeletion(contract, companyId);
   }

--- a/src/helpers/contracts.js
+++ b/src/helpers/contracts.js
@@ -175,7 +175,7 @@ exports.endContract = async (contractId, contractToEnd, credentials) => {
     .lean({ autopopulate: true, virtuals: true });
 
   await EventHelper.unassignInterventionsOnContractEnd(updatedContract, credentials);
-  await EventHelper.removeRepetitionsOnContractEnd(updatedContract);
+  await EventHelper.removeRepetitionsOnContractEndOrDeletion(updatedContract);
   await EventHelper.removeEventsExceptInterventionsOnContractEnd(updatedContract, credentials);
   await EventHelper.updateAbsencesOnContractEnd(updatedContract.user._id, updatedContract.endDate, credentials);
   await ReferentHistoryHelper.unassignReferentOnContractEnd(updatedContract);
@@ -315,7 +315,7 @@ exports.deleteVersion = async (contractId, versionId, credentials) => {
     if (eventCount) throw Boom.forbidden();
 
     await Contract.deleteOne({ _id: contractId });
-    await EventHelper.removeRepetitionsOnContractEnd(contract);
+    await EventHelper.removeRepetitionsOnContractEndOrDeletion(contract);
     await User.updateOne({ _id: contract.user }, { $pull: { contracts: contract._id } });
     await SectorHistoryHelper.updateHistoryOnContractDeletion(contract, companyId);
   }

--- a/src/helpers/events.js
+++ b/src/helpers/events.js
@@ -316,7 +316,7 @@ exports.updateEvent = async (event, eventPayload, credentials) => {
   return exports.populateEventSubscription(updatedEvent);
 };
 
-exports.removeRepetitionsOnContractEnd = async (contract) => {
+exports.removeRepetitionsOnContractEndOrDeletion = async (contract) => {
   const { sector, _id: auxiliaryId } = contract.user;
 
   await Repetition.updateMany(

--- a/tests/unit/helpers/contracts.test.js
+++ b/tests/unit/helpers/contracts.test.js
@@ -440,7 +440,7 @@ describe('endContract', () => {
   let findOneContract;
   let findOneAndUpdateContract;
   let updateUserInactivityDate;
-  let removeRepetitionsOnContractEnd;
+  let removeRepetitionsOnContractEndOrDeletion;
   let unassignInterventionsOnContractEnd;
   let removeEventsExceptInterventionsOnContractEnd;
   let updateAbsencesOnContractEnd;
@@ -454,7 +454,7 @@ describe('endContract', () => {
     eventCountDocuments = sinon.stub(Event, 'countDocuments');
     findOneAndUpdateContract = sinon.stub(Contract, 'findOneAndUpdate');
     updateUserInactivityDate = sinon.stub(UserHelper, 'updateUserInactivityDate');
-    removeRepetitionsOnContractEnd = sinon.stub(EventHelper, 'removeRepetitionsOnContractEnd');
+    removeRepetitionsOnContractEndOrDeletion = sinon.stub(EventHelper, 'removeRepetitionsOnContractEndOrDeletion');
     unassignInterventionsOnContractEnd = sinon.stub(EventHelper, 'unassignInterventionsOnContractEnd');
     removeEventsExceptInterventionsOnContractEnd = sinon.stub(
       EventHelper,
@@ -468,7 +468,7 @@ describe('endContract', () => {
     findOneContract.restore();
     findOneAndUpdateContract.restore();
     updateUserInactivityDate.restore();
-    removeRepetitionsOnContractEnd.restore();
+    removeRepetitionsOnContractEndOrDeletion.restore();
     unassignInterventionsOnContractEnd.restore();
     removeEventsExceptInterventionsOnContractEnd.restore();
     countDocumentHistories.restore();
@@ -509,7 +509,7 @@ describe('endContract', () => {
 
     expect(result).toMatchObject(updatedContract);
     sinon.assert.calledWithExactly(updateUserInactivityDate, updatedContract.user._id, payload.endDate, credentials);
-    sinon.assert.calledWithExactly(removeRepetitionsOnContractEnd, updatedContract);
+    sinon.assert.calledWithExactly(removeRepetitionsOnContractEndOrDeletion, updatedContract);
     sinon.assert.calledWithExactly(unassignInterventionsOnContractEnd, updatedContract, credentials);
     sinon.assert.calledWithExactly(unassignReferentOnContractEnd, updatedContract);
     sinon.assert.calledWithExactly(removeEventsExceptInterventionsOnContractEnd, updatedContract, credentials);
@@ -617,7 +617,7 @@ describe('endContract', () => {
       expect(e.output.statusCode).toEqual(403);
     } finally {
       sinon.assert.notCalled(updateUserInactivityDate);
-      sinon.assert.notCalled(removeRepetitionsOnContractEnd);
+      sinon.assert.notCalled(removeRepetitionsOnContractEndOrDeletion);
       sinon.assert.notCalled(unassignInterventionsOnContractEnd);
       sinon.assert.notCalled(unassignReferentOnContractEnd);
       sinon.assert.notCalled(removeEventsExceptInterventionsOnContractEnd);
@@ -701,7 +701,7 @@ describe('endContract', () => {
       expect(e.output.statusCode).toEqual(403);
     } finally {
       sinon.assert.notCalled(updateUserInactivityDate);
-      sinon.assert.notCalled(removeRepetitionsOnContractEnd);
+      sinon.assert.notCalled(removeRepetitionsOnContractEndOrDeletion);
       sinon.assert.notCalled(unassignInterventionsOnContractEnd);
       sinon.assert.notCalled(unassignReferentOnContractEnd);
       sinon.assert.notCalled(removeEventsExceptInterventionsOnContractEnd);
@@ -754,7 +754,7 @@ describe('endContract', () => {
       expect(e.output.statusCode).toEqual(409);
     } finally {
       sinon.assert.notCalled(updateUserInactivityDate);
-      sinon.assert.notCalled(removeRepetitionsOnContractEnd);
+      sinon.assert.notCalled(removeRepetitionsOnContractEndOrDeletion);
       sinon.assert.notCalled(unassignInterventionsOnContractEnd);
       sinon.assert.notCalled(unassignReferentOnContractEnd);
       sinon.assert.notCalled(removeEventsExceptInterventionsOnContractEnd);
@@ -1324,6 +1324,7 @@ describe('deleteVersion', () => {
   let deleteFile;
   let countAuxiliaryEventsBetweenDates;
   let updateHistoryOnContractDeletionStub;
+  let removeRepetitionsOnContractEndOrDeletion;
   const versionId = new ObjectId();
   const contractId = new ObjectId();
   const credentials = { company: { _id: new ObjectId() } };
@@ -1334,6 +1335,7 @@ describe('deleteVersion', () => {
     updateOneCustomer = sinon.stub(Customer, 'updateOne');
     updateOneUser = sinon.stub(User, 'updateOne');
     deleteFile = sinon.stub(GDriveStorageHelper, 'deleteFile');
+    removeRepetitionsOnContractEndOrDeletion = sinon.stub(EventHelper, 'removeRepetitionsOnContractEndOrDeletion');
     countAuxiliaryEventsBetweenDates = sinon.stub(EventRepository, 'countAuxiliaryEventsBetweenDates');
     updateHistoryOnContractDeletionStub = sinon.stub(SectorHistoryHelper, 'updateHistoryOnContractDeletion');
   });
@@ -1344,6 +1346,7 @@ describe('deleteVersion', () => {
     updateOneCustomer.restore();
     updateOneUser.restore();
     deleteFile.restore();
+    removeRepetitionsOnContractEndOrDeletion.restore();
     countAuxiliaryEventsBetweenDates.restore();
     updateHistoryOnContractDeletionStub.restore();
   });
@@ -1367,6 +1370,7 @@ describe('deleteVersion', () => {
     });
     sinon.assert.notCalled(saveContract);
     sinon.assert.calledWithExactly(deleteOne, { _id: contractId.toHexString() });
+    sinon.assert.calledWithExactly(removeRepetitionsOnContractEndOrDeletion, contract);
     sinon.assert.calledWithExactly(updateOneUser, { _id: 'toot' }, { $pull: { contracts: contractId } });
     sinon.assert.notCalled(updateOneCustomer);
     sinon.assert.calledWithExactly(deleteFile, '123456789');
@@ -1394,6 +1398,7 @@ describe('deleteVersion', () => {
       sinon.assert.notCalled(saveContract);
       sinon.assert.called(countAuxiliaryEventsBetweenDates);
       sinon.assert.notCalled(deleteOne);
+      sinon.assert.notCalled(removeRepetitionsOnContractEndOrDeletion);
       sinon.assert.notCalled(updateOneUser);
       sinon.assert.notCalled(updateOneCustomer);
       sinon.assert.notCalled(deleteFile);
@@ -1413,6 +1418,7 @@ describe('deleteVersion', () => {
     sinon.assert.calledWithExactly(findOneContract, { _id: contractId.toHexString(), 'versions.0': { $exists: true } });
     sinon.assert.called(saveContract);
     sinon.assert.notCalled(deleteOne);
+    sinon.assert.notCalled(removeRepetitionsOnContractEndOrDeletion);
     sinon.assert.notCalled(updateOneUser);
     sinon.assert.notCalled(updateOneCustomer);
     sinon.assert.calledWithExactly(deleteFile, '123456789');

--- a/tests/unit/helpers/events.test.js
+++ b/tests/unit/helpers/events.test.js
@@ -871,7 +871,7 @@ describe('populateEvents', () => {
   });
 });
 
-describe('removeRepetitionsOnContractEnd', () => {
+describe('removeRepetitionsOnContractEndOrDeletion', () => {
   let updateManyRepetition;
   let deleteManyRepetition;
 
@@ -890,7 +890,7 @@ describe('removeRepetitionsOnContractEnd', () => {
   it('should unassigned repetition intervention and remove other repetitions', async () => {
     const contract = { endDate: '2019-10-02T08:00:00.000Z', user: { _id: userId, sector: sectorId } };
 
-    await EventHelper.removeRepetitionsOnContractEnd(contract);
+    await EventHelper.removeRepetitionsOnContractEndOrDeletion(contract);
     sinon.assert.calledOnceWithExactly(
       updateManyRepetition,
       { auxiliary: userId, type: 'intervention' },


### PR DESCRIPTION
<details open><summary> TESTS  :computer: </summary>

- [x] J'ai codé les tests unitaires
- [ ] J'ai codé les tests d'intégration -np
- [ ] C'est une ancienne route utilisée par les apps mobiles. -np
  - [ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens
</details>

- [ ] Je replie cette section car mes modifications n'ont pas besoin de tests unitaires ou d'intégration

---

<details open><summary> POINTS D'ATTENTION POUR CETTE PR  :warning: </summary>

- [ ] J'ai fait des modifications sur une route utilisée sur plusieurs plateformes [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/n3bq2hr9Ia)
- [ ] J'ai modifié un modèle utilisé en mobile [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/rqTfwpUib)
- [ ] J'ai ajouté un modèle spécifique à une structure 
  - [ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés
- [ ] J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile
  - [ ] Si oui, j'ai précisé sur le [slite de MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) qu'il faut forcer la mise à jour
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

</details>

- [x] Je replie cette section car je n'ai pas fait de modifications entrainant un point d'attention

---

<details open><summary> FONCTIONNALITÉS APPS MOBILES  :iphone: </summary>

- [ ] Mes changements impactent l'application formation
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours
- [ ] Mes changements impactent l'application erp
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours

</details>

- [x] Je replie cette section car mes modifications n'ont pas d'impact sur les applications mobiles

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : client admin / coach

- Cas d'usage : Lorsque ke supprime la version d'un contrat, les repetitions (heures internes + indispo) associées sont supprimées et les interventions sont passées en a affecter

- Comment tester ? :

_Si tu as lu cette description, pense a réagir avec un :eye:_
