### PR TITLE
COM-3309 refacto CompaniInterval.rangeBy

### DIFF
--- a/src/helpers/dates/companiIntervals.js
+++ b/src/helpers/dates/companiIntervals.js
@@ -11,8 +11,8 @@ const CompaniIntervalFactory = (inputInterval) => {
       return _interval;
     },
 
+    // TO BE REMOVED AFTER SPLITING outils FROM formation
     rangeBy(miscTypeDurationStep, excludeEnd = false) {
-      // TO BE REMOVED AFTER SPLITING outils FROM formation
       const luxonDurationStep = CompaniDuration(miscTypeDurationStep)._getDuration;
       if (luxonDurationStep.toMillis() === 0) throw new Error('invalid argument : duration is zero');
 
@@ -26,8 +26,8 @@ const CompaniIntervalFactory = (inputInterval) => {
       return excludeEnd ? dates.slice(0, -1) : dates;
     },
 
+    // TO BE RENAMED "rangeBy" AFTER SPLITING outils FROM formation
     newRangeBy(durationISO) {
-      // TO BE RENAMED "rangeBy" AFTER SPLITING outils FROM formation
       const luxonDurationStep = luxon.Duration.fromISO(durationISO);
       if (luxonDurationStep.toMillis() === 0) throw new Error('invalid argument : duration is zero');
 

--- a/src/helpers/dates/companiIntervals.js
+++ b/src/helpers/dates/companiIntervals.js
@@ -12,8 +12,7 @@ const CompaniIntervalFactory = (inputInterval) => {
     },
 
     rangeBy(miscTypeDurationStep, excludeEnd = false) {
-      // after spliting "outil" from "formation", first argument should be only duration in string ISO
-      // const luxonDurationStep = luxon.Duration.fromISO(durationISO);
+      // TO BE REMOVED AFTER SPLITING outils FROM formation
       const luxonDurationStep = CompaniDuration(miscTypeDurationStep)._getDuration;
       if (luxonDurationStep.toMillis() === 0) throw new Error('invalid argument : duration is zero');
 
@@ -25,6 +24,21 @@ const CompaniIntervalFactory = (inputInterval) => {
       if (lastFragmentEqualsDurationStep) dates.push(_interval.end.toUTC().toISO());
 
       return excludeEnd ? dates.slice(0, -1) : dates;
+    },
+
+    newRangeBy(durationISO) {
+      // TO BE RENAMED "rangeBy" AFTER SPLITING outils FROM formation
+      const luxonDurationStep = luxon.Duration.fromISO(durationISO);
+      if (luxonDurationStep.toMillis() === 0) throw new Error('invalid argument : duration is zero');
+
+      const fragmentedIntervals = _interval.splitBy(luxonDurationStep);
+      const dates = fragmentedIntervals.map(fi => fi.start.toUTC().toISO());
+
+      const lastFragment = fragmentedIntervals[fragmentedIntervals.length - 1];
+      const lastFragmentEqualsDurationStep = lastFragment.start.plus(luxonDurationStep).equals(lastFragment.end);
+      if (lastFragmentEqualsDurationStep) dates.push(_interval.end.toUTC().toISO());
+
+      return dates;
     },
   });
 };

--- a/tests/unit/helpers/dates/companiIntervals.test.js
+++ b/tests/unit/helpers/dates/companiIntervals.test.js
@@ -115,6 +115,47 @@ describe('rangeBy', () => {
   });
 });
 
+describe('newRangeBy', () => {
+  it('should return sequence of dates, endDate is not included', () => {
+    const interval = CompaniIntervalsHelper.CompaniInterval('2022-02-11T09:00:00.000Z', '2022-02-13T10:30:00.000Z');
+    const result = interval.newRangeBy('P1D');
+
+    expect(result).toEqual(['2022-02-11T09:00:00.000Z', '2022-02-12T09:00:00.000Z', '2022-02-13T09:00:00.000Z']);
+  });
+
+  it('should return sequence of dates (step is 1 day), endDate is the last element of the sequence', () => {
+    const interval = CompaniIntervalsHelper.CompaniInterval('2022-02-11T09:00:00.000Z', '2022-02-13T09:00:00.000Z');
+    const result = interval.newRangeBy('P1D');
+
+    expect(result).toEqual(['2022-02-11T09:00:00.000Z', '2022-02-12T09:00:00.000Z', '2022-02-13T09:00:00.000Z']);
+  });
+
+  it('should return sequence of dates (step is 1 month), endDate is the last element of the sequence,', () => {
+    const interval = CompaniIntervalsHelper.CompaniInterval(
+      '2022-01-03T10:00:00.000+01:00',
+      '2022-05-03T10:00:00.000+02:00'
+    );
+    const result = interval.newRangeBy('P1M');
+
+    expect(result).toEqual([
+      '2022-01-03T09:00:00.000Z',
+      '2022-02-03T09:00:00.000Z',
+      '2022-03-03T09:00:00.000Z',
+      '2022-04-03T08:00:00.000Z', // time shifts from winter to summer
+      '2022-05-03T08:00:00.000Z',
+    ]);
+  });
+
+  it('should return error if duration is zero', () => {
+    try {
+      const interval = CompaniIntervalsHelper.CompaniInterval('2022-02-11T09:00:00.000Z', '2022-02-13T10:30:00.000Z');
+      interval.newRangeBy('PT0S');
+    } catch (e) {
+      expect(e).toEqual(new Error('invalid argument : duration is zero'));
+    }
+  });
+});
+
 describe('_formatMiscToCompaniInterval', () => {
   let datefromISO;
   let intervalInvalid;


### PR DESCRIPTION
<details open><summary> TESTS  :computer: </summary>

- [x] J'ai codé les tests unitaires
- [ ] J'ai codé les tests d'intégration
- [ ] C'est une ancienne route utilisée par les apps mobiles.
  - [ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens
</details>

- [ ] Je replie cette section car mes modifications n'ont pas besoin de tests unitaires ou d'intégration

---

<details><summary> POINTS D'ATTENTION POUR CETTE PR  :warning: </summary>

- [ ] J'ai fait des modifications sur une route utilisée sur plusieurs plateformes [Doc de détail](https://www.notion.so/Points-d-attention-sur-les-routes-a548a8e32d314d5e92cb342e66cce443)
- [ ] J'ai modifié un modèle utilisé en mobile [Doc de détail](https://www.notion.so/Point-d-attention-sur-les-mod-les-e46fbf180cd34a569f3c6102366e47ca)
- [ ] J'ai ajouté un modèle spécifique à une structure 
  - [ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés
- [ ] J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile
  - [ ] Si oui, j'ai précisé sur le [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) qu'il faut forcer la mise à jour
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [Doc de MES](https://www.notion.so/Pas-pas-Mise-en-staging-01755ac57d944b4cb0c189861428e5d2) et [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) les modifications faites

</details>

- [x] Je replie cette section car je n'ai pas fait de modifications entrainant un point d'attention

---

<details><summary> FONCTIONNALITÉS APPS MOBILES  :iphone: </summary>

- [ ] Mes changements impactent l'application formation
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours
- [ ] Mes changements impactent l'application erp
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours

</details>

- [x] Je replie cette section car mes modifications n'ont pas d'impact sur les applications mobiles

_Si tu as lu cette description, pense à réagir avec un :eye:_
