### PR TITLE
Com 3215

### DIFF
--- a/src/helpers/dates/companiDates.js
+++ b/src/helpers/dates/companiDates.js
@@ -112,6 +112,20 @@ const CompaniDateFactory = (inputDate) => {
       return { [unit]: floatedDiff > 0 ? Math.floor(floatedDiff) : Math.ceil(floatedDiff) };
     },
 
+    diff(miscTypeOtherDate, unit, typeFloat = false) {
+      if (typeof unit !== 'string') throw Error('Invalid argument: expected unit to be a string');
+
+      const otherDate = exports._formatMiscToCompaniDate(miscTypeOtherDate);
+      const floatedDiff = _date.diff(otherDate, unit);
+
+      if (typeFloat) return floatedDiff.toISO();
+
+      const diffAsUnit = floatedDiff.as(unit);
+      const intDiff = diffAsUnit > 0 ? Math.floor(diffAsUnit) : Math.ceil(diffAsUnit);
+
+      return floatedDiff.set({ [unit]: intDiff }).toISO();
+    },
+
     add(amount) {
       if (amount instanceof Number) throw Error('Invalid argument: expected to be an object, got number');
       return CompaniDateFactory(_date.plus(amount));

--- a/src/helpers/dates/companiDates.js
+++ b/src/helpers/dates/companiDates.js
@@ -112,18 +112,13 @@ const CompaniDateFactory = (inputDate) => {
       return { [unit]: floatedDiff > 0 ? Math.floor(floatedDiff) : Math.ceil(floatedDiff) };
     },
 
-    diff(miscTypeOtherDate, unit, typeFloat = false) {
+    diff(miscTypeOtherDate, unit) {
       if (typeof unit !== 'string') throw Error('Invalid argument: expected unit to be a string');
 
       const otherDate = exports._formatMiscToCompaniDate(miscTypeOtherDate);
       const floatedDiff = _date.diff(otherDate, unit);
 
-      if (typeFloat) return floatedDiff.toISO();
-
-      const diffAsUnit = floatedDiff.as(unit);
-      const intDiff = diffAsUnit > 0 ? Math.floor(diffAsUnit) : Math.ceil(diffAsUnit);
-
-      return floatedDiff.set({ [unit]: intDiff }).toISO();
+      return floatedDiff.toISO();
     },
 
     add(amount) {

--- a/src/helpers/steps.js
+++ b/src/helpers/steps.js
@@ -40,13 +40,13 @@ exports.getPresenceStepProgress = (slots) => {
     attendanceDuration: slots
       .reduce(
         (acc, slot) => (slot.attendances.length
-          ? acc.add(CompaniDate(slot.endDate).oldDiff(slot.startDate, 'minutes'))
+          ? acc.add(CompaniDate(slot.endDate).diff(slot.startDate, 'minutes'))
           : acc),
-        CompaniDuration({ minutes: 0 })
+        CompaniDuration()
       )
       .toObject(),
     maxDuration: slots
-      .reduce((acc, slot) => acc.add(CompaniDate(slot.endDate).oldDiff(slot.startDate, 'minutes')), CompaniDuration())
+      .reduce((acc, slot) => acc.add(CompaniDate(slot.endDate).diff(slot.startDate, 'minutes')), CompaniDuration())
       .toObject(),
   };
 };

--- a/src/helpers/steps.js
+++ b/src/helpers/steps.js
@@ -36,17 +36,20 @@ exports.getLiveStepProgress = (slots) => {
 exports.getPresenceStepProgress = (slots) => {
   if (!slots.length) return { attendanceDuration: { minutes: 0 }, maxDuration: { minutes: 0 } };
 
-  return {
-    attendanceDuration: slots
+  const slotsWithDuration = slots.map(s => ({ ...s, duration: CompaniDate(s.endDate).diff(s.startDate, 'minutes') }));
+
+  const attendanceDuration = slotsWithDuration.some(s => s.attendances.length)
+    ? slotsWithDuration
       .reduce(
-        (acc, slot) => (slot.attendances.length
-          ? acc.add(CompaniDate(slot.endDate).diff(slot.startDate, 'minutes'))
-          : acc),
+        (acc, slot) => (slot.attendances.length ? acc.add(slot.duration) : acc),
         CompaniDuration()
-      )
-      .toObject(),
-    maxDuration: slots
-      .reduce((acc, slot) => acc.add(CompaniDate(slot.endDate).diff(slot.startDate, 'minutes')), CompaniDuration())
+      ).toObject()
+    : { minutes: 0 };
+
+  return {
+    attendanceDuration,
+    maxDuration: slotsWithDuration
+      .reduce((acc, s) => acc.add(s.duration), CompaniDuration())
       .toObject(),
   };
 };

--- a/tests/unit/helpers/dates/companiDates.test.js
+++ b/tests/unit/helpers/dates/companiDates.test.js
@@ -817,35 +817,11 @@ describe('MANIPULATE', () => {
       sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, otherDate);
     });
 
-    it('should return difference in days. Result should be 1 if difference is between 24h and 48h', () => {
-      const otherDate = '2021-11-22T21:00:00.000Z';
-      const result = companiDate.diff(otherDate, 'days');
-
-      expect(result).toStrictEqual('P1D');
-      sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, otherDate);
-    });
-
-    it('should return difference in days. Result should be 0 if difference is less than 24h', () => {
-      const otherDate = '2021-11-23T21:00:00.000Z';
-      const result = companiDate.diff(otherDate, 'days');
-
-      expect(result).toStrictEqual('PT0S');
-      sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, otherDate);
-    });
-
     it('should return difference in negative days', () => {
       const otherDate = '2021-11-30T10:00:00.000Z';
       const result = companiDate.diff(otherDate, 'days');
 
       expect(result).toStrictEqual('P-6D');
-      sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, otherDate);
-    });
-
-    it('should return difference in float if typeFloat param', () => {
-      const otherDate = '2021-11-20T22:00:00.000Z';
-      const result = companiDate.diff(otherDate, 'days', true);
-
-      expect(result).toStrictEqual('P3.5D');
       sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, otherDate);
     });
 

