### PR TITLE
COM-3016 block repetition creation if auxiliary has ending contract

### DIFF
--- a/src/helpers/contracts.js
+++ b/src/helpers/contracts.js
@@ -417,6 +417,6 @@ exports.auxiliaryHasActiveContractOnDay = (contracts, day) =>
 
 exports.auxiliaryHasActiveContractBetweenDates = (contracts, startDate, endDate) =>
   contracts.some(c => DatesHelper.isSameOrBefore(c.startDate, startDate) &&
-    (!c.endDate || DatesHelper.isSameOrAfter(c.endDate, endDate)));
+    (!c.endDate || (endDate && DatesHelper.isSameOrAfter(c.endDate, endDate))));
 
 exports.getStaffRegister = async companyId => ContractRepository.getStaffRegister(companyId);

--- a/src/helpers/eventsValidation.js
+++ b/src/helpers/eventsValidation.js
@@ -36,9 +36,15 @@ exports.isUserContractValidOnEventDates = async (event) => {
   const user = await User.findOne({ _id: event.auxiliary }).populate('contracts').lean();
   if (!user.contracts || user.contracts.length === 0) return false;
 
-  return event.type === ABSENCE
-    ? ContractsHelper.auxiliaryHasActiveContractBetweenDates(user.contracts, event.startDate, event.endDate)
-    : ContractsHelper.auxiliaryHasActiveContractOnDay(user.contracts, event.startDate);
+  if (event.type === ABSENCE) {
+    return ContractsHelper.auxiliaryHasActiveContractBetweenDates(user.contracts, event.startDate, event.endDate);
+  }
+
+  if (isRepetition(event)) {
+    return ContractsHelper.auxiliaryHasActiveContractBetweenDates(user.contracts, event.startDate);
+  }
+
+  return ContractsHelper.auxiliaryHasActiveContractOnDay(user.contracts, event.startDate);
 };
 
 exports.hasConflicts = async (event) => {

--- a/tests/unit/helpers/contracts.test.js
+++ b/tests/unit/helpers/contracts.test.js
@@ -1657,3 +1657,54 @@ describe('getStaffRegister', () => {
     sinon.assert.calledWithExactly(getStaffRegisterStub, companyId);
   });
 });
+
+describe('auxiliaryHasActiveContractBetweenDates', () => {
+  it('should return true if auxiliary has contract that start before the start date and don\'t end', () => {
+    const contracts = [{ startDate: '2019-01-01T08:38:18.000Z' }];
+    const startDate = '2020-01-01T08:38:18.000Z';
+    const endDate = '2020-01-04T08:38:18.000Z';
+
+    const result = ContractHelper.auxiliaryHasActiveContractBetweenDates(contracts, startDate, endDate);
+
+    expect(result).toBe(true);
+  });
+
+  it('should return true if auxiliary has contract that start before the start date and end after the endDate', () => {
+    const contracts = [{ startDate: '2019-01-01T08:38:18.000Z', endDate: '2021-01-04T08:38:18.000Z' }];
+    const startDate = '2020-01-01T08:38:18.000Z';
+    const endDate = '2020-01-04T08:38:18.000Z';
+
+    const result = ContractHelper.auxiliaryHasActiveContractBetweenDates(contracts, startDate, endDate);
+
+    expect(result).toBe(true);
+  });
+
+  it('should return false if auxiliary has contract that start after the start date', () => {
+    const contracts = [{ startDate: '2019-01-01T08:38:18.000Z' }];
+    const startDate = '2018-01-01T08:38:18.000Z';
+    const endDate = '2018-01-04T08:38:18.000Z';
+
+    const result = ContractHelper.auxiliaryHasActiveContractBetweenDates(contracts, startDate, endDate);
+
+    expect(result).toBe(false);
+  });
+
+  it('should return false if auxiliary has contract that end before the start date', () => {
+    const contracts = [{ startDate: '2019-01-01T08:38:18.000Z', endDate: '2019-01-03T08:38:18.000Z' }];
+    const startDate = '2019-01-01T08:38:18.000Z';
+    const endDate = '2019-01-04T08:38:18.000Z';
+
+    const result = ContractHelper.auxiliaryHasActiveContractBetweenDates(contracts, startDate, endDate);
+
+    expect(result).toBe(false);
+  });
+
+  it('should return false if auxiliary has ending contract and endDate is not given as an argument', () => {
+    const contracts = [{ startDate: '2019-01-01T08:38:18.000Z', endDate: '2019-01-03T08:38:18.000Z' }];
+    const startDate = '2019-01-01T08:38:18.000Z';
+
+    const result = ContractHelper.auxiliaryHasActiveContractBetweenDates(contracts, startDate);
+
+    expect(result).toBe(false);
+  });
+});


### PR DESCRIPTION
<details open><summary> TESTS  :computer: </summary>

- [x] J'ai codé les tests unitaires
- [ ] J'ai codé les tests d'intégration -np
- [ ] C'est une ancienne route utilisée par les apps mobiles.
  - [ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens
</details>

- [ ] Je replie cette section car mes modifications n'ont pas besoin de tests unitaires ou d'intégration

---

<details><summary> POINTS D'ATTENTION POUR CETTE PR  :warning: </summary>

- [ ] J'ai fait des modifications sur une route utilisée sur plusieurs plateformes [Doc de détail](https://www.notion.so/Points-d-attention-sur-les-routes-a548a8e32d314d5e92cb342e66cce443)
- [ ] J'ai modifié un modèle utilisé en mobile [Doc de détail](https://www.notion.so/Point-d-attention-sur-les-mod-les-e46fbf180cd34a569f3c6102366e47ca)
- [ ] J'ai ajouté un modèle spécifique à une structure 
  - [ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés
- [ ] J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile
  - [ ] Si oui, j'ai précisé sur le [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) qu'il faut forcer la mise à jour
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [Doc de MES](https://www.notion.so/Pas-pas-Mise-en-staging-01755ac57d944b4cb0c189861428e5d2) et [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) les modifications faites

</details>

- [ ] Je replie cette section car je n'ai pas fait de modifications entrainant un point d'attention

---

<details><summary> FONCTIONNALITÉS APPS MOBILES  :iphone: </summary>

- [ ] Mes changements impactent l'application formation
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours
- [ ] Mes changements impactent l'application erp
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours

</details>

- [ ] Je replie cette section car mes modifications n'ont pas d'impact sur les applications mobiles

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : coach/auxiliaire

- Cas d'usage : impossible de créer une repetition pour une auxiliaire qui a un contrat qui s'arrete (meme si un nouveau contrat commence plus tard)

- Comment tester ? : 
   - pour tester le back, d'abord etre sur dev en front : 
       - verifier que la creation est bien bloquée pour l'ajout de repetition pour une auxiliaire dont le contrat se termine puis recommence (seulement sur l'ancien contrat, sur le nouveau contrat on peut toujours les créer) 
   - puis se mettre sur COM-3016 aussi en front et tester de créer des répétitions pour différentes auxiliaires avec différents cas de contrat (sans date de fin, avec date de fin, avec plusieurs contrats...) 

_Si tu as lu cette description, pense à réagir avec un :eye:_
