### PR TITLE
Com 3246

### DIFF
--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -450,8 +450,10 @@ module.exports = {
   PHONE: 'phone',
   // Time
   SECONDS_IN_AN_HOUR: 3600,
-  HHhMMmin: 'HH\'h\' MM\'min\'',
-  HHhMM: 'HH\'h\'MM',
+  HhMMmin: 'h\'h\' mm\'min\'',
+  HhMM: 'h\'h\'mm',
+  Hh: 'h\'h\'',
+  Mmin: 'm\'min\'',
   // PARTNER
   SOCIAL_WORKER: 'social_worker',
   MEDICO_SOCIAL_ASSESSOR: 'medico_social_assessor',

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -450,8 +450,8 @@ module.exports = {
   PHONE: 'phone',
   // Time
   SECONDS_IN_AN_HOUR: 3600,
-  HH_h_MM_min: 'HH\'h\' MM\'min\'',
-  HH_h_MM: 'HH\'h\'MM',
+  HHhMMmin: 'HH\'h\' MM\'min\'',
+  HHhMM: 'HH\'h\'MM',
   // PARTNER
   SOCIAL_WORKER: 'social_worker',
   MEDICO_SOCIAL_ASSESSOR: 'medico_social_assessor',

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -450,6 +450,8 @@ module.exports = {
   PHONE: 'phone',
   // Time
   SECONDS_IN_AN_HOUR: 3600,
+  HH_h_MM_min: 'HH\'h\' MM\'min\'',
+  HH_h_MM: 'HH\'h\'MM',
   // PARTNER
   SOCIAL_WORKER: 'social_worker',
   MEDICO_SOCIAL_ASSESSOR: 'medico_social_assessor',

--- a/src/helpers/dates/companiDurations.js
+++ b/src/helpers/dates/companiDurations.js
@@ -1,4 +1,4 @@
-const { DURATION_UNITS, HH_h_MM, HH_h_MM_min } = require('../constants');
+const { DURATION_UNITS, HHhMM, HHhMMmin } = require('../constants');
 const luxon = require('./luxon');
 
 exports.CompaniDuration = (...args) => companiDurationFactory(exports._formatMiscToCompaniDuration(...args));
@@ -14,16 +14,21 @@ const companiDurationFactory = (inputDuration) => {
 
     // DISPLAY
     format(template) {
-      if (template === HH_h_MM) {
+      if (template === HHhMM) {
         const shiftedDuration = _duration.shiftTo('hours', 'minutes', 'seconds');
 
         if (shiftedDuration.get('minutes') > 0) return _duration.toFormat('h\'h\'mm');
         return _duration.toFormat('h\'h\'');
-      } if (template === HH_h_MM_min) {
+      } if (template === HHhMMmin) {
         const shiftedDuration = _duration.shiftTo('hours', 'minutes', 'seconds');
+        const minutes = shiftedDuration.get('minutes');
+        const hours = shiftedDuration.get('hours');
 
-        if (shiftedDuration.get('hours') === 0) return _duration.toFormat('mm\'min\'');
-        if (shiftedDuration.get('minutes') === 0) return _duration.toFormat('h\'h\'');
+        if (hours === 0) {
+          if (minutes === 0) return '0min';
+          return _duration.toFormat('mm\'min\'');
+        }
+        if (minutes === 0) return _duration.toFormat('h\'h\'');
         return _duration.toFormat('h\'h\' mm\'min\'');
       }
       throw Error('Invalid argument: expected specific format');

--- a/src/helpers/dates/companiDurations.js
+++ b/src/helpers/dates/companiDurations.js
@@ -1,4 +1,4 @@
-const { DURATION_UNITS } = require('../constants');
+const { DURATION_UNITS, HH_h_MM, HH_h_MM_min } = require('../constants');
 const luxon = require('./luxon');
 
 exports.CompaniDuration = (...args) => companiDurationFactory(exports._formatMiscToCompaniDuration(...args));
@@ -13,11 +13,20 @@ const companiDurationFactory = (inputDuration) => {
     },
 
     // DISPLAY
-    format() {
-      const durationInHoursAndMinutes = _duration.shiftTo('hours', 'minutes');
-      const format = Math.floor(durationInHoursAndMinutes.get('minutes')) > 0 ? 'h\'h\'mm' : 'h\'h\'';
+    format(template) {
+      if (template === HH_h_MM) {
+        const shiftedDuration = _duration.shiftTo('hours', 'minutes', 'seconds');
 
-      return _duration.toFormat(format);
+        if (shiftedDuration.get('minutes') > 0) return _duration.toFormat('h\'h\'mm');
+        return _duration.toFormat('h\'h\'');
+      } if (template === HH_h_MM_min) {
+        const shiftedDuration = _duration.shiftTo('hours', 'minutes', 'seconds');
+
+        if (shiftedDuration.get('hours') === 0) return _duration.toFormat('mm\'min\'');
+        if (shiftedDuration.get('minutes') === 0) return _duration.toFormat('h\'h\'');
+        return _duration.toFormat('h\'h\' mm\'min\'');
+      }
+      throw Error('Invalid argument: expected specific format');
     },
 
     asHours() {

--- a/src/helpers/dates/companiDurations.js
+++ b/src/helpers/dates/companiDurations.js
@@ -1,4 +1,4 @@
-const { DURATION_UNITS, HHhMM, HHhMMmin } = require('../constants');
+const { DURATION_UNITS, Hh, HhMM, Mmin, HhMMmin } = require('../constants');
 const luxon = require('./luxon');
 
 exports.CompaniDuration = (...args) => companiDurationFactory(exports._formatMiscToCompaniDuration(...args));
@@ -14,22 +14,19 @@ const companiDurationFactory = (inputDuration) => {
 
     // DISPLAY
     format(template) {
-      if (template === HHhMM) {
-        const shiftedDuration = _duration.shiftTo('hours', 'minutes', 'seconds');
+      const shiftedDuration = _duration.shiftTo('hours', 'minutes', 'seconds');
+      const minutes = shiftedDuration.get('minutes');
+      const hours = shiftedDuration.get('hours');
 
-        if (shiftedDuration.get('minutes') > 0) return _duration.toFormat('h\'h\'mm');
-        return _duration.toFormat('h\'h\'');
-      } if (template === HHhMMmin) {
-        const shiftedDuration = _duration.shiftTo('hours', 'minutes', 'seconds');
-        const minutes = shiftedDuration.get('minutes');
-        const hours = shiftedDuration.get('hours');
+      if (template === HhMM) {
+        if (minutes === 0) return _duration.toFormat(Hh);
 
-        if (hours === 0) {
-          if (minutes === 0) return '0min';
-          return _duration.toFormat('mm\'min\'');
-        }
-        if (minutes === 0) return _duration.toFormat('h\'h\'');
-        return _duration.toFormat('h\'h\' mm\'min\'');
+        return _duration.toFormat(HhMM);
+      } if (template === HhMMmin) {
+        if (hours === 0) return _duration.toFormat(Mmin);
+        if (minutes === 0) return _duration.toFormat(Hh);
+
+        return _duration.toFormat(HhMMmin);
       }
       throw Error('Invalid argument: expected specific format');
     },

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -3,7 +3,7 @@ const isEmpty = require('lodash/isEmpty');
 const { ObjectId } = require('mongodb');
 const Intl = require('intl');
 const moment = require('../extensions/moment');
-const { CIVILITY_LIST } = require('./constants');
+const { CIVILITY_LIST, HHhMM } = require('./constants');
 const DatesHelper = require('./dates');
 const { CompaniDate } = require('./dates/companiDates');
 const { CompaniDuration } = require('./dates/companiDurations');
@@ -228,7 +228,7 @@ exports.getTotalDuration = (timePeriods) => {
     CompaniDuration()
   );
 
-  return totalDuration.format();
+  return totalDuration.format(HHhMM);
 };
 
 exports.getTotalDurationForExport = (timePeriods) => {
@@ -241,7 +241,7 @@ exports.getTotalDurationForExport = (timePeriods) => {
 };
 
 exports.getDuration = (startDate, endDate) =>
-  CompaniDuration(CompaniDate(endDate).oldDiff(startDate, 'minutes')).format();
+  CompaniDuration(CompaniDate(endDate).oldDiff(startDate, 'minutes')).format(HHhMM);
 
 exports.getDurationForExport = (startDate, endDate) =>
   exports.formatFloatForExport(CompaniDuration(CompaniDate(endDate).oldDiff(startDate, 'minutes')).asHours());

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -3,7 +3,7 @@ const isEmpty = require('lodash/isEmpty');
 const { ObjectId } = require('mongodb');
 const Intl = require('intl');
 const moment = require('../extensions/moment');
-const { CIVILITY_LIST, HHhMM } = require('./constants');
+const { CIVILITY_LIST, HhMM } = require('./constants');
 const DatesHelper = require('./dates');
 const { CompaniDate } = require('./dates/companiDates');
 const { CompaniDuration } = require('./dates/companiDurations');
@@ -228,7 +228,7 @@ exports.getTotalDuration = (timePeriods) => {
     CompaniDuration()
   );
 
-  return totalDuration.format(HHhMM);
+  return totalDuration.format(HhMM);
 };
 
 exports.getTotalDurationForExport = (timePeriods) => {
@@ -241,7 +241,7 @@ exports.getTotalDurationForExport = (timePeriods) => {
 };
 
 exports.getDuration = (startDate, endDate) =>
-  CompaniDuration(CompaniDate(endDate).oldDiff(startDate, 'minutes')).format(HHhMM);
+  CompaniDuration(CompaniDate(endDate).oldDiff(startDate, 'minutes')).format(HhMM);
 
 exports.getDurationForExport = (startDate, endDate) =>
   exports.formatFloatForExport(CompaniDuration(CompaniDate(endDate).oldDiff(startDate, 'minutes')).asHours());

--- a/tests/unit/helpers/dates/companiDuration.test.js
+++ b/tests/unit/helpers/dates/companiDuration.test.js
@@ -1,6 +1,6 @@
 const expect = require('expect');
 const sinon = require('sinon');
-const { HHhMM, HHhMMmin } = require('../../../../src/helpers/constants');
+const { HhMM, HhMMmin } = require('../../../../src/helpers/constants');
 const luxon = require('../../../../src/helpers/dates/luxon');
 const CompaniDurationsHelper = require('../../../../src/helpers/dates/companiDurations');
 
@@ -68,159 +68,159 @@ describe('GETTER', () => {
 
 describe('DISPLAY', () => {
   describe('format', () => {
-    describe('HHhMM', () => {
+    describe('HhMM', () => {
       it('should return formatted duration with minutes', () => {
         const companiDuration = CompaniDurationsHelper.CompaniDuration('PT5H16M');
-        const result = companiDuration.format(HHhMM);
+        const result = companiDuration.format(HhMM);
 
         expect(result).toBe('5h16');
       });
 
       it('should return formatted duration with minutes, leading zero on minutes', () => {
         const companiDuration = CompaniDurationsHelper.CompaniDuration('PT5H3M');
-        const result = companiDuration.format(HHhMM);
+        const result = companiDuration.format(HhMM);
 
         expect(result).toBe('5h03');
       });
 
       it('should return formatted duration without minutes', () => {
         const companiDuration = CompaniDurationsHelper.CompaniDuration('PT13H');
-        const result = companiDuration.format(HHhMM);
+        const result = companiDuration.format(HhMM);
 
         expect(result).toBe('13h');
       });
 
       it('should return formatted duration without hours', () => {
         const companiDuration = CompaniDurationsHelper.CompaniDuration('PT34M');
-        const result = companiDuration.format(HHhMM);
+        const result = companiDuration.format(HhMM);
 
         expect(result).toBe('0h34');
       });
 
       it('should return formatted duration without hours, leading zero on minutes', () => {
         const companiDuration = CompaniDurationsHelper.CompaniDuration('PT8M');
-        const result = companiDuration.format(HHhMM);
+        const result = companiDuration.format(HhMM);
 
         expect(result).toBe('0h08');
       });
 
-      it('should return formatted duration, value is null', () => {
+      it('should return formatted duration, value is 0', () => {
         const companiDuration = CompaniDurationsHelper.CompaniDuration('PT0S');
-        const result = companiDuration.format(HHhMM);
+        const result = companiDuration.format(HhMM);
 
         expect(result).toBe('0h');
       });
 
       it('should return formatted duration, days are converted to hours', () => {
         const companiDuration = CompaniDurationsHelper.CompaniDuration('P2DT1H');
-        const result = companiDuration.format(HHhMM);
+        const result = companiDuration.format(HhMM);
 
         expect(result).toBe('49h');
       });
 
       it('should return formatted duration, month are converted to hours', () => {
         const companiDuration = CompaniDurationsHelper.CompaniDuration('P1M');
-        const result = companiDuration.format(HHhMM);
+        const result = companiDuration.format(HhMM);
 
         expect(result).toBe('720h'); // 30 * 24 = 720
       });
 
       it('should return formatted duration, seconds are converted to minutes', () => {
         const companiDuration = CompaniDurationsHelper.CompaniDuration('PT2H742S');
-        const result = companiDuration.format(HHhMM);
+        const result = companiDuration.format(HhMM);
 
         expect(result).toBe('2h12');
       });
 
       it('should return formatted duration with minutes, seconds have no effect under 60s', () => {
         const companiDuration = CompaniDurationsHelper.CompaniDuration('PT1H2M32.1S');
-        const result = companiDuration.format(HHhMM);
+        const result = companiDuration.format(HhMM);
 
         expect(result).toBe('1h02');
       });
 
       it('should return formatted duration without minutes, seconds have no effect under 60s', () => {
         const companiDuration = CompaniDurationsHelper.CompaniDuration('PT1H32.1S');
-        const result = companiDuration.format(HHhMM);
+        const result = companiDuration.format(HhMM);
 
         expect(result).toBe('1h');
       });
     });
 
-    describe('HHhMMmin', () => {
+    describe('HhMMmin', () => {
       it('should return formatted duration with minutes', () => {
         const companiDuration = CompaniDurationsHelper.CompaniDuration('PT5H16M');
-        const result = companiDuration.format(HHhMMmin);
+        const result = companiDuration.format(HhMMmin);
 
         expect(result).toBe('5h 16min');
       });
 
       it('should return formatted duration with minutes, leading zero on minutes', () => {
         const companiDuration = CompaniDurationsHelper.CompaniDuration('PT5H3M');
-        const result = companiDuration.format(HHhMMmin);
+        const result = companiDuration.format(HhMMmin);
 
         expect(result).toBe('5h 03min');
       });
 
       it('should return formatted duration without minutes', () => {
         const companiDuration = CompaniDurationsHelper.CompaniDuration('PT13H');
-        const result = companiDuration.format(HHhMMmin);
+        const result = companiDuration.format(HhMMmin);
 
         expect(result).toBe('13h');
       });
 
       it('should return formatted duration without hours, leading zero on minutes', () => {
         const companiDuration = CompaniDurationsHelper.CompaniDuration('PT7M');
-        const result = companiDuration.format(HHhMMmin);
+        const result = companiDuration.format(HhMMmin);
 
-        expect(result).toBe('07min');
+        expect(result).toBe('7min');
       });
 
       it('should return formatted duration without hours, leading zero on minutes', () => {
         const companiDuration = CompaniDurationsHelper.CompaniDuration('PT34M');
-        const result = companiDuration.format(HHhMMmin);
+        const result = companiDuration.format(HhMMmin);
 
         expect(result).toBe('34min');
       });
 
-      it('should return formatted duration, value is null', () => {
+      it('should return formatted duration, value is 0', () => {
         const companiDuration = CompaniDurationsHelper.CompaniDuration('PT0S');
-        const result = companiDuration.format(HHhMMmin);
+        const result = companiDuration.format(HhMMmin);
 
         expect(result).toBe('0min');
       });
 
       it('should return formatted duration, days are converted to hours', () => {
         const companiDuration = CompaniDurationsHelper.CompaniDuration('P2DT1H');
-        const result = companiDuration.format(HHhMMmin);
+        const result = companiDuration.format(HhMMmin);
 
         expect(result).toBe('49h');
       });
 
       it('should return formatted duration, month are converted to hours', () => {
         const companiDuration = CompaniDurationsHelper.CompaniDuration('P1M');
-        const result = companiDuration.format(HHhMMmin);
+        const result = companiDuration.format(HhMMmin);
 
         expect(result).toBe('720h'); // 30 * 24 = 720
       });
 
       it('should return formatted duration, seconds are converted to minutes', () => {
         const companiDuration = CompaniDurationsHelper.CompaniDuration('PT2H742S');
-        const result = companiDuration.format(HHhMMmin);
+        const result = companiDuration.format(HhMMmin);
 
         expect(result).toBe('2h 12min');
       });
 
       it('should return formatted duration with minutes, seconds have no effect under 60s', () => {
         const companiDuration = CompaniDurationsHelper.CompaniDuration('PT1H2M32.1S');
-        const result = companiDuration.format(HHhMMmin);
+        const result = companiDuration.format(HhMMmin);
 
         expect(result).toBe('1h 02min');
       });
 
       it('should return formatted duration without minutes, seconds have no effect under 60s', () => {
         const companiDuration = CompaniDurationsHelper.CompaniDuration('PT1H32.1S');
-        const result = companiDuration.format(HHhMMmin);
+        const result = companiDuration.format(HhMMmin);
 
         expect(result).toBe('1h');
       });

--- a/tests/unit/helpers/dates/companiDuration.test.js
+++ b/tests/unit/helpers/dates/companiDuration.test.js
@@ -1,5 +1,6 @@
 const expect = require('expect');
 const sinon = require('sinon');
+const { HHhMM, HHhMMmin } = require('../../../../src/helpers/constants');
 const luxon = require('../../../../src/helpers/dates/luxon');
 const CompaniDurationsHelper = require('../../../../src/helpers/dates/companiDurations');
 
@@ -67,52 +68,162 @@ describe('GETTER', () => {
 
 describe('DISPLAY', () => {
   describe('format', () => {
-    it('should return formatted duration with minutes', () => {
-      const durationAmount = { hours: 5, minutes: 16 };
-      const companiDuration = CompaniDurationsHelper.CompaniDuration(durationAmount);
-      const result = companiDuration.format();
+    describe('HHhMM', () => {
+      it('should return formatted duration with minutes', () => {
+        const companiDuration = CompaniDurationsHelper.CompaniDuration('PT5H16M');
+        const result = companiDuration.format(HHhMM);
 
-      expect(result).toBe('5h16');
+        expect(result).toBe('5h16');
+      });
+
+      it('should return formatted duration with minutes, leading zero on minutes', () => {
+        const companiDuration = CompaniDurationsHelper.CompaniDuration('PT5H3M');
+        const result = companiDuration.format(HHhMM);
+
+        expect(result).toBe('5h03');
+      });
+
+      it('should return formatted duration without minutes', () => {
+        const companiDuration = CompaniDurationsHelper.CompaniDuration('PT13H');
+        const result = companiDuration.format(HHhMM);
+
+        expect(result).toBe('13h');
+      });
+
+      it('should return formatted duration without hours', () => {
+        const companiDuration = CompaniDurationsHelper.CompaniDuration('PT34M');
+        const result = companiDuration.format(HHhMM);
+
+        expect(result).toBe('0h34');
+      });
+
+      it('should return formatted duration without hours, leading zero on minutes', () => {
+        const companiDuration = CompaniDurationsHelper.CompaniDuration('PT8M');
+        const result = companiDuration.format(HHhMM);
+
+        expect(result).toBe('0h08');
+      });
+
+      it('should return formatted duration, value is null', () => {
+        const companiDuration = CompaniDurationsHelper.CompaniDuration('PT0S');
+        const result = companiDuration.format(HHhMM);
+
+        expect(result).toBe('0h');
+      });
+
+      it('should return formatted duration, days are converted to hours', () => {
+        const companiDuration = CompaniDurationsHelper.CompaniDuration('P2DT1H');
+        const result = companiDuration.format(HHhMM);
+
+        expect(result).toBe('49h');
+      });
+
+      it('should return formatted duration, month are converted to hours', () => {
+        const companiDuration = CompaniDurationsHelper.CompaniDuration('P1M');
+        const result = companiDuration.format(HHhMM);
+
+        expect(result).toBe('720h'); // 30 * 24 = 720
+      });
+
+      it('should return formatted duration, seconds are converted to minutes', () => {
+        const companiDuration = CompaniDurationsHelper.CompaniDuration('PT2H742S');
+        const result = companiDuration.format(HHhMM);
+
+        expect(result).toBe('2h12');
+      });
+
+      it('should return formatted duration with minutes, seconds have no effect under 60s', () => {
+        const companiDuration = CompaniDurationsHelper.CompaniDuration('PT1H2M32.1S');
+        const result = companiDuration.format(HHhMM);
+
+        expect(result).toBe('1h02');
+      });
+
+      it('should return formatted duration without minutes, seconds have no effect under 60s', () => {
+        const companiDuration = CompaniDurationsHelper.CompaniDuration('PT1H32.1S');
+        const result = companiDuration.format(HHhMM);
+
+        expect(result).toBe('1h');
+      });
     });
 
-    it('should return formatted duration with minutes, leading zero on minutes', () => {
-      const durationAmount = { hours: 5, minutes: 3 };
-      const companiDuration = CompaniDurationsHelper.CompaniDuration(durationAmount);
-      const result = companiDuration.format();
+    describe('HHhMMmin', () => {
+      it('should return formatted duration with minutes', () => {
+        const companiDuration = CompaniDurationsHelper.CompaniDuration('PT5H16M');
+        const result = companiDuration.format(HHhMMmin);
 
-      expect(result).toBe('5h03');
-    });
+        expect(result).toBe('5h 16min');
+      });
 
-    it('should return formatted duration without minutes', () => {
-      const durationAmount = { hours: 13 };
-      const companiDuration = CompaniDurationsHelper.CompaniDuration(durationAmount);
-      const result = companiDuration.format();
+      it('should return formatted duration with minutes, leading zero on minutes', () => {
+        const companiDuration = CompaniDurationsHelper.CompaniDuration('PT5H3M');
+        const result = companiDuration.format(HHhMMmin);
 
-      expect(result).toBe('13h');
-    });
+        expect(result).toBe('5h 03min');
+      });
 
-    it('should return formatted duration, days are converted to hours', () => {
-      const durationAmount = { days: 2, hours: 1 };
-      const companiDuration = CompaniDurationsHelper.CompaniDuration(durationAmount);
-      const result = companiDuration.format();
+      it('should return formatted duration without minutes', () => {
+        const companiDuration = CompaniDurationsHelper.CompaniDuration('PT13H');
+        const result = companiDuration.format(HHhMMmin);
 
-      expect(result).toBe('49h');
-    });
+        expect(result).toBe('13h');
+      });
 
-    it('should return formatted duration with minutes, seconds and milliseconds have no effect', () => {
-      const durationAmount = { hours: 1, minutes: 2, seconds: 4 };
-      const companiDuration = CompaniDurationsHelper.CompaniDuration(durationAmount);
-      const result = companiDuration.format();
+      it('should return formatted duration without hours, leading zero on minutes', () => {
+        const companiDuration = CompaniDurationsHelper.CompaniDuration('PT7M');
+        const result = companiDuration.format(HHhMMmin);
 
-      expect(result).toBe('1h02');
-    });
+        expect(result).toBe('07min');
+      });
 
-    it('should return formatted duration without minutes, seconds and milliseconds have no effect', () => {
-      const durationAmount = { hours: 1, seconds: 9 };
-      const companiDuration = CompaniDurationsHelper.CompaniDuration(durationAmount);
-      const result = companiDuration.format();
+      it('should return formatted duration without hours, leading zero on minutes', () => {
+        const companiDuration = CompaniDurationsHelper.CompaniDuration('PT34M');
+        const result = companiDuration.format(HHhMMmin);
 
-      expect(result).toBe('1h');
+        expect(result).toBe('34min');
+      });
+
+      it('should return formatted duration, value is null', () => {
+        const companiDuration = CompaniDurationsHelper.CompaniDuration('PT0S');
+        const result = companiDuration.format(HHhMMmin);
+
+        expect(result).toBe('0min');
+      });
+
+      it('should return formatted duration, days are converted to hours', () => {
+        const companiDuration = CompaniDurationsHelper.CompaniDuration('P2DT1H');
+        const result = companiDuration.format(HHhMMmin);
+
+        expect(result).toBe('49h');
+      });
+
+      it('should return formatted duration, month are converted to hours', () => {
+        const companiDuration = CompaniDurationsHelper.CompaniDuration('P1M');
+        const result = companiDuration.format(HHhMMmin);
+
+        expect(result).toBe('720h'); // 30 * 24 = 720
+      });
+
+      it('should return formatted duration, seconds are converted to minutes', () => {
+        const companiDuration = CompaniDurationsHelper.CompaniDuration('PT2H742S');
+        const result = companiDuration.format(HHhMMmin);
+
+        expect(result).toBe('2h 12min');
+      });
+
+      it('should return formatted duration with minutes, seconds have no effect under 60s', () => {
+        const companiDuration = CompaniDurationsHelper.CompaniDuration('PT1H2M32.1S');
+        const result = companiDuration.format(HHhMMmin);
+
+        expect(result).toBe('1h 02min');
+      });
+
+      it('should return formatted duration without minutes, seconds have no effect under 60s', () => {
+        const companiDuration = CompaniDurationsHelper.CompaniDuration('PT1H32.1S');
+        const result = companiDuration.format(HHhMMmin);
+
+        expect(result).toBe('1h');
+      });
     });
   });
 

--- a/tests/unit/helpers/utils.test.js
+++ b/tests/unit/helpers/utils.test.js
@@ -468,6 +468,17 @@ describe('getTotalDuration', () => {
     expect(result).toEqual('4h');
   });
 
+  it('should return duration without hours', () => {
+    const slots = [
+      { startDate: '2020-03-20T09:00:00.000Z', endDate: '2020-03-20T09:15:00.000Z' },
+      { startDate: '2020-04-21T09:00:00.000Z', endDate: '2020-04-21T09:30:00.000Z' },
+    ];
+
+    const result = UtilsHelper.getTotalDuration(slots);
+
+    expect(result).toEqual('0h45');
+  });
+
   it('should return duration with days', () => {
     const slots = [
       { startDate: '2020-03-20T07:00:00.000Z', endDate: '2020-03-20T22:00:00.000Z' },
@@ -541,6 +552,15 @@ describe('getDuration', () => {
     const result = UtilsHelper.getDuration(startDate, endDate);
 
     expect(result).toEqual('2h');
+  });
+
+  it('should return duration without hours', () => {
+    const startDate = '2020-03-20T10:15:00.000Z';
+    const endDate = '2020-03-20T11:00:00.000Z';
+
+    const result = UtilsHelper.getDuration(startDate, endDate);
+
+    expect(result).toEqual('0h45');
   });
 
   it('should return duration with days', () => {


### PR DESCRIPTION
<details open><summary> TESTS  :computer: </summary>

- [x] J'ai codé les tests unitaires
- [ ] J'ai codé les tests d'intégration
- [ ] C'est une ancienne route utilisée par les apps mobiles.
  - [ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens
</details>

- [ ] Je replie cette section car mes modifications n'ont pas besoin de tests unitaires ou d'intégration

---

<details open><summary> POINTS D'ATTENTION POUR CETTE PR  :warning: </summary>

- [x] J'ai fait des modifications sur une route utilisée sur plusieurs plateformes [Doc de détail](https://www.notion.so/Points-d-attention-sur-les-routes-a548a8e32d314d5e92cb342e66cce443)
- [ ] J'ai modifié un modèle utilisé en mobile [Doc de détail](https://www.notion.so/Point-d-attention-sur-les-mod-les-e46fbf180cd34a569f3c6102366e47ca)
- [ ] J'ai ajouté un modèle spécifique à une structure 
  - [ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés
- [ ] J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile
  - [ ] Si oui, j'ai précisé sur le [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) qu'il faut forcer la mise à jour
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [Doc de MES](https://www.notion.so/Pas-pas-Mise-en-staging-01755ac57d944b4cb0c189861428e5d2) et [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) les modifications faites

</details>

- [ ] Je replie cette section car je n'ai pas fait de modifications entrainant un point d'attention

---

<details open><summary> FONCTIONNALITÉS APPS MOBILES  :iphone: </summary>

- [x] Mes changements impactent l'application formation
  - [x] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours
- [ ] Mes changements impactent l'application erp
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours

</details>

- [ ] Je replie cette section car mes modifications n'ont pas d'impact sur les applications mobiles

Remarque: finalement on a pas retenu les formats `HH_h_MM_min` et `HH_h_MM` car eslint n'acceptait pas cette case hybride entre le chameau et le serpent.
Du coup on a choisi `HHhMMmin` et `HHhmm` avec Ulysse et Chloé

_Si tu as lu cette description, pense à réagir avec un :eye:_
