### PR TITLE
COM-3248: add toISO method

### DIFF
--- a/src/helpers/dates/companiDurations.js
+++ b/src/helpers/dates/companiDurations.js
@@ -7,21 +7,17 @@ const companiDurationFactory = (inputDuration) => {
   const _duration = inputDuration;
 
   return {
+    // GETTER
     get _getDuration() {
       return _duration;
     },
 
+    // DISPLAY
     format() {
       const durationInHoursAndMinutes = _duration.shiftTo('hours', 'minutes');
       const format = Math.floor(durationInHoursAndMinutes.get('minutes')) > 0 ? 'h\'h\'mm' : 'h\'h\'';
 
       return _duration.toFormat(format);
-    },
-
-    add(miscTypeOtherDuration) {
-      const otherDuration = exports._formatMiscToCompaniDuration(miscTypeOtherDuration);
-
-      return companiDurationFactory(_duration.plus(otherDuration));
     },
 
     asHours() {
@@ -34,6 +30,13 @@ const companiDurationFactory = (inputDuration) => {
 
     toISO() {
       return _duration.toISO();
+    },
+
+    // MANIPULATE
+    add(miscTypeOtherDuration) {
+      const otherDuration = exports._formatMiscToCompaniDuration(miscTypeOtherDuration);
+
+      return companiDurationFactory(_duration.plus(otherDuration));
     },
   };
 };

--- a/src/helpers/dates/companiDurations.js
+++ b/src/helpers/dates/companiDurations.js
@@ -31,6 +31,10 @@ const companiDurationFactory = (inputDuration) => {
     toObject() {
       return _duration.toObject();
     },
+
+    toISO() {
+      return _duration.toISO();
+    },
   };
 };
 

--- a/tests/unit/helpers/dates/companiDuration.test.js
+++ b/tests/unit/helpers/dates/companiDuration.test.js
@@ -158,6 +158,28 @@ describe('toObject', () => {
   });
 });
 
+describe('toISO', () => {
+  const duration = 'PT2H30M';
+
+  it('should return ISO string if argument is ISO string', () => {
+    const result = CompaniDurationsHelper.CompaniDuration('PT2H30M').toISO();
+
+    expect(result).toEqual(duration);
+  });
+
+  it('should return ISO string if argument is object', () => {
+    const result = CompaniDurationsHelper.CompaniDuration({ hours: 2, minutes: 30 }).toISO();
+
+    expect(result).toEqual(duration);
+  });
+
+  it('should return PT0S if no argument', () => {
+    const result = CompaniDurationsHelper.CompaniDuration().toISO();
+
+    expect(result).toEqual('PT0S');
+  });
+});
+
 describe('_formatMiscToCompaniDuration', () => {
   let fromObject;
   let fromMillis;

--- a/tests/unit/helpers/dates/companiDuration.test.js
+++ b/tests/unit/helpers/dates/companiDuration.test.js
@@ -33,8 +33,10 @@ describe('CompaniDuration', () => {
         .toEqual(expect.objectContaining({
           _getDuration: expect.any(luxon.Duration),
           format: expect.any(Function),
-          add: expect.any(Function),
           asHours: expect.any(Function),
+          toObject: expect.any(Function),
+          toISO: expect.any(Function),
+          add: expect.any(Function),
         }));
       sinon.assert.calledWithExactly(_formatMiscToCompaniDuration.getCall(0), duration);
     });
@@ -112,30 +114,6 @@ describe('format', () => {
   });
 });
 
