### PR TITLE
Com 2893 intl

### DIFF
--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -84,7 +84,9 @@ const roundFrenchPrice = (number) => {
     'fr-FR',
     { minimumFractionDigits: 2, style: 'currency', currency: 'EUR', currencyDisplay: 'symbol' }
   );
-  return nf.format(number);
+
+  const roundedNumber = NumbersHelper.toFixedToFloat(number);
+  return nf.format(roundedNumber);
 };
 
 exports.formatPrice = val => (val ? roundFrenchPrice(val) : roundFrenchPrice(0));
@@ -94,7 +96,9 @@ exports.roundFrenchNumber = (number, digits) => {
     'fr-FR',
     { minimumFractionDigits: digits, style: 'decimal', maximumFractionDigits: digits }
   );
-  return nf.format(number);
+
+  const roundedNumber = NumbersHelper.toFixedToFloat(number, digits);
+  return nf.format(roundedNumber);
 };
 
 exports.formatHour = val => (val ? `${exports.roundFrenchNumber(val, 2)}h` : `${exports.roundFrenchNumber(0, 2)}h`);

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -109,7 +109,9 @@ exports.formatHourWithMinutes = hour => (moment(hour).minutes()
 
 const roundFrenchPercentage = (number) => {
   const nf = new Intl.NumberFormat('fr-FR', { minimumFractionDigits: 2, style: 'percent' });
-  return nf.format(number);
+
+  const roundedNumber = NumbersHelper.toFixedToFloat(number, 4);
+  return nf.format(roundedNumber);
 };
 
 exports.formatPercentage = val => (val ? roundFrenchPercentage(val) : roundFrenchPercentage(0));

--- a/tests/unit/helpers/utils.test.js
+++ b/tests/unit/helpers/utils.test.js
@@ -187,6 +187,11 @@ describe('formatPrice', () => {
     const res = UtilsHelper.formatPrice('595.7549999999999838');
     expect(res).toEqual('595,75\u00a0€');
   });
+
+  it('should format price for 0', () => {
+    const res = UtilsHelper.formatPrice(0);
+    expect(res).toEqual('0,00\u00a0€');
+  });
 });
 
 describe('roundFrenchNumber', () => {
@@ -198,6 +203,18 @@ describe('roundFrenchNumber', () => {
   it('should round french number with 5 digits', () => {
     const res = UtilsHelper.roundFrenchNumber('12.256343213', 5);
     expect(res).toEqual('12,25634');
+  });
+});
+
+describe('formatPercentage', () => {
+  it('should format percentage', () => {
+    const res = UtilsHelper.formatPercentage('0.344449999999999999999');
+    expect(res).toEqual('34,44\u00a0%');
+  });
+
+  it('should format percentage for 0', () => {
+    const res = UtilsHelper.formatPercentage(0);
+    expect(res).toEqual('0,00\u00a0%');
   });
 });
 

--- a/tests/unit/helpers/utils.test.js
+++ b/tests/unit/helpers/utils.test.js
@@ -184,15 +184,20 @@ describe('removeSpaces', () => {
 
 describe('formatPrice', () => {
   it('should format price', () => {
-    const res = UtilsHelper.formatPrice(5.5);
-    expect(res).toEqual('5,50\u00a0€');
+    const res = UtilsHelper.formatPrice('595.7549999999999838');
+    expect(res).toEqual('595,75\u00a0€');
   });
 });
 
 describe('roundFrenchNumber', () => {
   it('should round french number', () => {
-    const res = UtilsHelper.roundFrenchNumber(5.5);
-    expect(res).toEqual('5,5');
+    const res = UtilsHelper.roundFrenchNumber('595.7549999999999838', 2);
+    expect(res).toEqual('595,75');
+  });
+
+  it('should round french number with 5 digits', () => {
+    const res = UtilsHelper.roundFrenchNumber('12.256343213', 5);
+    expect(res).toEqual('12,25634');
   });
 });
 


### PR DESCRIPTION
<details open><summary> TESTS  :computer: </summary>

- [x] J'ai codé les tests unitaires
- [ ] J'ai codé les tests d'intégration -np
- [ ] C'est une ancienne route utilisée par les apps mobiles.
  - [ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens
</details>

- [ ] Je replie cette section car mes modifications n'ont pas besoin de tests unitaires ou d'intégration

---

<details><summary> POINTS D'ATTENTION POUR CETTE PR  :warning: </summary>

- [ ] J'ai fait des modifications sur une route utilisée sur plusieurs plateformes [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/n3bq2hr9Ia)
- [ ] J'ai modifié un modèle utilisé en mobile [Slite de détail](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/rqTfwpUib)
- [ ] J'ai ajouté un modèle spécifique à une structure 
  - [ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés
- [ ] J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile
  - [ ] Si oui, j'ai précisé sur le [slite de MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) qu'il faut forcer la mise à jour
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

</details>

- [ ] Je replie cette section car je n'ai pas fait de modifications entrainant un point d'attention

---

<details><summary> FONCTIONNALITÉS APPS MOBILES  :iphone: </summary>

- [ ] Mes changements impactent l'application formation
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours
- [ ] Mes changements impactent l'application erp
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours

</details>

- [ ] Je replie cette section car mes modifications n'ont pas d'impact sur les applications mobiles

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : vendeur et client/ admin, coach, aidant

- Cas d'usage : Intl utilise les nombres js. Du coup si on lui passe un nombre BigNumber qui n'existe pas en js, cela pose probleme car il va d'abord modifier le nombre pour avoir un nombre js puis faire l'arrondi, ce qui peut poser probleme. Par exemple le nombre 595.7549999999999838 n'existe pas en js et est donc transforme en 595.755, ce qui arrondi donne 595.76 vs 595.75 qui est la valeur attendue.

J'ai tout de meme conservé Intl qui permet de formatter les nombres comme on le souhaite, mais en arrondissant avant. Dites moi ce que vous en pensez :) 

- Comment tester ? : 
    - tester la facture du bénéficiaire dont l'id est dans le ticket
    - Verifier cote outils :  
        - les factures
        - les avoirs 
        - les bordereaux tpp 
        - export facture 
        - attestations fiscales
    - Vérifier les factures & avoirs côté formation


_Si tu as lu cette description, pense a réagir avec un :eye:_
