### PR TITLE
COM-3213 CompaniDuration accepts iso string

### DIFF
--- a/src/helpers/dates/companiDurations.js
+++ b/src/helpers/dates/companiDurations.js
@@ -38,6 +38,8 @@ exports._formatMiscToCompaniDuration = (...args) => {
   if (args.length === 0) return luxon.Duration.fromObject({});
 
   if (args.length === 1) {
+    if (typeof args[0] === 'string') return luxon.Duration.fromISO(args[0]);
+
     if (args[0] instanceof Object) {
       if (args[0]._getDuration && args[0]._getDuration instanceof luxon.Duration) return args[0]._getDuration;
       if (Object.keys(args[0]).every(key => DURATION_UNITS.includes(key))) return luxon.Duration.fromObject(args[0]);

--- a/tests/unit/helpers/dates/companiDuration.test.js
+++ b/tests/unit/helpers/dates/companiDuration.test.js
@@ -58,7 +58,8 @@ describe('CompaniDuration', () => {
 
         expect(true).toBe(false);
       } catch (e) {
-        console.error(e);
+        expect(e)
+          .toEqual(new Error('Invalid Duration: unparsable: the input "P1Y2M2D3H4M2S" can\'t be parsed as ISO 8601'));
       } finally {
         sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDuration, 'P1Y2M2D3H4M2S');
       }

--- a/tests/unit/helpers/dates/companiDuration.test.js
+++ b/tests/unit/helpers/dates/companiDuration.test.js
@@ -39,6 +39,31 @@ describe('CompaniDuration', () => {
       sinon.assert.calledWithExactly(_formatMiscToCompaniDuration.getCall(0), duration);
     });
 
+    it('should return duration from iso', () => {
+      const result = CompaniDurationsHelper.CompaniDuration('P1Y2M2DT3H4M2S');
+
+      expect(result)
+        .toEqual(expect.objectContaining({
+          _getDuration: expect.any(luxon.Duration),
+          format: expect.any(Function),
+          add: expect.any(Function),
+          asHours: expect.any(Function),
+        }));
+      sinon.assert.calledWithExactly(_formatMiscToCompaniDuration.getCall(0), 'P1Y2M2DT3H4M2S');
+    });
+
+    it('should return error if invalid iso string', () => {
+      try {
+        CompaniDurationsHelper.CompaniDuration('P1Y2M2D3H4M2S');
+
+        expect(true).toBe(false);
+      } catch (e) {
+        console.error(e);
+      } finally {
+        sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDuration, 'P1Y2M2D3H4M2S');
+      }
+    });
+
     it('should return error if invalid argument', () => {
       try {
         CompaniDurationsHelper.CompaniDuration(null);


### PR DESCRIPTION
<details open><summary> TESTS  :computer: </summary>

- [x] J'ai codé les tests unitaires
- [ ] J'ai codé les tests d'intégration -np
- [ ] C'est une ancienne route utilisée par les apps mobiles.
  - [ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens
</details>

- [ ] Je replie cette section car mes modifications n'ont pas besoin de tests unitaires ou d'intégration

---

<details open><summary> POINTS D'ATTENTION POUR CETTE PR  :warning: </summary>

- [ ] J'ai fait des modifications sur une route utilisée sur plusieurs plateformes [Doc de détail](https://www.notion.so/Points-d-attention-sur-les-routes-a548a8e32d314d5e92cb342e66cce443)
- [ ] J'ai modifié un modèle utilisé en mobile [Doc de détail](https://www.notion.so/Point-d-attention-sur-les-mod-les-e46fbf180cd34a569f3c6102366e47ca)
- [ ] J'ai ajouté un modèle spécifique à une structure 
  - [ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés
- [ ] J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile
  - [ ] Si oui, j'ai précisé sur le [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) qu'il faut forcer la mise à jour
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [Doc de MES](https://www.notion.so/Pas-pas-Mise-en-staging-01755ac57d944b4cb0c189861428e5d2) et [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) les modifications faites

</details>

- [ ] Je replie cette section car je n'ai pas fait de modifications entrainant un point d'attention

---

<details open><summary> FONCTIONNALITÉS APPS MOBILES  :iphone: </summary>

- [ ] Mes changements impactent l'application formation
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours
- [ ] Mes changements impactent l'application erp
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours

</details>

- [ ] Je replie cette section car mes modifications n'ont pas d'impact sur les applications mobiles

---

### POUR TESTER LA PR  :white_check_mark:

Note : normalement ce ticket et les suivants peuvent aller directement sur dev, il n'y a pas de modifications qui cassent des fonctionnalités

- Périmètre interfaces / rôles : np

- Cas d'usage : CompaniDuration accepte a présent les durées ISO 

- Comment tester ? : 
     - Vérifier les tests unitaires 
     - Si vous voulez vérifier le fonctionnement sur un cas concret + comprendre comment fonctionne les strings iso : Vous pouvez tester avec l'appel à CompaniDuration dans step `getPresenceStepProgress`, et regarder sur le profil d'un apprenant comment change son nombre d'heure de présence à une étape d'une formation. (⚠️ si il y a deux etapes dans la formation et que vous passer d'une initialisation a 0 minute à 60 minutes, cela va ajouter 2h de presence a la formation car c'est un calcul par etape) 

Doc utile : https://fr.wikipedia.org/wiki/ISO_8601#Dur%C3%A9e

_Si tu as lu cette description, pense à réagir avec un :eye:_
