### PR TITLE
COM-3015 dont check contract if assigning repetition to sector

### DIFF
--- a/src/helpers/eventsValidation.js
+++ b/src/helpers/eventsValidation.js
@@ -56,7 +56,7 @@ exports.hasConflicts = async (event) => {
 
 const isOneDayEvent = event => CompaniDate(event.startDate).isSame(event.endDate, 'day');
 
-const isAuxiliaryUpdated = (payload, eventFromDB) =>
+const isAuxiliaryUpdated = (payload, eventFromDB) => payload.auxiliary &&
   !UtilsHelper.areObjectIdsEquals(payload.auxiliary, eventFromDB.auxiliary);
 
 const isRepetition = event => event.repetition && event.repetition.frequency && event.repetition.frequency !== NEVER;

--- a/tests/unit/helpers/eventsValidation.test.js
+++ b/tests/unit/helpers/eventsValidation.test.js
@@ -861,6 +861,30 @@ describe('isUpdateAllowed', () => {
     );
   });
 
+  it('should not check contract if the repetition is assign to a sector', async () => {
+    const auxiliaryId = new ObjectId();
+    const payload = {
+      startDate: '2019-04-13T09:00:00.000Z',
+      endDate: '2019-04-13T11:00:00.000Z',
+      shouldUpdateRepetition: true,
+      sector: new ObjectId(),
+    };
+    const eventFromDB = {
+      auxiliary: auxiliaryId,
+      type: INTERVENTION,
+      repetition: { frequency: 'every_week' },
+      startDate: '2019-01-01T09:00:00.000Z',
+      endDate: '2019-01-01T11:00:00.000Z',
+    };
+    hasConflicts.returns(false);
+    isEditionAllowed.returns(true);
+    countDocuments.returns(0);
+
+    await EventsValidationHelper.isUpdateAllowed(eventFromDB, payload);
+
+    sinon.assert.notCalled(countDocuments);
+  });
+
   it('should return true as repetition and auxiliary are updated (from sector) and auxiliary\'s contract is not ended',
     async () => {
       const payload = {


### PR DESCRIPTION
<details open><summary> TESTS  :computer: </summary>

- [x] J'ai codé les tests unitaires
- [ ] J'ai codé les tests d'intégration -np
- [ ] C'est une ancienne route utilisée par les apps mobiles.
  - [ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens
</details>

- [ ] Je replie cette section car mes modifications n'ont pas besoin de tests unitaires ou d'intégration

---

<details><summary> POINTS D'ATTENTION POUR CETTE PR  :warning: </summary>

- [ ] J'ai fait des modifications sur une route utilisée sur plusieurs plateformes [Doc de détail](https://www.notion.so/Points-d-attention-sur-les-routes-a548a8e32d314d5e92cb342e66cce443)
- [ ] J'ai modifié un modèle utilisé en mobile [Doc de détail](https://www.notion.so/Point-d-attention-sur-les-mod-les-e46fbf180cd34a569f3c6102366e47ca)
- [ ] J'ai ajouté un modèle spécifique à une structure 
  - [ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés
- [ ] J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile
  - [ ] Si oui, j'ai précisé sur le [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) qu'il faut forcer la mise à jour
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [Doc de MES](https://www.notion.so/Pas-pas-Mise-en-staging-01755ac57d944b4cb0c189861428e5d2) et [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) les modifications faites

</details>

- [x] Je replie cette section car je n'ai pas fait de modifications entrainant un point d'attention

---

<details><summary> FONCTIONNALITÉS APPS MOBILES  :iphone: </summary>

- [ ] Mes changements impactent l'application formation
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours
- [ ] Mes changements impactent l'application erp
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours

</details>

- [x] Je replie cette section car mes modifications n'ont pas d'impact sur les applications mobiles

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : client coach

- Cas d'usage : refacto code pour eviter de passer par du code specifique a une auxiliaire quand une repeittion est affectee a un secteur

- Comment tester ? : Vérifier que l'assignation de repetition/evenement se passent bien entre auxiliaires/secteurs

_Si tu as lu cette description, pense à réagir avec un :eye:_
