### PR TITLE
Com 3285

### DIFF
--- a/src/helpers/dates/companiDurations.js
+++ b/src/helpers/dates/companiDurations.js
@@ -86,6 +86,13 @@ const companiDurationFactory = (inputDuration) => {
       return durationInSeconds > otherDurationInSeconds;
     },
 
+    isShorterThan(miscTypeOtherDuration) {
+      const otherDurationInSeconds = exports._formatMiscToCompaniDuration(miscTypeOtherDuration).as('seconds');
+      const durationInSeconds = _duration.as('seconds');
+
+      return durationInSeconds < otherDurationInSeconds;
+    },
+
     // MANIPULATE
     add(miscTypeOtherDuration) {
       const otherDuration = exports._formatMiscToCompaniDuration(miscTypeOtherDuration);

--- a/src/helpers/dates/companiDurations.js
+++ b/src/helpers/dates/companiDurations.js
@@ -34,6 +34,14 @@ const companiDurationFactory = (inputDuration) => {
       throw Error('Invalid argument: expected specific format');
     },
 
+    asYears() {
+      return _duration.as('years');
+    },
+
+    asMonths() {
+      return _duration.as('months');
+    },
+
     asDays() {
       return _duration.as('days');
     },

--- a/src/helpers/dates/companiDurations.js
+++ b/src/helpers/dates/companiDurations.js
@@ -92,6 +92,11 @@ const companiDurationFactory = (inputDuration) => {
 
       return companiDurationFactory(_duration.plus(otherDuration));
     },
+
+    abs() {
+      if (_duration.as('seconds') > 0) return companiDurationFactory(_duration);
+      return companiDurationFactory(_duration.mapUnits(value => -value));
+    },
   };
 };
 

--- a/tests/unit/helpers/dates/companiDuration.test.js
+++ b/tests/unit/helpers/dates/companiDuration.test.js
@@ -561,6 +561,71 @@ describe('QUERY', () => {
       expect(result).toBe(false);
     });
   });
+
+  describe('isShorterThan', () => {
+    it('should return true if shorter duration with same units', () => {
+      const duration = 'P1DT1H2M6S';
+      const otherDuration = 'P1DT2H2M3S';
+
+      const result = CompaniDurationsHelper.CompaniDuration(duration).isShorterThan(otherDuration);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return true if shorter duration with different units', () => {
+      const duration = 'PT22H2M3S';
+      const otherDuration = 'P1DT30S';
+
+      const result = CompaniDurationsHelper.CompaniDuration(duration).isShorterThan(otherDuration);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return true if comparing with MAX_SAFE_INTEGER with lower value', () => {
+      const duration = `PT${Number.MAX_SAFE_INTEGER - 1000}S`;
+      const otherDuration = `PT${Number.MAX_SAFE_INTEGER}S`;
+
+      const result = CompaniDurationsHelper.CompaniDuration(duration).isShorterThan(otherDuration);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false if same duration with same units', () => {
+      const duration = 'P1DT2H2M3S';
+      const otherDuration = 'P1DT2H2M3S';
+
+      const result = CompaniDurationsHelper.CompaniDuration(duration).isShorterThan(otherDuration);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false if same duration with different units', () => {
+      const duration = 'P1DT1H2M3S';
+      const otherDuration = 'PT25H123S';
+
+      const result = CompaniDurationsHelper.CompaniDuration(duration).isShorterThan(otherDuration);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false if longer duration with same units', () => {
+      const duration = 'P1DT3H1M3S';
+      const otherDuration = 'P1DT2H2M3S';
+
+      const result = CompaniDurationsHelper.CompaniDuration(duration).isShorterThan(otherDuration);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false if longer duration with different units', () => {
+      const duration = 'P1DT30H';
+      const otherDuration = 'PT40H';
+
+      const result = CompaniDurationsHelper.CompaniDuration(duration).isShorterThan(otherDuration);
+
+      expect(result).toBe(false);
+    });
+  });
 });
 
 describe('_formatMiscToCompaniDuration', () => {

--- a/tests/unit/helpers/dates/companiDuration.test.js
+++ b/tests/unit/helpers/dates/companiDuration.test.js
@@ -445,6 +445,26 @@ describe('MANIPULATE', () => {
       sinon.assert.calledWithExactly(_formatMiscToCompaniDuration.getCall(0), addedAmount);
     });
   });