--- a/tests/unit/helpers/dates/companiDates.test.js
+++ b/tests/unit/helpers/dates/companiDates.test.js
@@ -825,6 +825,13 @@ describe('MANIPULATE', () => {
       sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, otherDate);
     });
 
+    it('should return difference 0', () => {
+      const result = companiDate.diff(companiDate, 'days');
+
+      expect(result).toStrictEqual('PT0S');
+      sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, companiDate);
+    });
+
     it('should return difference in positive day (singular) /!\\ bad practice to use singular', () => {
       const otherDate = '2021-11-20T10:00:00.000Z';
       const result = companiDate.diff(otherDate, 'day');

--- a/tests/unit/helpers/dates/companiDates.test.js
+++ b/tests/unit/helpers/dates/companiDates.test.js
@@ -789,7 +789,7 @@ describe('MANIPULATE', () => {
     });
   });
 
-  describe('diff #tag', () => {
+  describe('diff', () => {
     let _formatMiscToCompaniDate;
     const companiDate = CompaniDatesHelper.CompaniDate('2021-11-24T10:00:00.000Z');
 

--- a/tests/unit/helpers/dates/companiDates.test.js
+++ b/tests/unit/helpers/dates/companiDates.test.js
@@ -788,6 +788,122 @@ describe('MANIPULATE', () => {
       }
     });
   });
+
+  describe('diff #tag', () => {
+    let _formatMiscToCompaniDate;
+    const companiDate = CompaniDatesHelper.CompaniDate('2021-11-24T10:00:00.000Z');
+
+    beforeEach(() => {
+      _formatMiscToCompaniDate = sinon.spy(CompaniDatesHelper, '_formatMiscToCompaniDate');
+    });
+
+    afterEach(() => {
+      _formatMiscToCompaniDate.restore();
+    });
+
+    it('should return difference in positive days', () => {
+      const otherDate = '2021-11-20T10:00:00.000Z';
+      const result = companiDate.diff(otherDate, 'days');
+
+      expect(result).toStrictEqual('P4D');
+      sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, otherDate);
+    });
+
+    it('should return difference in positive minutes', () => {
+      const otherDate = '2021-11-20T10:00:00.000Z';
+      const result = companiDate.diff(otherDate, 'minutes');
+
+      expect(result).toStrictEqual('PT5760M');
+      sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, otherDate);
+    });
+
+    it('should return difference in days. Result should be 1 if difference is between 24h and 48h', () => {
+      const otherDate = '2021-11-22T21:00:00.000Z';
+      const result = companiDate.diff(otherDate, 'days');
+
+      expect(result).toStrictEqual('P1D');
+      sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, otherDate);
+    });
+
+    it('should return difference in days. Result should be 0 if difference is less than 24h', () => {
+      const otherDate = '2021-11-23T21:00:00.000Z';
+      const result = companiDate.diff(otherDate, 'days');
+
+      expect(result).toStrictEqual('PT0S');
+      sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, otherDate);
+    });
+
+    it('should return difference in negative days', () => {
+      const otherDate = '2021-11-30T10:00:00.000Z';
+      const result = companiDate.diff(otherDate, 'days');
+
+      expect(result).toStrictEqual('P-6D');
+      sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, otherDate);
+    });
+
+    it('should return difference in float if typeFloat param', () => {
+      const otherDate = '2021-11-20T22:00:00.000Z';
+      const result = companiDate.diff(otherDate, 'days', true);
+
+      expect(result).toStrictEqual('P3.5D');
+      sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, otherDate);
+    });
+
+    it('should return difference in positive day (singular) /!\\ bad practice to use singular', () => {
+      const otherDate = '2021-11-20T10:00:00.000Z';
+      const result = companiDate.diff(otherDate, 'day');
+
+      expect(result).toStrictEqual('P4D');
+      sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, otherDate);
+    });
+
+    it('should return error if invalid otherDate', () => {
+      try {
+        companiDate.diff(null, 'days');
+
+        expect(true).toBe(false);
+      } catch (e) {
+        expect(e).toEqual(new Error('Invalid DateTime: wrong arguments'));
+      } finally {
+        sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, null);
+      }
+    });
+
+    it('should return error if many units', () => {
+      const otherDate = '2021-11-30T08:00:00.000Z';
+      try {
+        companiDate.diff(otherDate, ['days', 'minutes']);
+
+        expect(true).toBe(false);
+      } catch (e) {
+        expect(e).toEqual(new Error('Invalid argument: expected unit to be a string'));
+      }
+    });
+
+    it('should return error if invalid unit', () => {
+      const otherDate = '2021-11-30T08:00:00.000Z';
+      try {
+        companiDate.diff(otherDate, 'jour');
+
+        expect(true).toBe(false);
+      } catch (e) {
+        expect(e).toEqual(new Error('Invalid unit jour'));
+      } finally {
+        sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, otherDate);
+      }
+    });
+
+    it('should return error if missing unit', () => {
+      const otherDate = '2021-11-30T08:00:00.000Z';
+      try {
+        companiDate.diff(otherDate);
+
+        expect(true).toBe(false);
+      } catch (e) {
+        expect(e).toEqual(new Error('Invalid argument: expected unit to be a string'));
+      }
+    });
+  });
 });
 
 describe('Old functions to be deleted', () => {

--- a/tests/unit/helpers/dates/companiDates.test.js
+++ b/tests/unit/helpers/dates/companiDates.test.js
@@ -825,7 +825,7 @@ describe('MANIPULATE', () => {
       sinon.assert.calledOnceWithExactly(_formatMiscToCompaniDate, otherDate);
     });
 
-    it('should return difference 0', () => {
+    it('should return difference 0 expressed in second (despite that diff was made in days)', () => {
       const result = companiDate.diff(companiDate, 'days');
 
       expect(result).toStrictEqual('PT0S');


### PR DESCRIPTION
<details open><summary> TESTS  :computer: </summary>

- [x] J'ai codé les tests unitaires
- [ ] J'ai codé les tests d'intégration -np
- [ ] C'est une ancienne route utilisée par les apps mobiles.
  - [ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens
</details>

- [ ] Je replie cette section car mes modifications n'ont pas besoin de tests unitaires ou d'intégration

---

<details><summary> POINTS D'ATTENTION POUR CETTE PR  :warning: </summary>

- [ ] J'ai fait des modifications sur une route utilisée sur plusieurs plateformes [Doc de détail](https://www.notion.so/Points-d-attention-sur-les-routes-a548a8e32d314d5e92cb342e66cce443)
- [ ] J'ai modifié un modèle utilisé en mobile [Doc de détail](https://www.notion.so/Point-d-attention-sur-les-mod-les-e46fbf180cd34a569f3c6102366e47ca)
- [ ] J'ai ajouté un modèle spécifique à une structure 
  - [ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés
- [ ] J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile
  - [ ] Si oui, j'ai précisé sur le [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) qu'il faut forcer la mise à jour
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [Doc de MES](https://www.notion.so/Pas-pas-Mise-en-staging-01755ac57d944b4cb0c189861428e5d2) et [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) les modifications faites

</details>

- [ ] Je replie cette section car je n'ai pas fait de modifications entrainant un point d'attention

---

<details><summary> FONCTIONNALITÉS APPS MOBILES  :iphone: </summary>

- [ ] Mes changements impactent l'application formation
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours
- [ ] Mes changements impactent l'application erp
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours

</details>

- [ ] Je replie cette section car mes modifications n'ont pas d'impact sur les applications mobiles

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : coach/rof

- Cas d'usage : ajout de la nouvelle methode diff + utilisation dans helper/steps

- Comment tester ? : Vérifier la duree des emargements sur le tableau de suivi sur une fiche apprenant
Note : j'ai l'impression que quand on demande l'iso à Duration avec 0, il renvoit `PT0S` quelque soit l'unité dans laquelle on lui a donné. 

_Si tu as lu cette description, pense à réagir avec un :eye:_
