### PR TITLE
COM-3267 accept millis on objet format in companiDuration parser

### DIFF
--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -33,6 +33,7 @@ module.exports = {
   HOURS: 'hours',
   MINUTES: 'minutes',
   SECONDS: 'seconds',
+  MILLISECONDS: 'milliseconds',
   get DURATION_UNITS() {
     return [
       this.YEARS,
@@ -43,6 +44,7 @@ module.exports = {
       this.HOURS,
       this.MINUTES,
       this.SECONDS,
+      this.MILLISECONDS,
     ];
   },
   // EVENTS

--- a/tests/unit/helpers/dates/companiDuration.test.js
+++ b/tests/unit/helpers/dates/companiDuration.test.js
@@ -368,11 +368,11 @@ describe('_formatMiscToCompaniDuration', () => {
   });
 
   it('should return duration if arg is an object with luxon duration keys', () => {
-    const payload = { hours: 3, minutes: 35, seconds: 12 };
+    const payload = { years: 1, months: 2, weeks: 3, days: 4, hours: 5, minutes: 35, seconds: 12, milliseconds: 873 };
     const result = CompaniDurationsHelper._formatMiscToCompaniDuration(payload);
 
     expect(result instanceof luxon.Duration).toBe(true);
-    expect(result.toMillis()).toEqual(3 * 60 * 60 * 1000 + 35 * 60 * 1000 + 12 * 1000);
+    expect(result.toMillis()).toEqual(((((1 * 365 + 2 * 30 + 3 * 7 + 4) * 24 + 5) * 60 + 35) * 60 + 12) * 1000 + 873);
     sinon.assert.calledOnce(fromObject);
     sinon.assert.notCalled(invalid);
   });

--- a/tests/unit/helpers/dates/companiDuration.test.js
+++ b/tests/unit/helpers/dates/companiDuration.test.js
@@ -26,7 +26,16 @@ describe('CompaniDuration', () => {
 
   describe('Constructor', () => {
     it('should return duration', () => {
-      const duration = { days: 13, hours: 19, minutes: 12 };
+      const duration = {
+        years: 3,
+        months: 1,
+        weeks: 2,
+        days: 13,
+        hours: 19,
+        minutes: 12,
+        seconds: 9,
+        milliseconds: 452,
+      };
 
       const result = CompaniDurationsHelper.CompaniDuration(duration);
 


### PR DESCRIPTION
<details open><summary> TESTS  :computer: </summary>

- [x] J'ai codé les tests unitaires
- [ ] J'ai codé les tests d'intégration
- [ ] C'est une ancienne route utilisée par les apps mobiles.
  - [ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens
</details>

- [ ] Je replie cette section car mes modifications n'ont pas besoin de tests unitaires ou d'intégration

---

<details><summary> POINTS D'ATTENTION POUR CETTE PR  :warning: </summary>

- [ ] J'ai fait des modifications sur une route utilisée sur plusieurs plateformes [Doc de détail](https://www.notion.so/Points-d-attention-sur-les-routes-a548a8e32d314d5e92cb342e66cce443)
- [ ] J'ai modifié un modèle utilisé en mobile [Doc de détail](https://www.notion.so/Point-d-attention-sur-les-mod-les-e46fbf180cd34a569f3c6102366e47ca)
- [ ] J'ai ajouté un modèle spécifique à une structure 
  - [ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés
- [ ] J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile
  - [ ] Si oui, j'ai précisé sur le [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) qu'il faut forcer la mise à jour
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [Doc de MES](https://www.notion.so/Pas-pas-Mise-en-staging-01755ac57d944b4cb0c189861428e5d2) et [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) les modifications faites

</details>

- [x] Je replie cette section car je n'ai pas fait de modifications entrainant un point d'attention

---

<details><summary> FONCTIONNALITÉS APPS MOBILES  :iphone: </summary>

- [ ] Mes changements impactent l'application formation
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours
- [ ] Mes changements impactent l'application erp
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours

</details>

- [x] Je replie cette section car mes modifications n'ont pas d'impact sur les applications mobiles

_Si tu as lu cette description, pense à réagir avec un :eye:_