+
+  describe('abs', () => {
+    it('should return same value, as it is positive', () => {
+      const duration = CompaniDurationsHelper.CompaniDuration('P1DT-13H-4M32S'); // 39392000 ms
+      const result = duration.abs();
+
+      expect(result).toEqual(expect.objectContaining({ _getDuration: expect.any(luxon.Duration) }));
+      expect(result._getDuration.toISO()).toEqual('P1DT-13H-4M32S');
+      expect(result._getDuration.toMillis()).toBe(39392000);
+    });
+
+    it('should return opposite value, as it is negative', () => {
+      const duration = CompaniDurationsHelper.CompaniDuration('P1DT-32H-4M32S'); // -29008000 ms
+      const result = duration.abs();
+
+      expect(result).toEqual(expect.objectContaining({ _getDuration: expect.any(luxon.Duration) }));
+      expect(result._getDuration.toISO()).toEqual('P-1DT32H4M-32S');
+      expect(result._getDuration.toMillis()).toBe(29008000);
+    });
+  });
 });
 
 describe('QUERY', () => {

--- a/tests/unit/helpers/dates/companiDuration.test.js
+++ b/tests/unit/helpers/dates/companiDuration.test.js
@@ -237,6 +237,66 @@ describe('DISPLAY', () => {
     });
   });
 
+  describe('asYears', () => {
+    it('should return duration in years', () => {
+      const companiDuration = CompaniDurationsHelper.CompaniDuration('P3Y');
+      const result = companiDuration.asYears();
+
+      expect(result).toBe(3);
+    });
+
+    it('should return duration in years, with months', () => {
+      const companiDuration = CompaniDurationsHelper.CompaniDuration('P1Y2M');
+      const result = companiDuration.asYears();
+
+      expect(result).toBe(1.1666666666666667); // 1.1666666666666667 = 1 + 2 / 12
+    });
+
+    it('should return duration in years, with days', () => {
+      const companiDuration = CompaniDurationsHelper.CompaniDuration('P4Y5D');
+      const result = companiDuration.asYears();
+
+      expect(result).toBe(4.013698630136986); // 4.013698630136986 = 4 + 5 / 365
+    });
+
+    it('should return duration in months, with seconds', () => {
+      const companiDuration = CompaniDurationsHelper.CompaniDuration('P7YT45S');
+      const result = companiDuration.asYears();
+
+      expect(result).toBe(7.000001426940639); //  7.000001426940639   = 7 + 4 / (3600 * 24 * 365)
+    });
+  });
+
+  describe('asMonths', () => {
+    it('should return duration in months', () => {
+      const companiDuration = CompaniDurationsHelper.CompaniDuration('P5M');
+      const result = companiDuration.asMonths();
+
+      expect(result).toBe(5);
+    });
+
+    it('should return duration in months, with days', () => {
+      const companiDuration = CompaniDurationsHelper.CompaniDuration('P1M9D');
+      const result = companiDuration.asMonths();
+
+      expect(result).toBe(1.3); // 1.2 = 1 + 9 / 30
+    });
+
+    it('should return duration in months, with hours', () => {
+      const companiDuration = CompaniDurationsHelper.CompaniDuration('P2MT9H');
+      const result = companiDuration.asMonths();
+
+      expect(result).toBe(2.0125); // 2.00625 = 2 + 9 / (24 * 30)
+    });
+
+    it('should return duration in months, with seconds', () => {
+      const companiDuration = CompaniDurationsHelper.CompaniDuration('P1MT4S');
+      const result = companiDuration.asMonths();
+
+      expect(result).toBe(1.0000015432098766); // 1.0000015432098766 = 1 + 4 / (3600 * 24 * 30)
+    });
+  });
+
   describe('asDays', () => {
     it('should return duration in days', () => {
       const companiDuration = CompaniDurationsHelper.CompaniDuration('P3D');


### PR DESCRIPTION
<details open><summary> TESTS  :computer: </summary>

- [x] J'ai codé les tests unitaires
- [ ] J'ai codé les tests d'intégration
- [ ] C'est une ancienne route utilisée par les apps mobiles.
  - [ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens
</details>

- [ ] Je replie cette section car mes modifications n'ont pas besoin de tests unitaires ou d'intégration

---

<details><summary> POINTS D'ATTENTION POUR CETTE PR  :warning: </summary>

- [ ] J'ai fait des modifications sur une route utilisée sur plusieurs plateformes [Doc de détail](https://www.notion.so/Points-d-attention-sur-les-routes-a548a8e32d314d5e92cb342e66cce443)
- [ ] J'ai modifié un modèle utilisé en mobile [Doc de détail](https://www.notion.so/Point-d-attention-sur-les-mod-les-e46fbf180cd34a569f3c6102366e47ca)
- [ ] J'ai ajouté un modèle spécifique à une structure 
  - [ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés
- [ ] J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile
  - [ ] Si oui, j'ai précisé sur le [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) qu'il faut forcer la mise à jour
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [Doc de MES](https://www.notion.so/Pas-pas-Mise-en-staging-01755ac57d944b4cb0c189861428e5d2) et [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) les modifications faites

</details>

- [x] Je replie cette section car je n'ai pas fait de modifications entrainant un point d'attention

---

<details><summary> FONCTIONNALITÉS APPS MOBILES  :iphone: </summary>

- [ ] Mes changements impactent l'application formation
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours
- [ ] Mes changements impactent l'application erp
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours

</details>

- [x] Je replie cette section car mes modifications n'ont pas d'impact sur les applications mobiles

_Si tu as lu cette description, pense à réagir avec un :eye:_
