### PR TITLE
COM-3216 use new .diff

### DIFF
--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -450,10 +450,9 @@ module.exports = {
   PHONE: 'phone',
   // Time
   SECONDS_IN_AN_HOUR: 3600,
-  HhMMmin: 'h\'h\' mm\'min\'',
-  HhMM: 'h\'h\'mm',
-  Hh: 'h\'h\'',
-  Mmin: 'm\'min\'',
+  // COMPANIDURATION FORMATS
+  LONG_DURATION_H_MM: 'h\'h\' mm\'min\'',
+  SHORT_DURATION_H_MM: 'h\'h\'mm',
   // PARTNER
   SOCIAL_WORKER: 'social_worker',
   MEDICO_SOCIAL_ASSESSOR: 'medico_social_assessor',

--- a/src/helpers/dates/companiDurations.js
+++ b/src/helpers/dates/companiDurations.js
@@ -1,5 +1,8 @@
-const { DURATION_UNITS, Hh, HhMM, Mmin, HhMMmin } = require('../constants');
+const { DURATION_UNITS, LONG_DURATION_H_MM, SHORT_DURATION_H_MM } = require('../constants');
 const luxon = require('./luxon');
+
+const DURATION_HOURS = 'h\'h\'';
+const DURATION_MINUTES = 'm\'min\'';
 
 exports.CompaniDuration = (...args) => companiDurationFactory(exports._formatMiscToCompaniDuration(...args));
 
@@ -18,15 +21,15 @@ const companiDurationFactory = (inputDuration) => {
       const minutes = shiftedDuration.get('minutes');
       const hours = shiftedDuration.get('hours');
 
-      if (template === HhMM) {
-        if (minutes === 0) return _duration.toFormat(Hh);
+      if (template === SHORT_DURATION_H_MM) {
+        if (minutes === 0) return _duration.toFormat(DURATION_HOURS);
 
-        return _duration.toFormat(HhMM);
-      } if (template === HhMMmin) {
-        if (hours === 0) return _duration.toFormat(Mmin);
-        if (minutes === 0) return _duration.toFormat(Hh);
+        return _duration.toFormat(SHORT_DURATION_H_MM);
+      } if (template === LONG_DURATION_H_MM) {
+        if (hours === 0) return _duration.toFormat(DURATION_MINUTES);
+        if (minutes === 0) return _duration.toFormat(DURATION_HOURS);
 
-        return _duration.toFormat(HhMMmin);
+        return _duration.toFormat(LONG_DURATION_H_MM);
       }
       throw Error('Invalid argument: expected specific format');
     },

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -224,7 +224,7 @@ exports.computeExclTaxesWithDiscount = (inclTaxes, discount, vat) => {
 
 exports.getTotalDuration = (timePeriods) => {
   const totalDuration = timePeriods.reduce(
-    (acc, tp) => acc.add(CompaniDuration(CompaniDate(tp.endDate).oldDiff(tp.startDate, 'minutes'))),
+    (acc, tp) => acc.add(CompaniDate(tp.endDate).diff(tp.startDate, 'minutes')),
     CompaniDuration()
   );
 
@@ -233,7 +233,7 @@ exports.getTotalDuration = (timePeriods) => {
 
 exports.getTotalDurationForExport = (timePeriods) => {
   const totalDuration = timePeriods.reduce(
-    (acc, tp) => acc.add(CompaniDuration(CompaniDate(tp.endDate).oldDiff(tp.startDate, 'minutes'))),
+    (acc, tp) => acc.add(CompaniDate(tp.endDate).diff(tp.startDate, 'minutes')),
     CompaniDuration()
   );
 
@@ -241,10 +241,10 @@ exports.getTotalDurationForExport = (timePeriods) => {
 };
 
 exports.getDuration = (startDate, endDate) =>
-  CompaniDuration(CompaniDate(endDate).oldDiff(startDate, 'minutes')).format(HhMM);
+  CompaniDuration(CompaniDate(endDate).diff(startDate, 'minutes')).format(HhMM);
 
 exports.getDurationForExport = (startDate, endDate) =>
-  exports.formatFloatForExport(CompaniDuration(CompaniDate(endDate).oldDiff(startDate, 'minutes')).asHours());
+  exports.formatFloatForExport(CompaniDuration(CompaniDate(endDate).diff(startDate, 'minutes')).asHours());
 
 exports.computeDuration = durations => durations
   .reduce((acc, duration) => acc.add(duration), CompaniDuration());

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -3,7 +3,7 @@ const isEmpty = require('lodash/isEmpty');
 const { ObjectId } = require('mongodb');
 const Intl = require('intl');
 const moment = require('../extensions/moment');
-const { CIVILITY_LIST, HhMM } = require('./constants');
+const { CIVILITY_LIST, SHORT_DURATION_H_MM } = require('./constants');
 const DatesHelper = require('./dates');
 const { CompaniDate } = require('./dates/companiDates');
 const { CompaniDuration } = require('./dates/companiDurations');
@@ -228,7 +228,7 @@ exports.getTotalDuration = (timePeriods) => {
     CompaniDuration()
   );
 
-  return totalDuration.format(HhMM);
+  return totalDuration.format(SHORT_DURATION_H_MM);
 };
 
 exports.getTotalDurationForExport = (timePeriods) => {
@@ -241,7 +241,7 @@ exports.getTotalDurationForExport = (timePeriods) => {
 };
 
 exports.getDuration = (startDate, endDate) =>
-  CompaniDuration(CompaniDate(endDate).diff(startDate, 'minutes')).format(HhMM);
+  CompaniDuration(CompaniDate(endDate).diff(startDate, 'minutes')).format(SHORT_DURATION_H_MM);
 
 exports.getDurationForExport = (startDate, endDate) =>
   exports.formatFloatForExport(CompaniDuration(CompaniDate(endDate).diff(startDate, 'minutes')).asHours());

--- a/tests/unit/helpers/dates/companiDuration.test.js
+++ b/tests/unit/helpers/dates/companiDuration.test.js
@@ -229,11 +229,18 @@ describe('DISPLAY', () => {
   });
 
   describe('asHours', () => {
-    it('should return duration in hours', () => {
+    it('should return duration in hours, with minutes', () => {
       const companiDuration = CompaniDurationsHelper.CompaniDuration('PT1H9M');
       const result = companiDuration.asHours();
 
       expect(result).toBe(1.15); // 1.15 = 1 + 9 / 60
+    });
+
+    it('should return duration in hours, with seconds', () => {
+      const companiDuration = CompaniDurationsHelper.CompaniDuration('PT1H4S');
+      const result = companiDuration.asHours();
+
+      expect(result).toBe(1.001111111111111);
     });
   });
 

--- a/tests/unit/helpers/dates/companiDuration.test.js
+++ b/tests/unit/helpers/dates/companiDuration.test.js
@@ -1,6 +1,6 @@
 const expect = require('expect');
 const sinon = require('sinon');
-const { HhMM, HhMMmin } = require('../../../../src/helpers/constants');
+const { SHORT_DURATION_H_MM, LONG_DURATION_H_MM } = require('../../../../src/helpers/constants');
 const luxon = require('../../../../src/helpers/dates/luxon');
 const CompaniDurationsHelper = require('../../../../src/helpers/dates/companiDurations');
 
@@ -69,159 +69,159 @@ describe('GETTER', () => {
 
 describe('DISPLAY', () => {
   describe('format', () => {
-    describe('HhMM', () => {
+    describe('SHORT_DURATION_H_MM', () => {
       it('should return formatted duration with minutes', () => {
         const companiDuration = CompaniDurationsHelper.CompaniDuration('PT5H16M');
-        const result = companiDuration.format(HhMM);
+        const result = companiDuration.format(SHORT_DURATION_H_MM);
 
         expect(result).toBe('5h16');
       });
 
       it('should return formatted duration with minutes, leading zero on minutes', () => {
         const companiDuration = CompaniDurationsHelper.CompaniDuration('PT5H3M');
-        const result = companiDuration.format(HhMM);
+        const result = companiDuration.format(SHORT_DURATION_H_MM);
 
         expect(result).toBe('5h03');
       });
 
       it('should return formatted duration without minutes', () => {
         const companiDuration = CompaniDurationsHelper.CompaniDuration('PT13H');
-        const result = companiDuration.format(HhMM);
+        const result = companiDuration.format(SHORT_DURATION_H_MM);
 
         expect(result).toBe('13h');
       });
 
       it('should return formatted duration without hours', () => {
         const companiDuration = CompaniDurationsHelper.CompaniDuration('PT34M');
-        const result = companiDuration.format(HhMM);
+        const result = companiDuration.format(SHORT_DURATION_H_MM);
 
         expect(result).toBe('0h34');
       });
 
       it('should return formatted duration without hours, leading zero on minutes', () => {
         const companiDuration = CompaniDurationsHelper.CompaniDuration('PT8M');
-        const result = companiDuration.format(HhMM);
+        const result = companiDuration.format(SHORT_DURATION_H_MM);
 
         expect(result).toBe('0h08');
       });
 
       it('should return formatted duration, value is 0', () => {
         const companiDuration = CompaniDurationsHelper.CompaniDuration('PT0S');
-        const result = companiDuration.format(HhMM);
+        const result = companiDuration.format(SHORT_DURATION_H_MM);
 
         expect(result).toBe('0h');
       });
 
       it('should return formatted duration, days are converted to hours', () => {
         const companiDuration = CompaniDurationsHelper.CompaniDuration('P2DT1H');
-        const result = companiDuration.format(HhMM);
+        const result = companiDuration.format(SHORT_DURATION_H_MM);
 
         expect(result).toBe('49h');
       });
 
       it('should return formatted duration, month are converted to hours', () => {
         const companiDuration = CompaniDurationsHelper.CompaniDuration('P1M');
-        const result = companiDuration.format(HhMM);
+        const result = companiDuration.format(SHORT_DURATION_H_MM);
 
         expect(result).toBe('720h'); // 30 * 24 = 720
       });
 
       it('should return formatted duration, seconds are converted to minutes', () => {
         const companiDuration = CompaniDurationsHelper.CompaniDuration('PT2H742S');
-        const result = companiDuration.format(HhMM);
+        const result = companiDuration.format(SHORT_DURATION_H_MM);
 
         expect(result).toBe('2h12');
       });
 
       it('should return formatted duration with minutes, seconds have no effect under 60s', () => {
         const companiDuration = CompaniDurationsHelper.CompaniDuration('PT1H2M32.1S');
-        const result = companiDuration.format(HhMM);
+        const result = companiDuration.format(SHORT_DURATION_H_MM);
 
         expect(result).toBe('1h02');
       });
 
       it('should return formatted duration without minutes, seconds have no effect under 60s', () => {
         const companiDuration = CompaniDurationsHelper.CompaniDuration('PT1H32.1S');
-        const result = companiDuration.format(HhMM);
+        const result = companiDuration.format(SHORT_DURATION_H_MM);
 
         expect(result).toBe('1h');
       });
     });
 
-    describe('HhMMmin', () => {
+    describe('LONG_DURATION_H_MM', () => {
       it('should return formatted duration with minutes', () => {
         const companiDuration = CompaniDurationsHelper.CompaniDuration('PT5H16M');
-        const result = companiDuration.format(HhMMmin);
+        const result = companiDuration.format(LONG_DURATION_H_MM);
 
         expect(result).toBe('5h 16min');
       });
 
       it('should return formatted duration with minutes, leading zero on minutes', () => {
         const companiDuration = CompaniDurationsHelper.CompaniDuration('PT5H3M');
-        const result = companiDuration.format(HhMMmin);
+        const result = companiDuration.format(LONG_DURATION_H_MM);
 
         expect(result).toBe('5h 03min');
       });
 
       it('should return formatted duration without minutes', () => {
         const companiDuration = CompaniDurationsHelper.CompaniDuration('PT13H');
-        const result = companiDuration.format(HhMMmin);
+        const result = companiDuration.format(LONG_DURATION_H_MM);
 
         expect(result).toBe('13h');
       });
 
       it('should return formatted duration without hours, leading zero on minutes', () => {
         const companiDuration = CompaniDurationsHelper.CompaniDuration('PT7M');
-        const result = companiDuration.format(HhMMmin);
+        const result = companiDuration.format(LONG_DURATION_H_MM);
 
         expect(result).toBe('7min');
       });
 
       it('should return formatted duration without hours, leading zero on minutes', () => {
         const companiDuration = CompaniDurationsHelper.CompaniDuration('PT34M');
-        const result = companiDuration.format(HhMMmin);
+        const result = companiDuration.format(LONG_DURATION_H_MM);
 
         expect(result).toBe('34min');
       });
 
       it('should return formatted duration, value is 0', () => {
         const companiDuration = CompaniDurationsHelper.CompaniDuration('PT0S');
-        const result = companiDuration.format(HhMMmin);
+        const result = companiDuration.format(LONG_DURATION_H_MM);
 
         expect(result).toBe('0min');
       });
 
       it('should return formatted duration, days are converted to hours', () => {
         const companiDuration = CompaniDurationsHelper.CompaniDuration('P2DT1H');
-        const result = companiDuration.format(HhMMmin);
+        const result = companiDuration.format(LONG_DURATION_H_MM);
 
         expect(result).toBe('49h');
       });
 
       it('should return formatted duration, month are converted to hours', () => {
         const companiDuration = CompaniDurationsHelper.CompaniDuration('P1M');
-        const result = companiDuration.format(HhMMmin);
+        const result = companiDuration.format(LONG_DURATION_H_MM);
 
         expect(result).toBe('720h'); // 30 * 24 = 720
       });
 
       it('should return formatted duration, seconds are converted to minutes', () => {
         const companiDuration = CompaniDurationsHelper.CompaniDuration('PT2H742S');
-        const result = companiDuration.format(HhMMmin);
+        const result = companiDuration.format(LONG_DURATION_H_MM);
 
         expect(result).toBe('2h 12min');
       });
 
       it('should return formatted duration with minutes, seconds have no effect under 60s', () => {
         const companiDuration = CompaniDurationsHelper.CompaniDuration('PT1H2M32.1S');
-        const result = companiDuration.format(HhMMmin);
+        const result = companiDuration.format(LONG_DURATION_H_MM);
 
         expect(result).toBe('1h 02min');
       });
 
       it('should return formatted duration without minutes, seconds have no effect under 60s', () => {
         const companiDuration = CompaniDurationsHelper.CompaniDuration('PT1H32.1S');
-        const result = companiDuration.format(HhMMmin);
+        const result = companiDuration.format(LONG_DURATION_H_MM);
 
         expect(result).toBe('1h');
       });

--- a/tests/unit/helpers/utils.test.js
+++ b/tests/unit/helpers/utils.test.js
@@ -263,7 +263,7 @@ describe('getFullTitleFromIdentity', () => {
 });
 
 describe('formatFloatForExport', () => {
-  const validCases = [[0, '0,00'], [1, '1,00'], [7.1, '7,10'], [3.56, '3,56'], [4.23506, '4,24']];
+  const validCases = [[0, '0,00'], [1, '1,00'], [7.1, '7,10'], [3.56, '3,56'], [4.23506, '4,24'], [4.23400, '4,23']];
   const invalidValues = [null, undefined, NaN, ''];
 
   validCases.forEach(([param, result]) => {
@@ -571,6 +571,15 @@ describe('getDuration', () => {
 
     expect(result).toEqual('30h');
   });
+
+  it('should return duration with meaningless second', () => {
+    const startDate = '2020-03-20T09:00:04.230Z';
+    const endDate = '2020-03-20T11:00:33.125Z';
+
+    const result = UtilsHelper.getDuration(startDate, endDate);
+
+    expect(result).toEqual('2h');
+  });
 });
 
 describe('getDurationForExport', () => {
@@ -599,6 +608,15 @@ describe('getDurationForExport', () => {
     const result = UtilsHelper.getDurationForExport(startDate, endDate);
 
     expect(result).toEqual('30,00');
+  });
+
+  it('should return duration with seconds', () => {
+    const startDate = '2020-03-20T09:00:00.000Z';
+    const endDate = '2020-03-20T11:00:31.230Z';
+
+    const result = UtilsHelper.getDurationForExport(startDate, endDate);
+
+    expect(result).toEqual('2,01');
   });
 });
 


### PR DESCRIPTION
<details open><summary> TESTS  :computer: </summary>

- [x] J'ai codé les tests unitaires
- [ ] J'ai codé les tests d'intégration
- [ ] C'est une ancienne route utilisée par les apps mobiles.
  - [ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens
</details>

- [ ] Je replie cette section car mes modifications n'ont pas besoin de tests unitaires ou d'intégration

---

<details open><summary> POINTS D'ATTENTION POUR CETTE PR  :warning: </summary>

- [x] J'ai fait des modifications sur une route utilisée sur plusieurs plateformes [Doc de détail](https://www.notion.so/Points-d-attention-sur-les-routes-a548a8e32d314d5e92cb342e66cce443)
- [ ] J'ai modifié un modèle utilisé en mobile [Doc de détail](https://www.notion.so/Point-d-attention-sur-les-mod-les-e46fbf180cd34a569f3c6102366e47ca)
- [ ] J'ai ajouté un modèle spécifique à une structure 
  - [ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés
- [ ] J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile
  - [ ] Si oui, j'ai précisé sur le [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) qu'il faut forcer la mise à jour
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [Doc de MES](https://www.notion.so/Pas-pas-Mise-en-staging-01755ac57d944b4cb0c189861428e5d2) et [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) les modifications faites

</details>

- [ ] Je replie cette section car je n'ai pas fait de modifications entrainant un point d'attention

---

<details open><summary> FONCTIONNALITÉS APPS MOBILES  :iphone: </summary>

- [x] Mes changements impactent l'application formation
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours
- [ ] Mes changements impactent l'application erp
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours

</details>

- [ ] Je replie cette section car mes modifications n'ont pas d'impact sur les applications mobiles

_Si tu as lu cette description, pense à réagir avec un :eye:_
