### PR TITLE
Com 2908

### DIFF
--- a/src/helpers/dates/companiDates.js
+++ b/src/helpers/dates/companiDates.js
@@ -71,6 +71,7 @@ const CompaniDateFactory = (inputDate) => {
 
       return (_date.hasSame(otherDate, unit) || _date.startOf(unit) > otherDate.startOf(unit));
     },
+
     isSameOrBetween(miscTypeFirstDate, miscTypeSecondDate, unit = 'millisecond') {
       const firstDate = exports._formatMiscToCompaniDate(miscTypeFirstDate);
       const secondDate = exports._formatMiscToCompaniDate(miscTypeSecondDate);
@@ -78,6 +79,7 @@ const CompaniDateFactory = (inputDate) => {
       return (_date.hasSame(firstDate, unit) || _date.hasSame(secondDate, unit) ||
         (_date.startOf(unit) > firstDate.startOf(unit) && _date.startOf(unit) < secondDate.startOf(unit)));
     },
+
     isHoliday() {
       const { year } = _date;
       const holidays = getHolidays(year);

--- a/src/helpers/repetitions.js
+++ b/src/helpers/repetitions.js
@@ -39,7 +39,7 @@ exports.formatPayloadForRepetitionCreation = (event, payload, companyId) => ({
   repetition: { ...payload.repetition, parentId: event._id },
 });
 
-const groupRepetitionByDay = (day, repetition, repetitionsGroupedByDay) => {
+const addRepetitionToRelevantDay = (day, repetition, repetitionsGroupedByDay) => {
   switch (repetition.frequency) {
     case EVERY_TWO_WEEKS:
     case EVERY_WEEK:
@@ -51,7 +51,7 @@ const groupRepetitionByDay = (day, repetition, repetitionsGroupedByDay) => {
       repetitionsGroupedByDay[day].push(repetition);
       break;
     case EVERY_WEEK_DAY:
-      if ([SATURDAY, SUNDAY].includes(parseInt(day, 10))) repetitionsGroupedByDay[day].push(repetition);
+      if (![SATURDAY, SUNDAY].includes(parseInt(day, 10))) repetitionsGroupedByDay[day].push(repetition);
       break;
   }
 };
@@ -107,7 +107,7 @@ exports.list = async (query, credentials) => {
 
   for (const day of Object.keys(repetitionsGroupedByDay)) {
     for (const repetition of repetitions) {
-      groupRepetitionByDay(day, repetition, repetitionsGroupedByDay);
+      addRepetitionToRelevantDay(day, repetition, repetitionsGroupedByDay);
     }
 
     repetitionsGroupedByDay[day].sort((a, b) => ascendingSortStartHour(a, b));

--- a/src/helpers/repetitions.js
+++ b/src/helpers/repetitions.js
@@ -96,7 +96,15 @@ exports.list = async (query, credentials) => {
           break;
       }
     }
-    repetitionsGroupedByDay[day].sort(DatesHelper.ascendingSort('startDate'));
+    repetitionsGroupedByDay[day].sort((a, b) => {
+      const getFirstRepetitionHours = CompaniDate(a.startDate).getUnits(['hour', 'minute']);
+      const getSecondRepetitionHours = CompaniDate(b.startDate).getUnits(['hour', 'minute']);
+      const formattedFirstRepetitionHours = CompaniDate().set(getFirstRepetitionHours).toISO();
+      const formattedSecondRepetitionHours = CompaniDate().set(getSecondRepetitionHours).toISO();
+
+      if (CompaniDate(formattedFirstRepetitionHours).isSameOrBefore(formattedSecondRepetitionHours)) return -1;
+      return 1;
+    });
   }
 
   return repetitionsGroupedByDay;

--- a/src/helpers/repetitions.js
+++ b/src/helpers/repetitions.js
@@ -3,7 +3,6 @@ const get = require('lodash/get');
 const Repetition = require('../models/Repetition');
 const Event = require('../models/Event');
 const EventsHelper = require('./events');
-const DatesHelper = require('./dates');
 const { CompaniDate } = require('./dates/companiDates');
 const {
   FIELDS_NOT_APPLICABLE_TO_REPETITION,
@@ -92,7 +91,7 @@ exports.list = async (query, credentials) => {
           repetitionsGroupedByDay[day].push(repetition);
           break;
         case EVERY_WEEK_DAY:
-          if (day !== SATURDAY && day !== SUNDAY) repetitionsGroupedByDay[day].push(repetition);
+          if (day !== SATURDAY.toString() && day !== SUNDAY.toString()) repetitionsGroupedByDay[day].push(repetition);
           break;
       }
     }

--- a/tests/integration/repetitions.test.js
+++ b/tests/integration/repetitions.test.js
@@ -13,6 +13,7 @@ const {
 } = require('./seed/repetitionsSeed');
 const { getToken } = require('./helpers/authentication');
 const { CompaniDate } = require('../../src/helpers/dates/companiDates');
+const { UNAVAILABILITY, EVERY_WEEK } = require('../../src/helpers/constants');
 
 describe('NODE ENV', () => {
   it('should be "test"', () => {
@@ -35,16 +36,15 @@ describe('REPETITIONS ROUTES - GET /repetitions', () => {
 
       expect(response.statusCode).toEqual(200);
       expect(Object.values(response.result.data.repetitions).flat().length).toEqual(9);
-      expect(Object.values(response.result.data.repetitions)[0][0]).toMatchObject({
-        _id: repetitionList[0]._id,
-        type: 'intervention',
-        startDate: CompaniDate(repetitionList[0].startDate).toDate(),
-        endDate: CompaniDate(repetitionList[0].endDate).toDate(),
+      expect(Object.values(response.result.data.repetitions)[3][1]).toMatchObject({
+        _id: repetitionList[2]._id,
+        type: UNAVAILABILITY,
+        startDate: CompaniDate(repetitionList[2].startDate).toDate(),
+        endDate: CompaniDate(repetitionList[2].endDate).toDate(),
         auxiliary: auxiliariesIdList[0],
-        subscription: customer.subscriptions[0]._id,
-        frequency: 'every_day',
-        parentId: repetitionList[0].parentId,
+        frequency: EVERY_WEEK,
         company: authCompany._id,
+        parentId: repetitionList[2].parentId,
       });
     });
 

--- a/tests/integration/repetitions.test.js
+++ b/tests/integration/repetitions.test.js
@@ -34,7 +34,7 @@ describe('REPETITIONS ROUTES - GET /repetitions', () => {
       });
 
       expect(response.statusCode).toEqual(200);
-      expect(Object.values(response.result.data.repetitions).flat().length).toEqual(8);
+      expect(Object.values(response.result.data.repetitions).flat().length).toEqual(9);
       expect(Object.values(response.result.data.repetitions)[0][0]).toMatchObject({
         _id: repetitionList[0]._id,
         type: 'intervention',

--- a/tests/integration/seed/repetitionsSeed.js
+++ b/tests/integration/seed/repetitionsSeed.js
@@ -110,7 +110,7 @@ const repetitionList = [
   {
     _id: new ObjectId(),
     type: UNAVAILABILITY,
-    startDate: '2021-11-11T16:30:00.000Z',
+    startDate: '2021-11-18T16:30:00.000Z',
     endDate: '2021-11-18T18:30:00.000Z',
     auxiliary: auxiliariesIdList[0],
     frequency: EVERY_WEEK,

--- a/tests/integration/seed/repetitionsSeed.js
+++ b/tests/integration/seed/repetitionsSeed.js
@@ -6,7 +6,14 @@ const Event = require('../../../src/models/Event');
 const Sector = require('../../../src/models/Sector');
 const SectorHistory = require('../../../src/models/SectorHistory');
 const Customer = require('../../../src/models/Customer');
-const { WEBAPP } = require('../../../src/helpers/constants');
+const {
+  WEBAPP,
+  EVERY_WEEK,
+  EVERY_DAY,
+  INTERNAL_HOUR,
+  INTERVENTION,
+  UNAVAILABILITY,
+} = require('../../../src/helpers/constants');
 const UserCompany = require('../../../src/models/UserCompany');
 const { authCompany } = require('../../seed/authCompaniesSeed');
 const { auxiliaryRoleId } = require('../../seed/authRolesSeed');
@@ -73,12 +80,12 @@ const auxiliaryList = [
 const repetitionList = [
   {
     _id: new ObjectId(),
-    type: 'intervention',
+    type: INTERVENTION,
     startDate: '2021-11-11T10:30:00.000Z',
     endDate: '2021-11-11T12:30:00.000Z',
     auxiliary: auxiliariesIdList[0],
     customer: customersIdList[0],
-    frequency: 'every_day',
+    frequency: EVERY_DAY,
     company: authCompany._id,
     address: {
       street: '37 rue de Ponthieu',
@@ -92,11 +99,21 @@ const repetitionList = [
   },
   {
     _id: new ObjectId(),
-    type: 'internal_hour',
+    type: INTERNAL_HOUR,
     startDate: '2021-11-10T10:30:00.000Z',
     endDate: '2021-11-10T12:30:00.000Z',
     auxiliary: auxiliariesIdList[0],
-    frequency: 'every_week',
+    frequency: EVERY_WEEK,
+    company: authCompany._id,
+    parentId: new ObjectId(),
+  },
+  {
+    _id: new ObjectId(),
+    type: UNAVAILABILITY,
+    startDate: '2021-11-11T16:30:00.000Z',
+    endDate: '2021-11-18T18:30:00.000Z',
+    auxiliary: auxiliariesIdList[0],
+    frequency: EVERY_WEEK,
     company: authCompany._id,
     parentId: new ObjectId(),
   },
@@ -104,13 +121,13 @@ const repetitionList = [
 
 const eventList = [
   {
-    repetition: { frequency: 'every_day' },
+    repetition: { frequency: EVERY_DAY },
     startDate: '2021-11-11T10:30:00.000Z',
     endDate: '2021-11-11T12:30:00.000Z',
     company: authCompany._id,
     auxiliary: auxiliariesIdList[0],
     customer: customersIdList[0],
-    type: 'intervention',
+    type: INTERVENTION,
     address: {
       street: '37 rue de Ponthieu',
       fullAddress: '37 rue de ponthieu 75008 Paris',
@@ -121,13 +138,13 @@ const eventList = [
     subscription: customer.subscriptions[0]._id,
   },
   {
-    repetition: { parentId: repetitionList[0].parentId, frequency: 'every_week' },
+    repetition: { parentId: repetitionList[0].parentId, frequency: EVERY_WEEK },
     startDate: '2022-07-28T10:30:00.000Z',
     endDate: '2022-07-28T12:30:00.000Z',
     company: authCompany._id,
     auxiliary: auxiliariesIdList[0],
     customer: customersIdList[0],
-    type: 'intervention',
+    type: INTERVENTION,
     address: {
       street: '37 rue de Ponthieu',
       fullAddress: '37 rue de ponthieu 75008 Paris',

--- a/tests/integration/seed/repetitionsSeed.js
+++ b/tests/integration/seed/repetitionsSeed.js
@@ -78,7 +78,7 @@ const repetitionList = [
     endDate: '2021-11-11T12:30:00.000Z',
     auxiliary: auxiliariesIdList[0],
     customer: customersIdList[0],
-    frequency: 'everey_day',
+    frequency: 'every_day',
     company: authCompany._id,
     address: {
       street: '37 rue de Ponthieu',
@@ -163,5 +163,7 @@ module.exports = {
   eventList,
   auxiliariesIdList,
   customersIdList,
+  customer,
+  authCompany,
   populateDB,
 };

--- a/tests/unit/helpers/repetitions.test.js
+++ b/tests/unit/helpers/repetitions.test.js
@@ -100,7 +100,7 @@ describe('list', () => {
     find.restore();
   });
 
-  it('should list auxiliary\'s repetitions', async () => {
+  it('should list auxiliary\'s repetitions grouped by day', async () => {
     const auxiliaryId = new ObjectId();
     const customerId = new ObjectId();
     const credentials = { company: { _id: new ObjectId() } };
@@ -110,6 +110,14 @@ describe('list', () => {
         type: 'intervention',
         startDate: '2019-07-13T20:00:00.000Z',
         endDate: '2019-07-13T22:00:00.000Z',
+        frequency: 'every_two_weeks',
+        auxiliary: auxiliaryId,
+        customer: customerId,
+      },
+      {
+        type: 'intervention',
+        startDate: '2019-07-20T09:00:00.000Z',
+        endDate: '2019-07-20T11:00:00.000Z',
         frequency: 'every_two_weeks',
         auxiliary: auxiliaryId,
         customer: customerId,
@@ -130,7 +138,7 @@ describe('list', () => {
       },
     ];
 
-    find.returns(SinonMongoose.stubChainedQueries([repetitions[0], repetitions[1]]));
+    find.returns(SinonMongoose.stubChainedQueries([repetitions[0], repetitions[1], repetitions[2]]));
 
     const result = await RepetitionHelper.list(query, credentials);
 
@@ -156,10 +164,18 @@ describe('list', () => {
         { query: 'lean' },
       ]
     );
-    expect(result).toEqual([repetitions[0], repetitions[1]]);
+    expect(result).toEqual({
+      0: [repetitions[2]],
+      1: [],
+      2: [],
+      3: [],
+      4: [],
+      5: [repetitions[1], repetitions[0]],
+      6: [],
+    });
   });
 
-  it('should list customer\'s repetitions', async () => {
+  it('should list customer\'s repetitions grouped by day', async () => {
     const auxiliaryId = new ObjectId();
     const customerId = new ObjectId();
     const credentials = { company: { _id: new ObjectId() } };
@@ -181,15 +197,24 @@ describe('list', () => {
         auxiliary: auxiliaryId,
       },
       {
-        type: 'unavailability',
-        startDate: '2019-07-24T08:00:00.000Z',
-        endDate: '2019-07-13T09:00:00.000Z',
-        frequency: 'every_day',
+        type: 'intervention',
+        startDate: '2019-07-20T08:00:00.000Z',
+        endDate: '2019-07-20T07:00:00.000Z',
+        frequency: 'every_two_weeks',
         auxiliary: auxiliaryId,
+        customer: customerId,
+      },
+      {
+        type: 'intervention',
+        startDate: '2019-07-12T08:00:00.000Z',
+        endDate: '2019-07-12T07:00:00.000Z',
+        frequency: 'every_two_weeks',
+        auxiliary: auxiliaryId,
+        customer: customerId,
       },
     ];
 
-    find.returns(SinonMongoose.stubChainedQueries([repetitions[0]]));
+    find.returns(SinonMongoose.stubChainedQueries([repetitions[0], repetitions[2], repetitions[3]]));
 
     const result = await RepetitionHelper.list(query, credentials);
 
@@ -219,7 +244,15 @@ describe('list', () => {
         { query: 'lean' },
       ]
     );
-    expect(result).toEqual([repetitions[0]]);
+    expect(result).toEqual({
+      0: [],
+      1: [],
+      2: [],
+      3: [],
+      4: [repetitions[3]],
+      5: [repetitions[2], repetitions[0]],
+      6: [],
+    });
   });
 });
 


### PR DESCRIPTION
<details open><summary> TESTS  :computer: </summary>

- [x] J'ai codé les tests unitaires
- [x] J'ai codé les tests d'intégration
- [ ] C'est une ancienne route utilisée par les apps mobiles.
  - [ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens
</details>

- [ ] Je replie cette section car mes modifications n'ont pas besoin de tests unitaires ou d'intégration

---

<details open><summary> POINTS D'ATTENTION POUR CETTE PR  :warning: </summary>

- [ ] J'ai fait des modifications sur une route utilisée sur plusieurs plateformes [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/n3bq2hr9Ia)
- [ ] J'ai modifié un modèle utilisé en mobile [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/rqTfwpUib)
- [ ] J'ai ajouté un modèle spécifique à une structure 
  - [ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés
- [ ] J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile
  - [ ] Si oui, j'ai précisé sur le [slite de MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) qu'il faut forcer la mise à jour
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

</details>

- [x] Je replie cette section car je n'ai pas fait de modifications entrainant un point d'attention

---

<details open><summary> FONCTIONNALITÉS APPS MOBILES  :iphone: </summary>

- [ ] Mes changements impactent l'application formation
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours
- [ ] Mes changements impactent l'application erp
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours

</details>

- [x] Je replie cette section car mes modifications n'ont pas d'impact sur les applications mobiles

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : ETQ client admin / coach / planning referent

- Cas d'usage : lorsque je visualise les répétitions d'un bénéficiaire ou auxiliaire, elles sont groupées par jour

- Comment tester ? : 
   - afficher les répétitions d'un bénéficiaire ou auxiliaire
   - verifier qu'elles sont toutes affichées (si fréquence tous les jours vérifier qu'elle apparait tous les jours)
   - verifier qu'elles sont rangées par ordre croissant sur l'heure de debut

_Si tu as lu cette description, pense a réagir avec un :eye:_
