### PR TITLE
COM-2992 - fix dates displays in working events export

### DIFF
--- a/src/helpers/historyExport.js
+++ b/src/helpers/historyExport.js
@@ -86,12 +86,11 @@ const getMatchingSector = (histories, event) => histories
   .filter(sh => CompaniDate(sh.startDate).isBefore(event.startDate))
   .sort(DatesHelper.descendingSort('startDate'))[0];
 
-const displayDate = (path, timestamp = null, scheduledDate = null) => {
-  let date = '';
-  if (timestamp) date = CompaniDate(get(timestamp, path)).toLocalISO();
-  else if (scheduledDate) date = CompaniDate(scheduledDate).toLocalISO();
+const displayDate = (date) => {
+  if (!date) return '';
 
-  return date.replace(/-/g, '/').replace('T', ' ').slice(0, 19);
+  const dateToFormat = CompaniDate(date).toLocalISO();
+  return dateToFormat.replace(/-/g, '/').replace('T', ' ').slice(0, 19);
 };
 
 exports.EVENT_PROJECTION_FILEDS = {
@@ -171,13 +170,13 @@ exports.exportWorkingEventsHistory = async (startDate, endDate, credentials) => 
       EVENT_TYPE_LIST[event.type],
       get(event, 'internalHour.name', ''),
       event.subscription ? getServiceName(event.subscription.service) : '',
-      displayDate('update.startHour.from', startHourTimeStamping, event.startDate),
-      displayDate('update.startHour.to', startHourTimeStamping),
+      displayDate(startHourTimeStamping ? get(startHourTimeStamping, 'update.startHour.from') : event.startDate),
+      startHourTimeStamping ? displayDate(get(startHourTimeStamping, 'update.startHour.to')) : '',
       TIMESTAMPING_ACTION_TYPE_LIST[get(startHourTimeStamping, 'action')] || '',
       get(startHourTimeStamping, 'action') === MANUAL_TIME_STAMPING
         ? MANUAL_TIME_STAMPING_REASONS[get(startHourTimeStamping, 'manualTimeStampingReason')] : '',
-      displayDate('update.endHour.from', endHourTimeStamping, event.endDate),
-      displayDate('update.endHour.to', endHourTimeStamping),
+      displayDate(endHourTimeStamping ? get(endHourTimeStamping, 'update.endHour.from') : event.endDate),
+      endHourTimeStamping ? displayDate(get(endHourTimeStamping, 'update.endHour.to')) : '',
       TIMESTAMPING_ACTION_TYPE_LIST[get(endHourTimeStamping, 'action')] || '',
       get(endHourTimeStamping, 'action') === MANUAL_TIME_STAMPING
         ? MANUAL_TIME_STAMPING_REASONS[get(endHourTimeStamping, 'manualTimeStampingReason')] : '',

--- a/src/helpers/historyExport.js
+++ b/src/helpers/historyExport.js
@@ -89,7 +89,7 @@ const getMatchingSector = (histories, event) => histories
 const displayDate = (path, timestamp = null, scheduledDate = null) => {
   let date = '';
   if (timestamp) date = CompaniDate(get(timestamp, path)).toLocalISO();
-  if (scheduledDate) date = CompaniDate(scheduledDate).toLocalISO();
+  else if (scheduledDate) date = CompaniDate(scheduledDate).toLocalISO();
 
   return date.replace(/-/g, '/').replace('T', ' ').slice(0, 19);
 };

--- a/tests/unit/helpers/historyExport.test.js
+++ b/tests/unit/helpers/historyExport.test.js
@@ -216,6 +216,7 @@ describe('exportWorkingEventsHistory', () => {
     'Statut de l\'annulation',
     'Raison de l\'annulation',
   ];
+  const credentials = { company: { _id: '1234567890' } };
   const auxiliaryId = new ObjectId();
   const auxiliaries = [
     {
@@ -243,11 +244,11 @@ describe('exportWorkingEventsHistory', () => {
         identity: { title: 'mrs', firstname: 'Mimi', lastname: 'Mathy' },
       },
       auxiliary: auxiliaryId,
-      startDate: '2019-05-20T08:00:00.000Z',
-      endDate: '2019-05-20T10:00:00.000Z',
+      startDate: '2019-05-18T08:00:00.000Z',
+      endDate: '2019-05-18T10:00:00.000Z',
       histories: [
         {
-          update: { startHour: { from: '2019-05-20T08:00:00.000Z', to: '2019-05-20T08:01:18.000Z' } },
+          update: { startHour: { from: '2019-05-18T08:00:00.000Z', to: '2019-05-18T08:01:18.000Z' } },
           event: { type: 'intervention', auxiliary: auxiliaryId },
           auxiliaries: [auxiliaryId],
           action: 'manual_time_stamping',
@@ -302,8 +303,8 @@ describe('exportWorkingEventsHistory', () => {
         _id: new ObjectId(),
         identity: { title: 'mr', firstname: 'Bojack', lastname: 'Horseman' },
       },
-      startDate: '2019-05-20T08:00:00.000Z',
-      endDate: '2019-05-20T10:00:00.000Z',
+      startDate: '2019-05-24T08:00:00.000Z',
+      endDate: '2019-05-24T10:00:00.000Z',
       misc: 'brbr',
       histories: [],
     },
@@ -323,32 +324,38 @@ describe('exportWorkingEventsHistory', () => {
   });
 
   it('should return an array containing just the header', async () => {
+    const start = '2019-06-16T08:00:00.000Z';
+    const end = '2019-06-24T22:00:00.000Z';
+
     getWorkingEventsForExport.returns([]);
     getAuxiliariesWithSectorHistory.returns([]);
-    const exportArray = await ExportHelper.exportWorkingEventsHistory(null, null);
+    const exportArray = await ExportHelper.exportWorkingEventsHistory(start, end, credentials);
 
     expect(exportArray).toEqual([header]);
   });
 
   it('should return an array with the header and 3 rows', async () => {
+    const start = '2019-05-16T08:00:00.000Z';
+    const end = '2019-05-24T22:00:00.000Z';
+
     getWorkingEventsForExport.returns(events);
     getAuxiliariesWithSectorHistory.returns(auxiliaries);
 
     getLastVersion.callsFake(ver => ver[0]);
 
-    const exportArray = await ExportHelper.exportWorkingEventsHistory(null, null);
+    const exportArray = await ExportHelper.exportWorkingEventsHistory(start, end, credentials);
 
     expect(exportArray).toEqual([
       header,
-      ['Intervention', '', 'Lala', '2019/05/20 10:00:00', '2019/05/20 10:01:18', 'Manuel', 'QR Code manquant',
-        '2019/05/20 12:00:00', '', '', '', '2,00', 'Une fois par semaine', '667,00', 'Transports en commun / À pied',
+      ['Intervention', '', 'Lala', '2019/05/18 10:00:00', '2019/05/18 10:01:18', 'Manuel', 'QR Code manquant',
+        '2019/05/18 12:00:00', '', '', '', '2,00', 'Une fois par semaine', '667,00', 'Transports en commun / À pied',
         'Girafes - 75', expect.any(ObjectId), '', 'Jean-Claude', 'VAN DAMME', 'Non', expect.any(ObjectId), 'Mme',
         'MATHY', 'Mimi', '', 'Oui', 'Non', '', ''],
       ['Intervention', '', 'Lala', '2019/05/20 10:00:00', '2019/05/20 10:01:18', 'Manuel', 'QR Code manquant',
         '2019/05/20 12:00:00', '2019/05/20 12:03:24', 'Manuel', 'Problème de caméra', '2,00', 'Une fois par semaine',
         '', '', 'Girafes - 75', '', '', '', '', 'Oui', expect.any(ObjectId), 'Mme', 'MATHY', 'Mimi', '',
         'Oui', 'Non', '', ''],
-      ['Heure interne', 'Formation', '', '2019/05/20 10:00:00', '', '', '', '2019/05/20 12:00:00', '', '', '',
+      ['Heure interne', 'Formation', '', '2019/05/24 10:00:00', '', '', '', '2019/05/24 12:00:00', '', '', '',
         '2,00', '', '4124,00', 'Véhicule d\'entreprise', 'Etoiles - 75', '', '', '', '', 'Oui', expect.any(ObjectId), 'M.',
         'HORSEMAN', 'Bojack', 'brbr', 'Non', 'Oui', 'Facturée & non payée', 'Initiative de l\'intervenant(e)'],
     ]);


### PR DESCRIPTION
<details open><summary> TESTS  :computer: </summary>

- [x] J'ai codé les tests unitaires
- [ ] J'ai codé les tests d'intégration
- [ ] C'est une ancienne route utilisée par les apps mobiles.
  - [ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens
</details>

- [ ] Je replie cette section car mes modifications n'ont pas besoin de tests unitaires ou d'intégration

---

<details open><summary> POINTS D'ATTENTION POUR CETTE PR  :warning: </summary>

- [ ] J'ai fait des modifications sur une route utilisée sur plusieurs plateformes [Doc de détail](https://www.notion.so/Points-d-attention-sur-les-routes-a548a8e32d314d5e92cb342e66cce443)
- [ ] J'ai modifié un modèle utilisé en mobile [Doc de détail](https://www.notion.so/Point-d-attention-sur-les-mod-les-e46fbf180cd34a569f3c6102366e47ca)
- [ ] J'ai ajouté un modèle spécifique à une structure 
  - [ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés
- [ ] J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile
  - [ ] Si oui, j'ai précisé sur le [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) qu'il faut forcer la mise à jour
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [Doc de MES](https://www.notion.so/Pas-pas-Mise-en-staging-01755ac57d944b4cb0c189861428e5d2) et [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) les modifications faites

</details>

- [x] Je replie cette section car je n'ai pas fait de modifications entrainant un point d'attention

---

<details open><summary> FONCTIONNALITÉS APPS MOBILES  :iphone: </summary>

- [ ] Mes changements impactent l'application formation
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours
- [ ] Mes changements impactent l'application erp
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours

</details>

- [x] Je replie cette section car mes modifications n'ont pas d'impact sur les applications mobiles

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : ETQ Admin

- Cas d'usage : dans l'export des historiques d'interventions et heures internes, les heures de debut et de fin planifiées sont différentes des heures horodatées

- Comment tester ? :
  - télécharger l'export des historiques d'intervention et heures internes et verifier que les heures de de début et de fin planifiées sont les bonnes 
  - versifier que l'export sur une période d'un an fonctionne correctement (~ 20sec pour generer le doc)

_Si tu as lu cette description, pense à réagir avec un :eye:_
