### PR TITLE
COM-2960 fix prehandler to authorize elearning for coach

### DIFF
--- a/src/routes/preHandlers/courses.js
+++ b/src/routes/preHandlers/courses.js
@@ -280,7 +280,7 @@ exports.authorizeGetCourse = async (req) => {
       .lean();
     const someTraineesAreInCompany = courseWithTrainees.trainees
       .some(trainee => UtilsHelper.areObjectIdsEquals(trainee.company, userCompany));
-    if (!someTraineesAreInCompany) throw Boom.forbidden();
+    if (course.format === BLENDED && !someTraineesAreInCompany) throw Boom.forbidden();
 
     return null;
   } catch (e) {

--- a/tests/integration/courses.test.js
+++ b/tests/integration/courses.test.js
@@ -466,7 +466,7 @@ describe('COURSES ROUTES - GET /courses/{_id}', () => {
       expect(response.result.data.course._id.toHexString()).toBe(courseFromAuthCompanyInterB2b._id.toHexString());
     });
 
-    it('should return elearning course with no access rule #tag',
+    it('should return elearning course with no access rule',
       async () => {
         const response = await app.inject({
           method: 'GET',

--- a/tests/integration/courses.test.js
+++ b/tests/integration/courses.test.js
@@ -466,6 +466,17 @@ describe('COURSES ROUTES - GET /courses/{_id}', () => {
       expect(response.result.data.course._id.toHexString()).toBe(courseFromAuthCompanyInterB2b._id.toHexString());
     });
 
+    it('should return elearning course with no access rule #tag',
+      async () => {
+        const response = await app.inject({
+          method: 'GET',
+          url: `/courses/${coursesList[6]._id}`,
+          headers: { Cookie: `alenvi_token=${authToken}` },
+        });
+
+        expect(response.statusCode).toBe(200);
+      });
+
     it('should return course if course is eLearning and has accessRules that contain user company',
       async () => {
         const response = await app.inject({


### PR DESCRIPTION
<details open><summary> TESTS  :computer: </summary>

- [ ] J'ai codé les tests unitaires
- [x] J'ai codé les tests d'intégration
- [ ] C'est une ancienne route utilisée par les apps mobiles.
  - [ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens
</details>

- [ ] Je replie cette section car mes modifications n'ont pas besoin de tests unitaires ou d'intégration

---

<details><summary> POINTS D'ATTENTION POUR CETTE PR  :warning: </summary>

- [ ] J'ai fait des modifications sur une route utilisée sur plusieurs plateformes [Doc de détail](https://www.notion.so/Points-d-attention-sur-les-routes-a548a8e32d314d5e92cb342e66cce443)
- [ ] J'ai modifié un modèle utilisé en mobile [Doc de détail](https://www.notion.so/Point-d-attention-sur-les-mod-les-e46fbf180cd34a569f3c6102366e47ca)
- [ ] J'ai ajouté un modèle spécifique à une structure 
  - [ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés
- [ ] J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile
  - [ ] Si oui, j'ai précisé sur le [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) qu'il faut forcer la mise à jour
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [Doc de MES](https://www.notion.so/Pas-pas-Mise-en-staging-01755ac57d944b4cb0c189861428e5d2) et [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) les modifications faites

</details>

- [x] Je replie cette section car je n'ai pas fait de modifications entrainant un point d'attention

---

<details><summary> FONCTIONNALITÉS APPS MOBILES  :iphone: </summary>

- [ ] Mes changements impactent l'application formation
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours
- [ ] Mes changements impactent l'application erp
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours

</details>

- [x] Je replie cette section car mes modifications n'ont pas d'impact sur les applications mobiles

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : formation / coach ou admin client

- Cas d'usage : 
  - un.e coach peut voir les infos sur le profile d'une formation elearning meme si aucun.e apprenant.e de sa structure ne suis cette formation

- Comment tester ? :
  - ETQAdmin sur la page d’une formation e-learning : 
    - si j’ai des apprenants de ma structure inscrits a la formation, je vois les infos
    - si je n’ai pas d’apprenants de ma structure inscrits, je vois les infos
  - ETQAdmin sur la page d’une formation mixte interb2b: 
    - si j’ai des apprenants de ma structure inscrits a la formation, je vois les infos
    - si je n’ai pas d’apprenants de ma structure inscrits, je ne vois pas les infos
       - on 

_Si tu as lu cette description, pense à réagir avec un :eye:_
