### PR TITLE
Com 3232

### DIFF
--- a/src/helpers/dates/companiIntervals.js
+++ b/src/helpers/dates/companiIntervals.js
@@ -27,19 +27,14 @@ const CompaniIntervalFactory = (inputInterval) => {
   });
 };
 
-const isCompaniDate = arg => arg instanceof Object && arg._getDate && arg._getDate instanceof luxon.DateTime;
 const isCompaniInterval = arg =>
   arg instanceof Object && arg._getInterval && arg._getInterval instanceof luxon.Interval;
 
 exports._formatMiscToCompaniInterval = (...args) => {
   if (args.length === 1) {
-    if (typeof args[0] === 'string' && args[0] !== '') return luxon.Interval.fromISO(args[0]);
     if (isCompaniInterval(args[0])) return args[0]._getInterval;
   }
   if (args.length === 2) {
-    if (isCompaniDate(args[0]) && isCompaniDate(args[1])) {
-      return luxon.Interval.fromDateTimes(args[0]._getDate, args[1]._getDate);
-    }
     if (typeof args[0] === 'string' && typeof args[1] === 'string') {
       const luxonDate1 = luxon.DateTime.fromISO(args[0]);
       const luxonDate2 = luxon.DateTime.fromISO(args[1]);

--- a/src/helpers/dates/companiIntervals.js
+++ b/src/helpers/dates/companiIntervals.js
@@ -12,6 +12,8 @@ const CompaniIntervalFactory = (inputInterval) => {
     },
 
     rangeBy(miscTypeDurationStep, excludeEnd = false) {
+      // after spliting "outil" from "formation", first argument should be only duration in string ISO
+      // const luxonDurationStep = luxon.Duration.fromISO(durationISO);
       const luxonDurationStep = CompaniDuration(miscTypeDurationStep)._getDuration;
       if (luxonDurationStep.toMillis() === 0) throw new Error('invalid argument : duration is zero');
 

--- a/tests/unit/helpers/dates/companiIntervals.test.js
+++ b/tests/unit/helpers/dates/companiIntervals.test.js
@@ -16,36 +16,44 @@ describe('CompaniInterval', () => {
   });
 
   it('should not mutate _interval', () => {
-    const intervalISO = '2021-11-24T09:00:00.000+01:00/2021-11-30T10:30:00.000+01:00';
-    const otherIntervalISO = '2022-01-03T12:00:00.000+01:00/2022-01-10T23:00:00.000+01:00';
-    const companiInterval = CompaniIntervalsHelper.CompaniInterval(intervalISO);
-    companiInterval._interval = luxon.Interval.fromISO(otherIntervalISO);
+    const startDateISO = '2021-11-24T08:00:00.000Z';
+    const endDateISO = '2021-11-30T09:30:00.000Z';
 
-    expect(companiInterval._getInterval.toISO()).toEqual(intervalISO);
+    const luxonDate1 = luxon.DateTime.fromISO('2022-01-03T11:00:00.000Z');
+    const luxonDate2 = luxon.DateTime.fromISO('2022-01-10T22:00:00.000Z');
+    const luxonInterval = luxon.Interval.fromDateTimes(luxonDate1, luxonDate2);
+
+    const companiInterval = CompaniIntervalsHelper.CompaniInterval(startDateISO, endDateISO);
+    companiInterval._interval = luxonInterval;
+
+    expect(companiInterval._getInterval.start.toUTC().toISO()).toEqual(startDateISO);
+    expect(companiInterval._getInterval.end.toUTC().toISO()).toEqual(endDateISO);
   });
 
   describe('Constructor', () => {
     it('should return interval', () => {
-      const intervalISO = '2021-11-24T08:00:00.000Z/2021-11-30T09:30:00.000Z';
-      const result = CompaniIntervalsHelper.CompaniInterval(intervalISO);
+      const startDateISO = '2021-11-24T08:00:00.000Z';
+      const endDateISO = '2021-11-30T09:30:00.000Z';
+      const result = CompaniIntervalsHelper.CompaniInterval(startDateISO, endDateISO);
 
       expect(result)
         .toEqual(expect.objectContaining({
           _getInterval: expect.any(luxon.Interval),
           rangeBy: expect.any(Function),
         }));
-      sinon.assert.calledWithExactly(_formatMiscToCompaniInterval.getCall(0), intervalISO);
+      sinon.assert.calledWithExactly(_formatMiscToCompaniInterval.getCall(0), startDateISO, endDateISO);
     });
 
     it('should return error if endDate is before startDate', () => {
-      const intervalISO = '2021-11-24T08:00:00.000Z/2021-11-20T09:30:00.000Z';
+      const startDateISO = '2021-11-24T08:00:00.000Z';
+      const endDateISO = '2021-11-30T09:30:00.000Z';
       try {
-        CompaniIntervalsHelper.CompaniInterval(intervalISO);
+        CompaniIntervalsHelper.CompaniInterval(startDateISO, endDateISO);
       } catch (e) {
         expect(e).toEqual(new Error('Invalid Interval: end before start: The end of an interval must be after '
           + 'its start, but you had start=2021-11-24T09:00:00.000+01:00 and end=2021-11-20T10:30:00.000+01:00'));
       } finally {
-        sinon.assert.calledOnceWithExactly(_formatMiscToCompaniInterval, intervalISO);
+        sinon.assert.calledOnceWithExactly(_formatMiscToCompaniInterval, startDateISO, endDateISO);
       }
     });
 
@@ -63,17 +71,21 @@ describe('CompaniInterval', () => {
 
 describe('getInterval', () => {
   it('should return _interval', () => {
-    const intervalISO = '2021-11-24T09:00:00.000+01:00/2021-11-30T10:30:00.000+01:00';
-    const companiInterval = CompaniIntervalsHelper.CompaniInterval(intervalISO);
+    const startDateISO = '2021-11-24T08:00:00.000Z';
+    const endDateISO = '2021-11-30T09:30:00.000Z';
+    const companiInterval = CompaniIntervalsHelper.CompaniInterval(startDateISO, endDateISO);
     const result = companiInterval._getInterval;
 
     expect(result).toEqual(expect.any(luxon.Interval));
-    expect(result).toEqual(luxon.Interval.fromISO(intervalISO));
+    expect(result.start.toUTC().toISO()).toEqual(startDateISO);
+    expect(result.end.toUTC().toISO()).toEqual(endDateISO);
   });
 });
 
 describe('rangeBy', () => {
-  const interval = CompaniIntervalsHelper.CompaniInterval('2022-02-11T09:00:00.000Z/2022-02-13T10:30:00.000Z');
+  const startDateISO = '2022-02-11T09:00:00.000Z';
+  const endDateISO = '2022-02-13T10:30:00.000Z';
+  const interval = CompaniIntervalsHelper.CompaniInterval(startDateISO, endDateISO);
 
   it('should return sequence of dates, endDate is not included', () => {
     const result = interval.rangeBy({ days: 1 });
@@ -82,7 +94,8 @@ describe('rangeBy', () => {
   });
 
   it('should return sequence of dates, endDate is the last element of the sequence', () => {
-    const otherInterval = CompaniIntervalsHelper.CompaniInterval('2022-02-11T09:00:00.000Z/2022-02-13T09:00:00.000Z');
+    const otherEndDateISO = '2022-02-13T09:00:00.000Z';
+    const otherInterval = CompaniIntervalsHelper.CompaniInterval(startDateISO, otherEndDateISO);
     const result = otherInterval.rangeBy({ days: 1 });
 
     expect(result).toEqual(['2022-02-11T09:00:00.000Z', '2022-02-12T09:00:00.000Z', '2022-02-13T09:00:00.000Z']);
@@ -111,28 +124,40 @@ describe('rangeBy', () => {
 
 describe('_formatMiscToCompaniInterval', () => {
   let datefromISO;
-  let intervalfromISO;
-  let intervalFromDateTimes;
   let intervalInvalid;
   const intervalISO = '2021-11-24T09:00:00.000+01:00/2021-11-30T10:30:00.000+01:00';
   const interval = luxon.Interval.fromISO(intervalISO);
-  const luxonStartDate = luxon.DateTime.fromISO('2021-11-24T09:00:00.000+01:00');
-  const luxonEndDate = luxon.DateTime.fromISO('2021-11-30T10:30:00.000+01:00');
-  const companiStartDate = CompaniDatesHelper.CompaniDate('2021-11-24T09:00:00.000+01:00');
-  const companiEndDate = CompaniDatesHelper.CompaniDate('2021-11-30T10:30:00.000+01:00');
 
   beforeEach(() => {
     datefromISO = sinon.spy(luxon.DateTime, 'fromISO');
-    intervalfromISO = sinon.spy(luxon.Interval, 'fromISO');
-    intervalFromDateTimes = sinon.spy(luxon.Interval, 'fromDateTimes');
     intervalInvalid = sinon.spy(luxon.Interval, 'invalid');
   });
 
   afterEach(() => {
     datefromISO.restore();
-    intervalfromISO.restore();
-    intervalFromDateTimes.restore();
     intervalInvalid.restore();
+  });
+
+  it('should return interval if arg is instance CompaniInterval', () => {
+    const payload = { _getInterval: interval };
+    const result = CompaniIntervalsHelper._formatMiscToCompaniInterval(payload);
+
+    expect(result instanceof luxon.Interval).toBe(true);
+    expect(new luxon.Interval(result).toISO()).toEqual(intervalISO);
+    sinon.assert.notCalled(datefromISO);
+    sinon.assert.notCalled(intervalInvalid);
+  });
+
+  it('should return interval if 2 args, 2 dates of type ISO string', () => {
+    const coupleOfDateISO = ['2021-11-24T08:00:00.000Z', '2021-11-30T09:30:00.000Z'];
+    const result = CompaniIntervalsHelper._formatMiscToCompaniInterval(...coupleOfDateISO);
+
+    expect(result instanceof luxon.Interval).toBe(true);
+    expect(new luxon.Interval(result).toISO()).toEqual(intervalISO);
+    sinon.assert.calledTwice(datefromISO);
+    sinon.assert.calledWithExactly(datefromISO.getCall(0), coupleOfDateISO[0]);
+    sinon.assert.calledWithExactly(datefromISO.getCall(1), coupleOfDateISO[1]);
+    sinon.assert.notCalled(intervalInvalid);
   });
 
   it('should return error if no arg', () => {
@@ -142,72 +167,32 @@ describe('_formatMiscToCompaniInterval', () => {
       expect(e).toEqual(new Error('Invalid Interval: wrong arguments'));
     } finally {
       sinon.assert.notCalled(datefromISO);
-      sinon.assert.notCalled(intervalfromISO);
-      sinon.assert.notCalled(intervalFromDateTimes);
       sinon.assert.calledOnceWithExactly(intervalInvalid, 'wrong arguments');
     }
   });
 
-  it('should return interval if arg is object with interval', () => {
-    const payload = { _getInterval: interval };
-    const result = CompaniIntervalsHelper._formatMiscToCompaniInterval(payload);
-
-    expect(result instanceof luxon.Interval).toBe(true);
-    expect(new luxon.Interval(result).toISO()).toEqual(intervalISO);
-    sinon.assert.notCalled(datefromISO);
-    sinon.assert.notCalled(intervalfromISO);
-    sinon.assert.notCalled(intervalFromDateTimes);
-    sinon.assert.notCalled(intervalInvalid);
-  });
-
-  it('should return interval if arg is string', () => {
-    const payload = '2022-02-11T09:00:00.000+01:00/2022-03-15T10:00:00.000+01:00';
-    const result = CompaniIntervalsHelper._formatMiscToCompaniInterval(payload);
-
-    expect(result instanceof luxon.Interval).toBe(true);
-    expect(new luxon.Interval(result).toISO()).toEqual('2022-02-11T09:00:00.000+01:00/2022-03-15T10:00:00.000+01:00');
-    sinon.assert.calledTwice(datefromISO); // called by luxon
-    sinon.assert.calledOnceWithExactly(intervalfromISO, payload);
-    sinon.assert.calledOnce(intervalFromDateTimes); // called by luxon
-    sinon.assert.notCalled(intervalInvalid);
-  });
-
-  it('should return error if arg is empty string', () => {
+  it('should return error if arg is interval of type ISO string', () => {
     try {
-      CompaniIntervalsHelper._formatMiscToCompaniInterval('');
+      const payload = '2022-02-11T09:00:00.000+01:00/2022-03-15T10:00:00.000+01:00';
+      CompaniIntervalsHelper._formatMiscToCompaniInterval(payload);
     } catch (e) {
       expect(e).toEqual(new Error('Invalid Interval: wrong arguments'));
     } finally {
       sinon.assert.notCalled(datefromISO);
-      sinon.assert.notCalled(intervalfromISO);
-      sinon.assert.notCalled(intervalFromDateTimes);
       sinon.assert.calledOnceWithExactly(intervalInvalid, 'wrong arguments');
     }
   });
 
-  it('should return interval if 2 args of type string', () => {
-    const coupleOfDateISO = ['2021-11-24T08:00:00.000Z', '2021-11-30T09:30:00.000Z'];
-    const result = CompaniIntervalsHelper._formatMiscToCompaniInterval(...coupleOfDateISO);
-
-    expect(result instanceof luxon.Interval).toBe(true);
-    expect(new luxon.Interval(result).toISO()).toEqual(intervalISO);
-    sinon.assert.calledOnceWithExactly(intervalFromDateTimes, luxonStartDate, luxonEndDate);
-    sinon.assert.calledTwice(datefromISO);
-    sinon.assert.calledWithExactly(datefromISO.getCall(0), coupleOfDateISO[0]);
-    sinon.assert.calledWithExactly(datefromISO.getCall(1), coupleOfDateISO[1]);
-    sinon.assert.notCalled(intervalfromISO);
-    sinon.assert.notCalled(intervalInvalid);
-  });
-
-  it('should return interval if 2 args of type DateTime', () => {
-    const result = CompaniIntervalsHelper._formatMiscToCompaniInterval(companiStartDate, companiEndDate);
-
-    expect(result instanceof luxon.Interval).toBe(true);
-    expect(new luxon.Interval(result).toISO()).toEqual(intervalISO);
-    sinon.assert.notCalled(datefromISO);
-    sinon.assert.notCalled(intervalfromISO);
-    sinon.assert.calledOnceWithExactly(intervalFromDateTimes, luxonStartDate, luxonEndDate);
-    sinon.assert.notCalled(intervalInvalid);
+  it('should return error if 2 args of type DateTime #tag', () => {
+    const companiStartDate = CompaniDatesHelper.CompaniDate('2021-11-24T09:00:00.000+01:00');
+    const companiEndDate = CompaniDatesHelper.CompaniDate('2021-11-30T10:30:00.000+01:00');
+    try {
+      CompaniIntervalsHelper._formatMiscToCompaniInterval(companiStartDate, companiEndDate);
+    } catch (e) {
+      expect(e).toEqual(new Error('Invalid Interval: wrong arguments'));
+    } finally {
+      sinon.assert.calledOnceWithExactly(intervalInvalid, 'wrong arguments');
+    }
   });
 
   it('should return error if arg is luxon.Interval', () => {
@@ -218,8 +203,6 @@ describe('_formatMiscToCompaniInterval', () => {
       expect(e).toEqual(new Error('Invalid Interval: wrong arguments'));
     } finally {
       sinon.assert.notCalled(datefromISO);
-      sinon.assert.notCalled(intervalfromISO);
-      sinon.assert.notCalled(intervalFromDateTimes);
       sinon.assert.calledOnceWithExactly(intervalInvalid, 'wrong arguments');
     }
   });
@@ -231,8 +214,6 @@ describe('_formatMiscToCompaniInterval', () => {
       expect(e).toEqual(new Error('Invalid Interval: wrong arguments'));
     } finally {
       sinon.assert.notCalled(datefromISO);
-      sinon.assert.notCalled(intervalfromISO);
-      sinon.assert.notCalled(intervalFromDateTimes);
       sinon.assert.calledOnceWithExactly(intervalInvalid, 'wrong arguments');
     }
   });

--- a/tests/unit/helpers/dates/companiIntervals.test.js
+++ b/tests/unit/helpers/dates/companiIntervals.test.js
@@ -44,19 +44,6 @@ describe('CompaniInterval', () => {
       sinon.assert.calledWithExactly(_formatMiscToCompaniInterval.getCall(0), startDateISO, endDateISO);
     });
 
-    it('should return error if endDate is before startDate', () => {
-      const startDateISO = '2021-11-24T08:00:00.000Z';
-      const endDateISO = '2021-11-30T09:30:00.000Z';
-      try {
-        CompaniIntervalsHelper.CompaniInterval(startDateISO, endDateISO);
-      } catch (e) {
-        expect(e).toEqual(new Error('Invalid Interval: end before start: The end of an interval must be after '
-          + 'its start, but you had start=2021-11-24T09:00:00.000+01:00 and end=2021-11-20T10:30:00.000+01:00'));
-      } finally {
-        sinon.assert.calledOnceWithExactly(_formatMiscToCompaniInterval, startDateISO, endDateISO);
-      }
-    });
-
     it('should return error if invalid argument', () => {
       try {
         CompaniIntervalsHelper.CompaniInterval(null);
@@ -164,6 +151,22 @@ describe('_formatMiscToCompaniInterval', () => {
     sinon.assert.calledWithExactly(datefromISO.getCall(0), coupleOfDateISO[0]);
     sinon.assert.calledWithExactly(datefromISO.getCall(1), coupleOfDateISO[1]);
     sinon.assert.notCalled(intervalInvalid);
+  });
+
+  it('should return error if endDate is before startDate', () => {
+    const startDateISO = '2021-11-24T08:00:00.000Z';
+    const endDateISO = '2021-11-30T09:30:00.000Z';
+    try {
+      CompaniIntervalsHelper._formatMiscToCompaniInterval(startDateISO, endDateISO);
+    } catch (e) {
+      expect(e).toEqual(new Error('Invalid Interval: end before start: The end of an interval must be after '
+        + 'its start, but you had start=2021-11-24T09:00:00.000+01:00 and end=2021-11-20T10:30:00.000+01:00'));
+    } finally {
+      sinon.assert.calledTwice(datefromISO);
+      sinon.assert.calledWithExactly(datefromISO.getCall(0), startDateISO);
+      sinon.assert.calledWithExactly(datefromISO.getCall(1), endDateISO);
+      sinon.assert.notCalled(intervalInvalid);
+    }
   });
 
   it('should return error if no arg', () => {

--- a/tests/unit/helpers/dates/companiIntervals.test.js
+++ b/tests/unit/helpers/dates/companiIntervals.test.js
@@ -87,8 +87,14 @@ describe('rangeBy', () => {
   const endDateISO = '2022-02-13T10:30:00.000Z';
   const interval = CompaniIntervalsHelper.CompaniInterval(startDateISO, endDateISO);
 
-  it('should return sequence of dates, endDate is not included', () => {
+  it('should accept duration object as argument. TO BE removed after spliting "outil" from "formation"', () => {
     const result = interval.rangeBy({ days: 1 });
+
+    expect(result).toEqual(['2022-02-11T09:00:00.000Z', '2022-02-12T09:00:00.000Z', '2022-02-13T09:00:00.000Z']);
+  });
+
+  it('should return sequence of dates, endDate is not included', () => {
+    const result = interval.rangeBy('P1D');
 
     expect(result).toEqual(['2022-02-11T09:00:00.000Z', '2022-02-12T09:00:00.000Z', '2022-02-13T09:00:00.000Z']);
   });
@@ -96,26 +102,26 @@ describe('rangeBy', () => {
   it('should return sequence of dates, endDate is the last element of the sequence', () => {
     const otherEndDateISO = '2022-02-13T09:00:00.000Z';
     const otherInterval = CompaniIntervalsHelper.CompaniInterval(startDateISO, otherEndDateISO);
-    const result = otherInterval.rangeBy({ days: 1 });
+    const result = otherInterval.rangeBy('P1D');
 
     expect(result).toEqual(['2022-02-11T09:00:00.000Z', '2022-02-12T09:00:00.000Z', '2022-02-13T09:00:00.000Z']);
   });
 
   it('should return sequence of dates, last element is excluded', () => {
-    const result = interval.rangeBy({ days: 1 }, true);
+    const result = interval.rangeBy('P1D', true);
 
     expect(result).toEqual(['2022-02-11T09:00:00.000Z', '2022-02-12T09:00:00.000Z']);
   });
 
   it('should return sequence of dates, step is not 1', () => {
-    const result = interval.rangeBy({ days: 1.5 });
+    const result = interval.rangeBy('P1.5D');
 
     expect(result).toEqual(['2022-02-11T09:00:00.000Z', '2022-02-12T21:00:00.000Z']);
   });
 
   it('should return error if duration is zero', () => {
     try {
-      interval.rangeBy({});
+      interval.rangeBy('PT0S');
     } catch (e) {
       expect(e).toEqual(new Error('invalid argument : duration is zero'));
     }
@@ -183,7 +189,7 @@ describe('_formatMiscToCompaniInterval', () => {
     }
   });
 
-  it('should return error if 2 args of type DateTime #tag', () => {
+  it('should return error if 2 args of type DateTime', () => {
     const companiStartDate = CompaniDatesHelper.CompaniDate('2021-11-24T09:00:00.000+01:00');
     const companiEndDate = CompaniDatesHelper.CompaniDate('2021-11-30T10:30:00.000+01:00');
     try {


### PR DESCRIPTION
<details open><summary> TESTS  :computer: </summary>

- [x] J'ai codé les tests unitaires
- [ ] J'ai codé les tests d'intégration
- [ ] C'est une ancienne route utilisée par les apps mobiles.
  - [ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens
</details>

- [ ] Je replie cette section car mes modifications n'ont pas besoin de tests unitaires ou d'intégration

---

<details><summary> POINTS D'ATTENTION POUR CETTE PR  :warning: </summary>

- [ ] J'ai fait des modifications sur une route utilisée sur plusieurs plateformes [Doc de détail](https://www.notion.so/Points-d-attention-sur-les-routes-a548a8e32d314d5e92cb342e66cce443)
- [ ] J'ai modifié un modèle utilisé en mobile [Doc de détail](https://www.notion.so/Point-d-attention-sur-les-mod-les-e46fbf180cd34a569f3c6102366e47ca)
- [ ] J'ai ajouté un modèle spécifique à une structure 
  - [ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés
- [ ] J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile
  - [ ] Si oui, j'ai précisé sur le [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) qu'il faut forcer la mise à jour
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [Doc de MES](https://www.notion.so/Pas-pas-Mise-en-staging-01755ac57d944b4cb0c189861428e5d2) et [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) les modifications faites

</details>

- [x] Je replie cette section car je n'ai pas fait de modifications entrainant un point d'attention

---

<details><summary> FONCTIONNALITÉS APPS MOBILES  :iphone: </summary>

- [ ] Mes changements impactent l'application formation
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours
- [ ] Mes changements impactent l'application erp
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours

</details>

- [x] Je replie cette section car mes modifications n'ont pas d'impact sur les applications mobiles

_Si tu as lu cette description, pense à réagir avec un :eye:_
