### PR TITLE
Com 2893

### DIFF
--- a/src/helpers/bills.js
+++ b/src/helpers/bills.js
@@ -312,7 +312,8 @@ exports.formatAndCreateBill = async (payload, credentials) => {
 
   let netInclTaxes = NumbersHelper.toString('0');
   for (const bi of billingItemList) {
-    netInclTaxes = NumbersHelper.add(netInclTaxes, NumbersHelper.multiply(bi.count, bi.unitInclTaxes));
+    const inclTaxes = NumbersHelper.toFixedToFloat(NumbersHelper.multiply(bi.count, bi.unitInclTaxes));
+    netInclTaxes = NumbersHelper.add(netInclTaxes, inclTaxes);
   }
 
   const bill = {

--- a/tests/unit/helpers/bills.test.js
+++ b/tests/unit/helpers/bills.test.js
@@ -2087,8 +2087,8 @@ describe('formatAndCreateBill', () => {
       date: '2021-09-01',
       shouldBeSent: true,
       billingItemList: [
-        { billingItem: billingItemId1, unitInclTaxes: 10, count: 2 },
-        { billingItem: billingItemId2, unitInclTaxes: 30, count: 1 },
+        { billingItem: billingItemId1, unitInclTaxes: 34, count: 4.927 },
+        { billingItem: billingItemId2, unitInclTaxes: 65.45, count: 1.456 },
       ],
     };
 
@@ -2097,8 +2097,8 @@ describe('formatAndCreateBill', () => {
     findBillingItem.returns(
       SinonMongoose.stubChainedQueries([{ _id: billingItemId1, vat: 10 }, { _id: billingItemId2, vat: 25 }], ['lean'])
     );
-    formatBillingItem.onCall(0).returns({ inclTaxes: 180 });
-    formatBillingItem.onCall(1).returns({ inclTaxes: 150 });
+    formatBillingItem.onCall(0).returns({ inclTaxes: 167.52 });
+    formatBillingItem.onCall(1).returns({ inclTaxes: 95.3 });
 
     await BillHelper.formatAndCreateBill(payload, credentials);
 
@@ -2118,12 +2118,12 @@ describe('formatAndCreateBill', () => {
     );
     sinon.assert.calledWithExactly(
       formatBillingItem.getCall(0),
-      { billingItem: billingItemId1, unitInclTaxes: 10, count: 2 },
+      { billingItem: billingItemId1, unitInclTaxes: 34, count: 4.927 },
       [{ _id: billingItemId1, vat: 10 }, { _id: billingItemId2, vat: 25 }]
     );
     sinon.assert.calledWithExactly(
       formatBillingItem.getCall(1),
-      { billingItem: billingItemId2, unitInclTaxes: 30, count: 1 },
+      { billingItem: billingItemId2, unitInclTaxes: 65.45, count: 1.456 },
       [{ _id: billingItemId1, vat: 10 }, { _id: billingItemId2, vat: 25 }]
     );
     sinon.assert.calledOnceWithExactly(
@@ -2132,9 +2132,9 @@ describe('formatAndCreateBill', () => {
         number: 'FACT-101092100001',
         date: '2021-09-01',
         customer: payload.customer,
-        netInclTaxes: 50,
+        netInclTaxes: 262.82,
         type: 'manual',
-        billingItemList: [{ inclTaxes: 180 }, { inclTaxes: 150 }],
+        billingItemList: [{ inclTaxes: 167.52 }, { inclTaxes: 95.3 }],
         company: companyId,
         shouldBeSent: true,
       }


### PR DESCRIPTION
<details open><summary> TESTS  :computer: </summary>

- [x] J'ai codé les tests unitaires
- [ ] J'ai codé les tests d'intégration
- [ ] C'est une ancienne route utilisée par les apps mobiles.
  - [ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens
</details>

- [ ] Je replie cette section car mes modifications n'ont pas besoin de tests unitaires ou d'intégration

---

<details open><summary> POINTS D'ATTENTION POUR CETTE PR  :warning: </summary>

- [ ] J'ai fait des modifications sur une route utilisée sur plusieurs plateformes [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/n3bq2hr9Ia)
- [ ] J'ai modifié un modèle utilisé en mobile [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/rqTfwpUib)
- [ ] J'ai ajouté un modèle spécifique à une structure 
  - [ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés
- [ ] J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile
  - [ ] Si oui, j'ai précisé sur le [slite de MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) qu'il faut forcer la mise à jour
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

</details>

- [x] Je replie cette section car je n'ai pas fait de modifications entrainant un point d'attention

---

<details open><summary> FONCTIONNALITÉS APPS MOBILES  :iphone: </summary>

- [ ] Mes changements impactent l'application formation
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours
- [ ] Mes changements impactent l'application erp
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours

</details>

- [x] Je replie cette section car mes modifications n'ont pas d'impact sur les applications mobiles

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : client admin

- Cas d'usage : Les montants figurant sur une facture manuelle et sur un avoir sur des articles de facturation sont justes.

Exemple de combinaison qui donnait des factures / avoirs avec des montants incohérents
<img width="503" alt="Capture d’écran 2022-07-21 à 17 56 12" src="https://user-images.githubusercontent.com/81675019/180259850-0a70404b-e620-49b3-b6da-9c271599bd01.png">

- Comment tester ? :
  - generer une facture manuelle
  - verifieer que tous les montants sont coherents (dans la modale de creation et sur la facture)
  - generer un avoir sur les articles de facturation
  - verifier que tous les montants sont coherents (dans la modale de creation et sur la facture)
  - vérifier que les montants sont justes dans la modale d'édition d'un avoir 

_Si tu as lu cette description, pense a réagir avec un :eye:_
