### PR TITLE
Com 3022

### DIFF
--- a/src/repositories/EventRepository.js
+++ b/src/repositories/EventRepository.js
@@ -120,6 +120,7 @@ exports.getAuxiliaryEventsBetweenDates = async (auxiliary, startDate, endDate, c
     .populate({ path: 'startDateTimeStamp' })
     .populate({ path: 'endDateTimeStamp' })
     .lean();
+
   if (!type) return eventList;
 
   return eventList.filter(event =>

--- a/src/repositories/EventRepository.js
+++ b/src/repositories/EventRepository.js
@@ -115,8 +115,15 @@ exports.getAuxiliaryEventsBetweenDates = async (auxiliary, startDate, endDate, c
     endDate: { $gt: new Date(startDate) },
     company: companyId,
   };
-  if (type) query.type = type;
-  return Event.find(query);
+
+  const eventList = await Event.find(query)
+    .populate({ path: 'startDateTimeStamp' })
+    .populate({ path: 'endDateTimeStamp' })
+    .lean();
+  if (!type) return eventList;
+
+  return eventList.filter(event =>
+    event.type === type || event.isBilled || event.startDateTimeStamp || event.endDateTimeStamp);
 };
 
 exports.getEvent = async (eventId, credentials) => Event.findOne({ _id: eventId })


### PR DESCRIPTION
<details open><summary> TESTS  :computer: </summary>

- [x] J'ai codé les tests unitaires
- [ ] J'ai codé les tests d'intégration -np
- [ ] ~~C'est une ancienne route utilisée par les apps mobiles.~~
  - [ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens
</details>

- [ ] Je replie cette section car mes modifications n'ont pas besoin de tests unitaires ou d'intégration

---

<details><summary> POINTS D'ATTENTION POUR CETTE PR  :warning: </summary>

- [ ] J'ai fait des modifications sur une route utilisée sur plusieurs plateformes [Doc de détail](https://www.notion.so/Points-d-attention-sur-les-routes-a548a8e32d314d5e92cb342e66cce443)
- [ ] J'ai modifié un modèle utilisé en mobile [Doc de détail](https://www.notion.so/Point-d-attention-sur-les-mod-les-e46fbf180cd34a569f3c6102366e47ca)
- [ ] J'ai ajouté un modèle spécifique à une structure 
  - [ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés
- [ ] J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile
  - [ ] Si oui, j'ai précisé sur le [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) qu'il faut forcer la mise à jour
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [Doc de MES](https://www.notion.so/Pas-pas-Mise-en-staging-01755ac57d944b4cb0c189861428e5d2) et [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) les modifications faites

</details>

- [x] Je replie cette section car je n'ai pas fait de modifications entrainant un point d'attention

---

<details><summary> FONCTIONNALITÉS APPS MOBILES  :iphone: </summary>

- [ ] Mes changements impactent l'application formation
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours
- [ ] Mes changements impactent l'application erp
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours

</details>

- [x] Je replie cette section car mes modifications n'ont pas d'impact sur les applications mobiles

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : client coach/admin/auxiliaire

- Cas d'usage : je ne peux pas créer une absence sur un événement déjà horodaté

- Comment tester ? : créer une absence sur une période de temps contenant un événement horodaté => 409

_Si tu as lu cette description, pense à réagir avec un :eye:_
