### PR TITLE
COM-3249 add isEquivalentTo method in companiDuration

### DIFF
--- a/src/helpers/dates/companiDurations.js
+++ b/src/helpers/dates/companiDurations.js
@@ -54,6 +54,14 @@ const companiDurationFactory = (inputDuration) => {
       return _duration.toISO();
     },
 
+    // QUERY
+    isEqual(miscTypeOtherDuration) {
+      const otherDurationInSeconds = exports._formatMiscToCompaniDuration(miscTypeOtherDuration).shiftTo('seconds');
+      const durationInSeconds = _duration.shiftTo('seconds');
+
+      return durationInSeconds.equals(otherDurationInSeconds);
+    },
+
     // MANIPULATE
     add(miscTypeOtherDuration) {
       const otherDuration = exports._formatMiscToCompaniDuration(miscTypeOtherDuration);

--- a/src/helpers/dates/companiDurations.js
+++ b/src/helpers/dates/companiDurations.js
@@ -55,7 +55,7 @@ const companiDurationFactory = (inputDuration) => {
     },
 
     // QUERY
-    isEqual(miscTypeOtherDuration) {
+    isEquivalent(miscTypeOtherDuration) {
       const otherDurationInSeconds = exports._formatMiscToCompaniDuration(miscTypeOtherDuration).shiftTo('seconds');
       const durationInSeconds = _duration.shiftTo('seconds');
 

--- a/src/helpers/dates/companiDurations.js
+++ b/src/helpers/dates/companiDurations.js
@@ -55,7 +55,7 @@ const companiDurationFactory = (inputDuration) => {
     },
 
     // QUERY
-    isEquivalent(miscTypeOtherDuration) {
+    isEquivalentTo(miscTypeOtherDuration) {
       const otherDurationInSeconds = exports._formatMiscToCompaniDuration(miscTypeOtherDuration).shiftTo('seconds');
       const durationInSeconds = _duration.shiftTo('seconds');
 

--- a/tests/unit/helpers/dates/companiDuration.test.js
+++ b/tests/unit/helpers/dates/companiDuration.test.js
@@ -369,6 +369,37 @@ describe('MANIPULATE', () => {
   });
 });
 
+describe('QUERY', () => {
+  describe('isEqual', () => {
+    it('should return true if same durations with same units', () => {
+      const duration = 'P1DT1H2M3S';
+      const otherDuration = 'P1DT1H2M3S';
+
+      const result = CompaniDurationsHelper.CompaniDuration(duration).isEqual(otherDuration);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return true if same durations with different units', () => {
+      const duration = 'P1DT1H2M3S';
+      const otherDuration = 'PT25H123S';
+
+      const result = CompaniDurationsHelper.CompaniDuration(duration).isEqual(otherDuration);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false if different durations', () => {
+      const duration = 'P1DT1H2M3S';
+      const otherDuration = 'PT24H123S';
+
+      const result = CompaniDurationsHelper.CompaniDuration(duration).isEqual(otherDuration);
+
+      expect(result).toBe(false);
+    });
+  });
+});
+
 describe('_formatMiscToCompaniDuration', () => {
   let fromObject;
   let fromMillis;

--- a/tests/unit/helpers/dates/companiDuration.test.js
+++ b/tests/unit/helpers/dates/companiDuration.test.js
@@ -370,12 +370,12 @@ describe('MANIPULATE', () => {
 });
 
 describe('QUERY', () => {
-  describe('isEqual', () => {
+  describe('isEquivalent', () => {
     it('should return true if same durations with same units', () => {
       const duration = 'P1DT1H2M3S';
       const otherDuration = 'P1DT1H2M3S';
 
-      const result = CompaniDurationsHelper.CompaniDuration(duration).isEqual(otherDuration);
+      const result = CompaniDurationsHelper.CompaniDuration(duration).isEquivalent(otherDuration);
 
       expect(result).toBe(true);
     });
@@ -384,7 +384,7 @@ describe('QUERY', () => {
       const duration = 'P1DT1H2M3S';
       const otherDuration = 'PT25H123S';
 
-      const result = CompaniDurationsHelper.CompaniDuration(duration).isEqual(otherDuration);
+      const result = CompaniDurationsHelper.CompaniDuration(duration).isEquivalent(otherDuration);
 
       expect(result).toBe(true);
     });
@@ -393,7 +393,7 @@ describe('QUERY', () => {
       const duration = 'P1DT1H2M3S';
       const otherDuration = 'PT24H123S';
 
-      const result = CompaniDurationsHelper.CompaniDuration(duration).isEqual(otherDuration);
+      const result = CompaniDurationsHelper.CompaniDuration(duration).isEquivalent(otherDuration);
 
       expect(result).toBe(false);
     });

--- a/tests/unit/helpers/dates/companiDuration.test.js
+++ b/tests/unit/helpers/dates/companiDuration.test.js
@@ -370,12 +370,12 @@ describe('MANIPULATE', () => {
 });
 
 describe('QUERY', () => {
-  describe('isEquivalent', () => {
+  describe('isEquivalentTo', () => {
     it('should return true if same durations with same units', () => {
       const duration = 'P1DT1H2M3S';
       const otherDuration = 'P1DT1H2M3S';
 
-      const result = CompaniDurationsHelper.CompaniDuration(duration).isEquivalent(otherDuration);
+      const result = CompaniDurationsHelper.CompaniDuration(duration).isEquivalentTo(otherDuration);
 
       expect(result).toBe(true);
     });
@@ -384,7 +384,7 @@ describe('QUERY', () => {
       const duration = 'P1DT1H2M3S';
       const otherDuration = 'PT25H123S';
 
-      const result = CompaniDurationsHelper.CompaniDuration(duration).isEquivalent(otherDuration);
+      const result = CompaniDurationsHelper.CompaniDuration(duration).isEquivalentTo(otherDuration);
 
       expect(result).toBe(true);
     });
@@ -393,7 +393,7 @@ describe('QUERY', () => {
       const duration = 'P1DT1H2M3S';
       const otherDuration = 'PT24H123S';
 
-      const result = CompaniDurationsHelper.CompaniDuration(duration).isEquivalent(otherDuration);
+      const result = CompaniDurationsHelper.CompaniDuration(duration).isEquivalentTo(otherDuration);
 
       expect(result).toBe(false);
     });


### PR DESCRIPTION
<details open><summary> TESTS  :computer: </summary>

- [x] J'ai codé les tests unitaires
- [ ] J'ai codé les tests d'intégration -np
- [ ] C'est une ancienne route utilisée par les apps mobiles.
  - [ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens
</details>

- [ ] Je replie cette section car mes modifications n'ont pas besoin de tests unitaires ou d'intégration

---

<details><summary> POINTS D'ATTENTION POUR CETTE PR  :warning: </summary>

- [ ] J'ai fait des modifications sur une route utilisée sur plusieurs plateformes [Doc de détail](https://www.notion.so/Points-d-attention-sur-les-routes-a548a8e32d314d5e92cb342e66cce443)
- [ ] J'ai modifié un modèle utilisé en mobile [Doc de détail](https://www.notion.so/Point-d-attention-sur-les-mod-les-e46fbf180cd34a569f3c6102366e47ca)
- [ ] J'ai ajouté un modèle spécifique à une structure 
  - [ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés
- [ ] J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile
  - [ ] Si oui, j'ai précisé sur le [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) qu'il faut forcer la mise à jour
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [Doc de MES](https://www.notion.so/Pas-pas-Mise-en-staging-01755ac57d944b4cb0c189861428e5d2) et [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) les modifications faites

</details>

- [x] Je replie cette section car je n'ai pas fait de modifications entrainant un point d'attention

---

<details><summary> FONCTIONNALITÉS APPS MOBILES  :iphone: </summary>

- [ ] Mes changements impactent l'application formation
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours
- [ ] Mes changements impactent l'application erp
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours

</details>

- [x] Je replie cette section car mes modifications n'ont pas d'impact sur les applications mobiles

Note : ajout d'une methode utilisée sur mobile

_Si tu as lu cette description, pense à réagir avec un :eye:_