-describe('add', () => {
-  let _formatMiscToCompaniDuration;
-  const durationAmount = { hours: 1 };
-  const companiDuration = CompaniDurationsHelper.CompaniDuration(durationAmount);
-
-  beforeEach(() => {
-    _formatMiscToCompaniDuration = sinon.spy(CompaniDurationsHelper, '_formatMiscToCompaniDuration');
-  });
-
-  afterEach(() => {
-    _formatMiscToCompaniDuration.restore();
-  });
-
-  it('should increase a newly constructed companiDuration, increased by amount', () => {
-    const addedAmount = { hours: 2, minutes: 5 };
-    const result = companiDuration.add(addedAmount);
-
-    expect(result).toEqual(expect.objectContaining({ _getDuration: expect.any(luxon.Duration) }));
-    const amountInMs = (durationAmount.hours + addedAmount.hours) * 60 * 60 * 1000 + addedAmount.minutes * 60 * 1000;
-    expect(result._getDuration.toMillis()).toBe(amountInMs);
-    sinon.assert.calledWithExactly(_formatMiscToCompaniDuration.getCall(0), addedAmount);
-  });
-});
-
 describe('asHours', () => {
   const durationAmount = { hours: 1, minutes: 9 };
   const companiDuration = CompaniDurationsHelper.CompaniDuration(durationAmount);
@@ -162,7 +140,7 @@ describe('toISO', () => {
   const duration = 'PT2H30M';
 
   it('should return ISO string if argument is ISO string', () => {
-    const result = CompaniDurationsHelper.CompaniDuration('PT2H30M').toISO();
+    const result = CompaniDurationsHelper.CompaniDuration(duration).toISO();
 
     expect(result).toEqual(duration);
   });
@@ -177,6 +155,36 @@ describe('toISO', () => {
     const result = CompaniDurationsHelper.CompaniDuration().toISO();
 
     expect(result).toEqual('PT0S');
+  });
+
+  it('should return PT0S if duration worths 0 month', () => {
+    const result = CompaniDurationsHelper.CompaniDuration('P0M').toISO();
+
+    expect(result).toEqual('PT0S');
+  });
+});
+
+describe('add', () => {
+  let _formatMiscToCompaniDuration;
+  const durationAmount = { hours: 1 };
+  const companiDuration = CompaniDurationsHelper.CompaniDuration(durationAmount);
+
+  beforeEach(() => {
+    _formatMiscToCompaniDuration = sinon.spy(CompaniDurationsHelper, '_formatMiscToCompaniDuration');
+  });
+
+  afterEach(() => {
+    _formatMiscToCompaniDuration.restore();
+  });
+
+  it('should increase a newly constructed companiDuration, increased by amount', () => {
+    const addedAmount = { hours: 2, minutes: 5 };
+    const result = companiDuration.add(addedAmount);
+
+    expect(result).toEqual(expect.objectContaining({ _getDuration: expect.any(luxon.Duration) }));
+    const amountInMs = (durationAmount.hours + addedAmount.hours) * 60 * 60 * 1000 + addedAmount.minutes * 60 * 1000;
+    expect(result._getDuration.toMillis()).toBe(amountInMs);
+    sinon.assert.calledWithExactly(_formatMiscToCompaniDuration.getCall(0), addedAmount);
   });
 });
 

--- a/tests/unit/helpers/dates/companiDuration.test.js
+++ b/tests/unit/helpers/dates/companiDuration.test.js
@@ -52,139 +52,143 @@ describe('CompaniDuration', () => {
     });
   });
 });
