### PR TITLE
Com 3218

### DIFF
--- a/src/helpers/dates/companiDates.js
+++ b/src/helpers/dates/companiDates.js
@@ -126,9 +126,15 @@ const CompaniDateFactory = (inputDate) => {
       return CompaniDateFactory(_date.plus(isoDuration));
     },
 
+    // fct to be deleted
     oldAdd(amount) {
       if (amount instanceof Number) throw Error('Invalid argument: expected to be an object, got number');
       return CompaniDateFactory(_date.plus(amount));
+    },
+
+    subtract(amount) {
+      const isoDuration = luxon.Duration.fromISO(amount);
+      return CompaniDateFactory(_date.minus(isoDuration));
     },
 
     // fct to be deleted

--- a/tests/unit/helpers/dates/companiDates.test.js
+++ b/tests/unit/helpers/dates/companiDates.test.js
@@ -53,6 +53,7 @@ describe('CompaniDate', () => {
           oldDiff: expect.any(Function),
           add: expect.any(Function),
           oldAdd: expect.any(Function),
+          subtract: expect.any(Function),
           oldSubtract: expect.any(Function),
           set: expect.any(Function),
         }));
@@ -883,6 +884,62 @@ describe('MANIPULATE', () => {
     it('should return error if number', () => {
       try {
         CompaniDatesHelper.CompaniDate('2022-01-01T00:00:00.000Z').add(12);
+
+        expect(true).toBe(false);
+      } catch (e) {
+        expect(e).toEqual(
+          new Error('Invalid Duration: unparsable: the input "12" can\'t be parsed as ISO 8601')
+        );
+      }
+    });
+  });
+
+  describe('subtract', () => {
+    it('should subtract iso amount to date', () => {
+      const result = CompaniDatesHelper.CompaniDate('2022-01-01T00:00:00.000Z').subtract('P1Y2M3DT1H15M33S');
+
+      expect(result.toISO()).toBe('2020-10-28T22:44:27.000Z');
+    });
+
+    it('should return error if invalid iso duration', () => {
+      try {
+        CompaniDatesHelper.CompaniDate('2022-01-01T00:00:00.000Z').subtract('P1M3Y');
+
+        expect(true).toBe(false);
+      } catch (e) {
+        expect(e).toEqual(
+          new Error('Invalid Duration: unparsable: the input "P1M3Y" can\'t be parsed as ISO 8601')
+        );
+      }
+    });
+
+    it('should return error if instance of CompaniDuration', () => {
+      try {
+        CompaniDatesHelper.CompaniDate('2022-01-01T00:00:00.000Z').subtract(CompaniDuration('PT1M'));
+
+        expect(true).toBe(false);
+      } catch (e) {
+        expect(e).toEqual(
+          new Error('Invalid Duration: unparsable: the input "[object Object]" can\'t be parsed as ISO 8601')
+        );
+      }
+    });
+
+    it('should return error if object', () => {
+      try {
+        CompaniDatesHelper.CompaniDate('2022-01-01T00:00:00.000Z').subtract({ minute: 1 });
+
+        expect(true).toBe(false);
+      } catch (e) {
+        expect(e).toEqual(
+          new Error('Invalid Duration: unparsable: the input "[object Object]" can\'t be parsed as ISO 8601')
+        );
+      }
+    });
+
+    it('should return error if number', () => {
+      try {
+        CompaniDatesHelper.CompaniDate('2022-01-01T00:00:00.000Z').subtract(12);
 
         expect(true).toBe(false);
       } catch (e) {

--- a/tests/unit/helpers/dates/companiDates.test.js
+++ b/tests/unit/helpers/dates/companiDates.test.js
@@ -51,6 +51,7 @@ describe('CompaniDate', () => {
           endOf: expect.any(Function),
           diff: expect.any(Function),
           oldDiff: expect.any(Function),
+          add: expect.any(Function),
           oldAdd: expect.any(Function),
           oldSubtract: expect.any(Function),
           set: expect.any(Function),
@@ -718,33 +719,6 @@ describe('MANIPULATE', () => {
     });
   });
 
-  describe('subtract', () => {
-    const companiDate = CompaniDatesHelper.CompaniDate('2021-12-01T07:00:00.000Z');
-
-    it('should return a newly constructed companiDate, decreased by amount', () => {
-      const result = companiDate.oldSubtract({ months: 1, hours: 2 });
-
-      expect(result).toEqual(expect.objectContaining({ _getDate: expect.any(luxon.DateTime) }));
-      expect(result._getDate.toUTC().toISO()).toEqual('2021-11-01T05:00:00.000Z');
-    });
-
-    it('should return error if invalid unit', () => {
-      try {
-        companiDate.oldSubtract({ jour: 1, hours: 2 });
-      } catch (e) {
-        expect(e).toEqual(new Error('Invalid unit jour'));
-      }
-    });
-
-    it('should return error if amount is number', () => {
-      try {
-        companiDate.oldSubtract(11111);
-      } catch (e) {
-        expect(e).toEqual(new Error('Invalid argument: expected to be an object, got number'));
-      }
-    });
-  });
-
   describe('set', () => {
     const companiDate = CompaniDatesHelper.CompaniDate('2021-12-20T07:00:00.000Z');
 
@@ -1027,6 +1001,33 @@ describe('Old functions to be deleted', () => {
     it('should return error if amount is number', () => {
       try {
         companiDate.oldAdd(11111);
+      } catch (e) {
+        expect(e).toEqual(new Error('Invalid argument: expected to be an object, got number'));
+      }
+    });
+  });
+
+  describe('oldSubtract', () => {
+    const companiDate = CompaniDatesHelper.CompaniDate('2021-12-01T07:00:00.000Z');
+
+    it('should return a newly constructed companiDate, decreased by amount', () => {
+      const result = companiDate.oldSubtract({ months: 1, hours: 2 });
+
+      expect(result).toEqual(expect.objectContaining({ _getDate: expect.any(luxon.DateTime) }));
+      expect(result._getDate.toUTC().toISO()).toEqual('2021-11-01T05:00:00.000Z');
+    });
+
+    it('should return error if invalid unit', () => {
+      try {
+        companiDate.oldSubtract({ jour: 1, hours: 2 });
+      } catch (e) {
+        expect(e).toEqual(new Error('Invalid unit jour'));
+      }
+    });
+
+    it('should return error if amount is number', () => {
+      try {
+        companiDate.oldSubtract(11111);
       } catch (e) {
         expect(e).toEqual(new Error('Invalid argument: expected to be an object, got number'));
       }


### PR DESCRIPTION
<details open><summary> TESTS  :computer: </summary>

- [x] J'ai codé les tests unitaires
- [ ] J'ai codé les tests d'intégration
- [ ] C'est une ancienne route utilisée par les apps mobiles.
  - [ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens
</details>

- [ ] Je replie cette section car mes modifications n'ont pas besoin de tests unitaires ou d'intégration

---

<details><summary> POINTS D'ATTENTION POUR CETTE PR  :warning: </summary>

- [ ] J'ai fait des modifications sur une route utilisée sur plusieurs plateformes [Doc de détail](https://www.notion.so/Points-d-attention-sur-les-routes-a548a8e32d314d5e92cb342e66cce443)
- [ ] J'ai modifié un modèle utilisé en mobile [Doc de détail](https://www.notion.so/Point-d-attention-sur-les-mod-les-e46fbf180cd34a569f3c6102366e47ca)
- [ ] J'ai ajouté un modèle spécifique à une structure 
  - [ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés
- [ ] J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile
  - [ ] Si oui, j'ai précisé sur le [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) qu'il faut forcer la mise à jour
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [Doc de MES](https://www.notion.so/Pas-pas-Mise-en-staging-01755ac57d944b4cb0c189861428e5d2) et [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) les modifications faites

</details>

- [x] Je replie cette section car je n'ai pas fait de modifications entrainant un point d'attention

---

<details><summary> FONCTIONNALITÉS APPS MOBILES  :iphone: </summary>

- [ ] Mes changements impactent l'application formation
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours
- [ ] Mes changements impactent l'application erp
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours

</details>

- [x] Je replie cette section car mes modifications n'ont pas d'impact sur les applications mobiles

_Si tu as lu cette description, pense à réagir avec un :eye:_
