### PR TITLE
COM-2870 change when specified time is in the file

### DIFF
--- a/tests/unit/helpers/delivery.test.js
+++ b/tests/unit/helpers/delivery.test.js
@@ -513,73 +513,46 @@ describe('getFileName', () => {
 describe('getTimeStampInfo', () => {
   it('should return info for event with both timestamp', () => {
     const histories = [
-      { update: { startHour: '2022-05-12T12:22:30.000Z' } },
-      { update: { endHour: '2022-05-12T12:22:30.000Z' } },
+      { createdAt: '2022-05-12T12:22:30.000Z', update: { startHour: '2022-05-12T12:22:30.000Z', isCancelled: true } },
+      { createdAt: '2022-05-12T13:26:30.000Z', update: { endHour: '2022-05-12T13:26:30.000Z' } },
+      { createdAt: '2022-05-12T12:24:30.000Z', update: { startHour: '2022-05-12T12:24:30.000Z' } },
+      { createdAt: '2022-05-12T12:22:30.000Z', update: { endHour: '2022-05-12T12:22:30.000Z', isCancelled: true } },
     ];
 
     const timeStampInfo = DeliveryHelper.getTimeStampInfo({ histories });
 
-    expect(timeStampInfo.isStartTimeStamped).toBe(true);
-    expect(timeStampInfo.isEndTimeStamped).toBe(true);
+    expect(timeStampInfo.startTimeStampList).toStrictEqual([
+      { createdAt: '2022-05-12T12:24:30.000Z', update: { startHour: '2022-05-12T12:24:30.000Z' } },
+      { createdAt: '2022-05-12T12:22:30.000Z', update: { startHour: '2022-05-12T12:22:30.000Z', isCancelled: true } },
+    ]);
+    expect(timeStampInfo.endTimeStampList).toStrictEqual([
+      { createdAt: '2022-05-12T13:26:30.000Z', update: { endHour: '2022-05-12T13:26:30.000Z' } },
+      { createdAt: '2022-05-12T12:22:30.000Z', update: { endHour: '2022-05-12T12:22:30.000Z', isCancelled: true } },
+    ]);
     expect(timeStampInfo.hasTimeStamp).toBe(true);
   });
 
-  it('should return info for event with startDate timestamp only (endDate cancelled)', () => {
-    const histories = [
-      { update: { startHour: '2022-05-12T12:22:30.000Z' } },
-      { update: { endHour: '2022-05-12T12:22:30.000Z' }, isCancelled: true },
-    ];
+  it('should return info for event with startDate timestamp only', () => {
+    const histories = [{ createdAt: '2022-05-12T12:22:30.000Z', update: { startHour: '2022-05-12T12:22:30.000Z' } }];
 
     const timeStampInfo = DeliveryHelper.getTimeStampInfo({ histories });
 
-    expect(timeStampInfo.isStartTimeStamped).toBe(true);
-    expect(timeStampInfo.isEndTimeStamped).toBe(false);
+    expect(timeStampInfo.startTimeStampList).toStrictEqual([
+      { createdAt: '2022-05-12T12:22:30.000Z', update: { startHour: '2022-05-12T12:22:30.000Z' } },
+    ]);
+    expect(timeStampInfo.endTimeStampList).toStrictEqual([]);
     expect(timeStampInfo.hasTimeStamp).toBe(true);
   });
 
-  it('should return info for event with startDate timestamp only (no endDate)', () => {
-    const histories = [{ update: { startHour: '2022-05-12T12:22:30.000Z' } }];
+  it('should return info for event with endDate timestamp only', () => {
+    const histories = [{ createdAt: '2022-05-12T12:22:30.000Z', update: { endHour: '2022-05-12T12:22:30.000Z' } }];
 
     const timeStampInfo = DeliveryHelper.getTimeStampInfo({ histories });
 
-    expect(timeStampInfo.isStartTimeStamped).toBe(true);
-    expect(timeStampInfo.isEndTimeStamped).toBe(false);
-    expect(timeStampInfo.hasTimeStamp).toBe(true);
-  });
-
-  it('should return info for event with endDate timestamp only (startDate cancelled)', () => {
-    const histories = [
-      { update: { startHour: '2022-05-12T12:22:30.000Z' }, isCancelled: true },
-      { update: { endHour: '2022-05-12T12:22:30.000Z' } },
-    ];
-
-    const timeStampInfo = DeliveryHelper.getTimeStampInfo({ histories });
-
-    expect(timeStampInfo.isStartTimeStamped).toBe(false);
-    expect(timeStampInfo.isEndTimeStamped).toBe(true);
-    expect(timeStampInfo.hasTimeStamp).toBe(true);
-  });
-
-  it('should return info for event with endDate timestamp only (no startDate)', () => {
-    const histories = [{ update: { endHour: '2022-05-12T12:22:30.000Z' } }];
-
-    const timeStampInfo = DeliveryHelper.getTimeStampInfo({ histories });
-
-    expect(timeStampInfo.isStartTimeStamped).toBe(false);
-    expect(timeStampInfo.isEndTimeStamped).toBe(true);
-    expect(timeStampInfo.hasTimeStamp).toBe(true);
-  });
-
-  it('should return info for event with both timestamp cancelled', () => {
-    const histories = [
-      { update: { startHour: '2022-05-12T12:22:30.000Z' }, isCancelled: true },
-      { update: { endHour: '2022-05-12T12:22:30.000Z' }, isCancelled: true },
-    ];
-
-    const timeStampInfo = DeliveryHelper.getTimeStampInfo({ histories });
-
-    expect(timeStampInfo.isStartTimeStamped).toBe(false);
-    expect(timeStampInfo.isEndTimeStamped).toBe(false);
+    expect(timeStampInfo.startTimeStampList).toStrictEqual([]);
+    expect(timeStampInfo.endTimeStampList).toStrictEqual([
+      { createdAt: '2022-05-12T12:22:30.000Z', update: { endHour: '2022-05-12T12:22:30.000Z' } },
+    ]);
     expect(timeStampInfo.hasTimeStamp).toBe(true);
   });
 
@@ -588,39 +561,39 @@ describe('getTimeStampInfo', () => {
 
     const timeStampInfo = DeliveryHelper.getTimeStampInfo({ histories });
 
-    expect(timeStampInfo.isStartTimeStamped).toBe(false);
-    expect(timeStampInfo.isEndTimeStamped).toBe(false);
+    expect(timeStampInfo.startTimeStampList).toStrictEqual([]);
+    expect(timeStampInfo.endTimeStampList).toStrictEqual([]);
     expect(timeStampInfo.hasTimeStamp).toBe(false);
   });
 });
 
 describe('getTypeCode', () => {
   it('should get typeCode for event with both timestamp', () => {
-    const typeCode = DeliveryHelper.getTypeCode(true, true, true);
+    const typeCode = DeliveryHelper.getTypeCode([{ isCancelled: false }], [{}], true);
 
     expect(typeCode).toBe('');
   });
 
   it('should get typeCode for event with only startDate timestamp', () => {
-    const typeCode = DeliveryHelper.getTypeCode(true, false, true);
+    const typeCode = DeliveryHelper.getTypeCode([{ isCancelled: false }], [], true);
 
     expect(typeCode).toBe('COD');
   });
 
   it('should get typeCode for event with only endDate timestamp', () => {
-    const typeCode = DeliveryHelper.getTypeCode(false, true, true);
+    const typeCode = DeliveryHelper.getTypeCode([{ isCancelled: true }], [{ isCancelled: false }], true);
 
     expect(typeCode).toBe('COA');
   });
 
   it('should get typeCode for event with both timestamps but cancelled', () => {
-    const typeCode = DeliveryHelper.getTypeCode(false, false, true);
+    const typeCode = DeliveryHelper.getTypeCode([{ isCancelled: true }], [{ isCancelled: true }], true);
 
     expect(typeCode).toBe('CO2');
   });
 
   it('should get typeCode for event with no timestamps', () => {
-    const typeCode = DeliveryHelper.getTypeCode(false, false, false);
+    const typeCode = DeliveryHelper.getTypeCode([], [], false);
 
     expect(typeCode).toBe('CRE');
   });


### PR DESCRIPTION
<details open><summary> TESTS  :computer: </summary>

- [x] J'ai codé les tests unitaires
- [ ] J'ai codé les tests d'intégration -np
- [ ] C'est une ancienne route utilisée par les apps mobiles.-np
  - [ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens
</details>

- [ ] Je replie cette section car mes modifications n'ont pas besoin de tests unitaires ou d'intégration

---

<details><summary> POINTS D'ATTENTION POUR CETTE PR  :warning: </summary>

- [ ] J'ai fait des modifications sur une route utilisée sur plusieurs plateformes [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/n3bq2hr9Ia)
- [ ] J'ai modifié un modèle utilisé en mobile [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/rqTfwpUib)
- [ ] J'ai ajouté un modèle spécifique à une structure 
  - [ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés
- [ ] J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile
  - [ ] Si oui, j'ai précisé sur le [slite de MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) qu'il faut forcer la mise à jour
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

</details>

- [x] Je replie cette section car je n'ai pas fait de modifications entrainant un point d'attention

---

<details><summary> FONCTIONNALITÉS APPS MOBILES  :iphone: </summary>

- [ ] Mes changements impactent l'application formation
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours
- [ ] Mes changements impactent l'application erp
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours

</details>

- [x] Je replie cette section car mes modifications n'ont pas d'impact sur les applications mobiles

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : admin client

- Cas d'usage : J'ai la balise `EffectiveCISpecifiedPeriod` des qu'il y a un horodatage (annulé ou non)

- Comment tester ? : Vérifier différents cas (horodatage puis annulation ou non de la date de début ou de fin, horodatage puis annulation puis re-horodatage) et vérifier que des qu'il y a eu horodatage a un momeent la balise est bien presente avec comme valeur le dernier horodatage. 

_Si tu as lu cette description, pense a réagir avec un :eye:_