+describe('GETTER', () => {
+  describe('getDuration', () => {
+    it('should return _duration', () => {
+      const durationObject = { hours: 3, minutes: 22, seconds: 57 };
+      const companiDuration = CompaniDurationsHelper.CompaniDuration(durationObject);
+      const result = companiDuration._getDuration;
 
-describe('getDuration', () => {
-  it('should return _duration', () => {
-    const durationObject = { hours: 3, minutes: 22, seconds: 57 };
-    const companiDuration = CompaniDurationsHelper.CompaniDuration(durationObject);
-    const result = companiDuration._getDuration;
-
-    expect(result).toEqual(expect.any(luxon.Duration));
-    expect(result).toEqual(luxon.Duration.fromObject(durationObject));
+      expect(result).toEqual(expect.any(luxon.Duration));
+      expect(result).toEqual(luxon.Duration.fromObject(durationObject));
+    });
   });
 });
 
-describe('format', () => {
-  it('should return formatted duration with minutes', () => {
-    const durationAmount = { hours: 5, minutes: 16 };
-    const companiDuration = CompaniDurationsHelper.CompaniDuration(durationAmount);
-    const result = companiDuration.format();
+describe('DISPLAY', () => {
+  describe('format', () => {
+    it('should return formatted duration with minutes', () => {
+      const durationAmount = { hours: 5, minutes: 16 };
+      const companiDuration = CompaniDurationsHelper.CompaniDuration(durationAmount);
+      const result = companiDuration.format();
 
-    expect(result).toBe('5h16');
+      expect(result).toBe('5h16');
+    });
+
+    it('should return formatted duration with minutes, leading zero on minutes', () => {
+      const durationAmount = { hours: 5, minutes: 3 };
+      const companiDuration = CompaniDurationsHelper.CompaniDuration(durationAmount);
+      const result = companiDuration.format();
+
+      expect(result).toBe('5h03');
+    });
+
+    it('should return formatted duration without minutes', () => {
+      const durationAmount = { hours: 13 };
+      const companiDuration = CompaniDurationsHelper.CompaniDuration(durationAmount);
+      const result = companiDuration.format();
+
+      expect(result).toBe('13h');
+    });
+
+    it('should return formatted duration, days are converted to hours', () => {
+      const durationAmount = { days: 2, hours: 1 };
+      const companiDuration = CompaniDurationsHelper.CompaniDuration(durationAmount);
+      const result = companiDuration.format();
+
+      expect(result).toBe('49h');
+    });
+
+    it('should return formatted duration with minutes, seconds and milliseconds have no effect', () => {
+      const durationAmount = { hours: 1, minutes: 2, seconds: 4 };
+      const companiDuration = CompaniDurationsHelper.CompaniDuration(durationAmount);
+      const result = companiDuration.format();
+
+      expect(result).toBe('1h02');
+    });
+
+    it('should return formatted duration without minutes, seconds and milliseconds have no effect', () => {
+      const durationAmount = { hours: 1, seconds: 9 };
+      const companiDuration = CompaniDurationsHelper.CompaniDuration(durationAmount);
+      const result = companiDuration.format();
+
+      expect(result).toBe('1h');
+    });
   });
 
-  it('should return formatted duration with minutes, leading zero on minutes', () => {
-    const durationAmount = { hours: 5, minutes: 3 };
+  describe('asHours', () => {
+    const durationAmount = { hours: 1, minutes: 9 };
     const companiDuration = CompaniDurationsHelper.CompaniDuration(durationAmount);
-    const result = companiDuration.format();
 
-    expect(result).toBe('5h03');
+    it('should return duration in hours', () => {
+      const result = companiDuration.asHours();
+
+      expect(result).toBe(1.15); // 1.15 = 1 + 9 / 60
+    });
   });
 
-  it('should return formatted duration without minutes', () => {
-    const durationAmount = { hours: 13 };
+  describe('toObject', () => {
+    const durationAmount = { hours: 1, minutes: 9 };
     const companiDuration = CompaniDurationsHelper.CompaniDuration(durationAmount);
-    const result = companiDuration.format();
 
-    expect(result).toBe('13h');
+    it('should return object from CompaniDuration', () => {
+      const result = companiDuration.toObject();
+
+      expect(result).toEqual(durationAmount);
+    });
   });
 
-  it('should return formatted duration, days are converted to hours', () => {
-    const durationAmount = { days: 2, hours: 1 };
-    const companiDuration = CompaniDurationsHelper.CompaniDuration(durationAmount);
-    const result = companiDuration.format();
+  describe('toISO', () => {
+    it('should return ISO string if argument is ISO string', () => {
+      const duration = 'PT2H30M';
+      const result = CompaniDurationsHelper.CompaniDuration(duration).toISO();
 
-    expect(result).toBe('49h');
-  });
+      expect(result).toEqual(duration);
+    });
 
-  it('should return formatted duration with minutes, seconds and milliseconds have no effect', () => {
-    const durationAmount = { hours: 1, minutes: 2, seconds: 4 };
-    const companiDuration = CompaniDurationsHelper.CompaniDuration(durationAmount);
-    const result = companiDuration.format();
+    it('should return ISO string if argument is object', () => {
+      const result = CompaniDurationsHelper.CompaniDuration({ hours: 2, minutes: 30 }).toISO();
 
-    expect(result).toBe('1h02');
-  });
+      expect(result).toEqual('PT2H30M');
+    });
 
-  it('should return formatted duration without minutes, seconds and milliseconds have no effect', () => {
-    const durationAmount = { hours: 1, seconds: 9 };
-    const companiDuration = CompaniDurationsHelper.CompaniDuration(durationAmount);
-    const result = companiDuration.format();
+    it('should return PT0S if no argument', () => {
+      const result = CompaniDurationsHelper.CompaniDuration().toISO();
 
-    expect(result).toBe('1h');
+      expect(result).toEqual('PT0S');
+    });
+
+    it('should return PT0S if duration worths 0 month', () => {
+      const result = CompaniDurationsHelper.CompaniDuration('P0M').toISO();
+
+      expect(result).toEqual('PT0S');
+    });
   });
 });
 
-describe('asHours', () => {
-  const durationAmount = { hours: 1, minutes: 9 };
-  const companiDuration = CompaniDurationsHelper.CompaniDuration(durationAmount);
+describe('MANIPULATE', () => {
+  describe('add', () => {
+    let _formatMiscToCompaniDuration;
+    const durationAmount = { hours: 1 };
+    const companiDuration = CompaniDurationsHelper.CompaniDuration(durationAmount);
 
-  it('should return duration in hours', () => {
-    const result = companiDuration.asHours();
+    beforeEach(() => {
+      _formatMiscToCompaniDuration = sinon.spy(CompaniDurationsHelper, '_formatMiscToCompaniDuration');
+    });
 
-    expect(result).toBe(1.15); // 1.15 = 1 + 9 / 60
-  });
-});
+    afterEach(() => {
+      _formatMiscToCompaniDuration.restore();
+    });
 
-describe('toObject', () => {
-  const durationAmount = { hours: 1, minutes: 9 };
-  const companiDuration = CompaniDurationsHelper.CompaniDuration(durationAmount);
+    it('should increase a newly constructed companiDuration, increased by amount', () => {
+      const addedAmount = { hours: 2, minutes: 5 };
+      const result = companiDuration.add(addedAmount);
 
-  it('should return object from CompaniDuration', () => {
-    const result = companiDuration.toObject();
-
-    expect(result).toEqual(durationAmount);
-  });
-});
-
-describe('toISO', () => {
-  const duration = 'PT2H30M';
-
-  it('should return ISO string if argument is ISO string', () => {
-    const result = CompaniDurationsHelper.CompaniDuration(duration).toISO();
-
-    expect(result).toEqual(duration);
-  });
-
-  it('should return ISO string if argument is object', () => {
-    const result = CompaniDurationsHelper.CompaniDuration({ hours: 2, minutes: 30 }).toISO();
-
-    expect(result).toEqual(duration);
-  });
-
-  it('should return PT0S if no argument', () => {
-    const result = CompaniDurationsHelper.CompaniDuration().toISO();
-
-    expect(result).toEqual('PT0S');
-  });
-
-  it('should return PT0S if duration worths 0 month', () => {
-    const result = CompaniDurationsHelper.CompaniDuration('P0M').toISO();
-
-    expect(result).toEqual('PT0S');
-  });
-});
-
-describe('add', () => {
-  let _formatMiscToCompaniDuration;
-  const durationAmount = { hours: 1 };
-  const companiDuration = CompaniDurationsHelper.CompaniDuration(durationAmount);
-
-  beforeEach(() => {
-    _formatMiscToCompaniDuration = sinon.spy(CompaniDurationsHelper, '_formatMiscToCompaniDuration');
-  });
-
-  afterEach(() => {
-    _formatMiscToCompaniDuration.restore();
-  });
-
-  it('should increase a newly constructed companiDuration, increased by amount', () => {
-    const addedAmount = { hours: 2, minutes: 5 };
-    const result = companiDuration.add(addedAmount);
-
-    expect(result).toEqual(expect.objectContaining({ _getDuration: expect.any(luxon.Duration) }));
-    const amountInMs = (durationAmount.hours + addedAmount.hours) * 60 * 60 * 1000 + addedAmount.minutes * 60 * 1000;
-    expect(result._getDuration.toMillis()).toBe(amountInMs);
-    sinon.assert.calledWithExactly(_formatMiscToCompaniDuration.getCall(0), addedAmount);
+      expect(result).toEqual(expect.objectContaining({ _getDuration: expect.any(luxon.Duration) }));
+      const amountInMs = (durationAmount.hours + addedAmount.hours) * 60 * 60 * 1000 + addedAmount.minutes * 60 * 1000;
+      expect(result._getDuration.toMillis()).toBe(amountInMs);
+      sinon.assert.calledWithExactly(_formatMiscToCompaniDuration.getCall(0), addedAmount);
+    });
   });
 });
 


### PR DESCRIPTION
<details open><summary> TESTS  :computer: </summary>

- [x] J'ai codé les tests unitaires
- [ ] J'ai codé les tests d'intégration -np
- [ ] ~~C'est une ancienne route utilisée par les apps mobiles.~~
  - [ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens
</details>

- [ ] Je replie cette section car mes modifications n'ont pas besoin de tests unitaires ou d'intégration

---

<details><summary> POINTS D'ATTENTION POUR CETTE PR  :warning: </summary>

- [ ] J'ai fait des modifications sur une route utilisée sur plusieurs plateformes [Doc de détail](https://www.notion.so/Points-d-attention-sur-les-routes-a548a8e32d314d5e92cb342e66cce443)
- [ ] J'ai modifié un modèle utilisé en mobile [Doc de détail](https://www.notion.so/Point-d-attention-sur-les-mod-les-e46fbf180cd34a569f3c6102366e47ca)
- [ ] J'ai ajouté un modèle spécifique à une structure 
  - [ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés
- [ ] J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile
  - [ ] Si oui, j'ai précisé sur le [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) qu'il faut forcer la mise à jour
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [Doc de MES](https://www.notion.so/Pas-pas-Mise-en-staging-01755ac57d944b4cb0c189861428e5d2) et [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) les modifications faites

</details>

- [x] Je replie cette section car je n'ai pas fait de modifications entrainant un point d'attention

---

<details><summary> FONCTIONNALITÉS APPS MOBILES  :iphone: </summary>

- [ ] Mes changements impactent l'application formation
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours
- [ ] Mes changements impactent l'application erp
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours

</details>

- [x] Je replie cette section car mes modifications n'ont pas d'impact sur les applications mobiles

_Si tu as lu cette description, pense à réagir avec un :eye:_
