### PR TITLE
COM-3022: add integration test

### DIFF
--- a/tests/integration/events.test.js
+++ b/tests/integration/events.test.js
@@ -398,7 +398,7 @@ describe('EVENTS ROUTES - GET /events/working-stats', () => {
 
       expect(response.statusCode).toEqual(200);
       expect(response.result.data.workingStats[auxiliaries[0]._id].hoursToWork).toEqual(2);
-      expect(response.result.data.workingStats[auxiliaries[0]._id].workedHours).toEqual(5.5);
+      expect(response.result.data.workingStats[auxiliaries[0]._id].workedHours).toEqual(7);
     });
 
     it('should return working stats for all auxiliaries', async () => {
@@ -1208,6 +1208,46 @@ describe('EVENTS ROUTES - POST /events', () => {
       });
 
       expect(response.statusCode).toEqual(403);
+    });
+
+    it('should return 409 if try to create absence on billed event', async () => {
+      const payload = {
+        type: ABSENCE,
+        startDate: '2019-01-16T00:00:00.000Z',
+        endDate: '2019-01-16T22:59:00.000Z',
+        auxiliary: eventsList[4].auxiliary,
+        absenceNature: DAILY,
+        absence: PARENTAL_LEAVE,
+      };
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/events',
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toEqual(409);
+    });
+
+    it('should return 409 if try to create absence on timestamped event', async () => {
+      const payload = {
+        type: ABSENCE,
+        startDate: '2019-01-17T00:00:00.000Z',
+        endDate: '2019-01-17T22:59:00.000Z',
+        auxiliary: eventsList[28].auxiliary,
+        absenceNature: DAILY,
+        absence: PARENTAL_LEAVE,
+      };
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/events',
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toEqual(409);
     });
   });
 

--- a/tests/integration/seed/eventsSeed.js
+++ b/tests/integration/seed/eventsSeed.js
@@ -978,6 +978,25 @@ const eventsList = [
       location: { type: 'Point', coordinates: [2.377133, 48.801389] },
     },
   },
+  { // 28
+    _id: new ObjectId(),
+    company: authCompany._id,
+    type: INTERVENTION,
+    repetition: { frequency: NEVER },
+    startDate: '2019-01-18T10:30:18.653Z',
+    endDate: '2019-01-18T12:00:18.653Z',
+    auxiliary: auxiliaries[0]._id,
+    customer: customerAuxiliaries[0]._id,
+    subscription: customerAuxiliaries[0].subscriptions[0]._id,
+    createdAt: '2022-01-05T15:24:18.653Z',
+    address: {
+      fullAddress: '4 rue du test 92160 Antony',
+      street: '4 rue du test',
+      zipCode: '92160',
+      city: 'Antony',
+      location: { type: 'Point', coordinates: [2.377133, 48.801389] },
+    },
+  },
 ];
 
 const eventFromOtherCompany = {
@@ -1044,6 +1063,14 @@ const eventHistoriesList = [
     manualTimeStampingReason: 'qrcode_missing',
     auxiliaries: [eventsList[24].auxiliary],
     update: { endHour: { from: eventsList[24].endDate, to: timeStampingDate } },
+  },
+  {
+    event: { eventId: eventsList[28]._id, endDate: eventsList[28].endDate, type: INTERVENTION },
+    company: eventsList[28].company,
+    action: 'manual_time_stamping',
+    manualTimeStampingReason: 'qrcode_missing',
+    auxiliaries: [eventsList[28].auxiliary],
+    update: { endHour: { from: eventsList[28].endDate, to: eventsList[28].endDate } },
   },
 ];
 


### PR DESCRIPTION
<details open><summary> TESTS  :computer: </summary>

- [ ] J'ai codé les tests unitaires -np
- [x] J'ai codé les tests d'intégration
- [ ] ~~C'est une ancienne route utilisée par les apps mobiles.~~
  - [ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens
</details>

- [ ] Je replie cette section car mes modifications n'ont pas besoin de tests unitaires ou d'intégration

---

<details><summary> POINTS D'ATTENTION POUR CETTE PR  :warning: </summary>

- [ ] J'ai fait des modifications sur une route utilisée sur plusieurs plateformes [Doc de détail](https://www.notion.so/Points-d-attention-sur-les-routes-a548a8e32d314d5e92cb342e66cce443)
- [ ] J'ai modifié un modèle utilisé en mobile [Doc de détail](https://www.notion.so/Point-d-attention-sur-les-mod-les-e46fbf180cd34a569f3c6102366e47ca)
- [ ] J'ai ajouté un modèle spécifique à une structure 
  - [ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés
- [ ] J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile
  - [ ] Si oui, j'ai précisé sur le [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) qu'il faut forcer la mise à jour
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [Doc de MES](https://www.notion.so/Pas-pas-Mise-en-staging-01755ac57d944b4cb0c189861428e5d2) et [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) les modifications faites

</details>

- [x] Je replie cette section car je n'ai pas fait de modifications entrainant un point d'attention

---

<details><summary> FONCTIONNALITÉS APPS MOBILES  :iphone: </summary>

- [ ] Mes changements impactent l'application formation
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours
- [ ] Mes changements impactent l'application erp
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours

</details>

- [x] Je replie cette section car mes modifications n'ont pas d'impact sur les applications mobiles

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : client auxiliaire

- Cas d'usage : ajout de test d'intégration pour vérifier qu'on bloque la création d'absence sur des événements facturés ou horodatés

- Comment tester ? : faire tourner les tests d'intégration

_Si tu as lu cette description, pense à réagir avec un :eye:_
