### PR TITLE
COM-3382 - can't remove courseSlot dates if attendances

### DIFF
--- a/src/helpers/translate.js
+++ b/src/helpers/translate.js
@@ -334,6 +334,7 @@ module.exports = {
     courseSlotDeleted: 'Course slot deleted.',
     courseSlotNotFound: 'Course slot not found.',
     courseSlotConflict: 'Course slot in conflict.',
+    courseSlotWithAttendances: 'Course slot has attendances.',
     /* Course funding organisation */
     courseFundingOrganisationsFound: 'Course funding organisations found.',
     courseFundingOrganisationsNotFound: 'Course funding organisations not found.',
@@ -739,6 +740,7 @@ module.exports = {
     courseSlotDeleted: 'Créneau de formation supprimé.',
     courseSlotNotFound: 'Créneau de formation non trouvé.',
     courseSlotConflict: 'Créneau de formation en conflit.',
+    courseSlotWithAttendances: 'Impossible: ce créneau de formation est émargé.',
     /* Course funding organisation */
     courseFundingOrganisationsFound: 'Financeurs trouvés.',
     courseFundingOrganisationsNotFound: 'Financeurs non trouvés.',

--- a/src/routes/preHandlers/courseSlot.js
+++ b/src/routes/preHandlers/courseSlot.js
@@ -80,8 +80,11 @@ exports.authorizeUpdate = async (req) => {
       .lean();
     if (!courseSlot) throw Boom.notFound(translate[language].courseSlotNotFound);
 
-    const attendances = await Attendance.countDocuments({ courseSlot: req.params._id });
-    if (attendances) throw Boom.forbidden(translate[language].courseSlotWithAttendances);
+    const { startDate, endDate } = req.payload;
+    if (!startDate && !endDate) {
+      const attendances = await Attendance.countDocuments({ courseSlot: req.params._id });
+      if (attendances) throw Boom.forbidden(translate[language].courseSlotWithAttendances);
+    }
 
     const courseId = get(courseSlot, 'course') || '';
     await formatAndCheckAuthorization(courseId, req.auth.credentials);

--- a/src/routes/preHandlers/courseSlot.js
+++ b/src/routes/preHandlers/courseSlot.js
@@ -80,6 +80,9 @@ exports.authorizeUpdate = async (req) => {
       .lean();
     if (!courseSlot) throw Boom.notFound(translate[language].courseSlotNotFound);
 
+    const attendances = await Attendance.countDocuments({ courseSlot: req.params._id });
+    if (attendances) throw Boom.forbidden(translate[language].courseSlotWithAttendances);
+
     const courseId = get(courseSlot, 'course') || '';
     await formatAndCheckAuthorization(courseId, req.auth.credentials);
     await checkPayload(courseSlot, req.payload);

--- a/tests/integration/courseSlots.test.js
+++ b/tests/integration/courseSlots.test.js
@@ -247,7 +247,7 @@ describe('COURSE SLOTS ROUTES - PUT /courseslots/{_id}', () => {
       expect(response.statusCode).toBe(403);
     });
 
-    it('should return 403 if course slot has attendances', async () => {
+    it('should return 403 as trying to remove dates and course slot has attendances', async () => {
       const payload = { startDate: '', endDate: '' };
       const response = await app.inject({
         method: 'PUT',

--- a/tests/integration/courseSlots.test.js
+++ b/tests/integration/courseSlots.test.js
@@ -247,6 +247,18 @@ describe('COURSE SLOTS ROUTES - PUT /courseslots/{_id}', () => {
       expect(response.statusCode).toBe(403);
     });
 
+    it('should return 403 if course slot has attendances', async () => {
+      const payload = { startDate: '', endDate: '' };
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/courseslots/${courseSlotsList[4]._id}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+        payload,
+      });
+
+      expect(response.statusCode).toBe(403);
+    });
+
     it('should return 409 if slots conflict', async () => {
       const payload = {
         startDate: courseSlotsList[0].startDate,


### PR DESCRIPTION
<details open><summary> TESTS  :computer: </summary>

- [ ] J'ai codé les tests unitaires -np
- [x] J'ai codé les tests d'intégration
- [ ] C'est une ancienne route utilisée par les apps mobiles.
  - [ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens
</details>

- [ ] Je replie cette section car mes modifications n'ont pas besoin de tests unitaires ou d'intégration

---

<details closed><summary> POINTS D'ATTENTION POUR CETTE PR  :warning: </summary>

- [ ] J'ai fait des modifications sur une route utilisée sur plusieurs plateformes [Doc de détail](https://www.notion.so/Points-d-attention-sur-les-routes-a548a8e32d314d5e92cb342e66cce443)
- [ ] J'ai modifié un modèle utilisé en mobile [Doc de détail](https://www.notion.so/Point-d-attention-sur-les-mod-les-e46fbf180cd34a569f3c6102366e47ca)
- [ ] J'ai ajouté un modèle spécifique à une structure 
  - [ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés
- [ ] J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile
  - [ ] Si oui, j'ai précisé sur le [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) qu'il faut forcer la mise à jour
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [Doc de MES](https://www.notion.so/Pas-pas-Mise-en-staging-01755ac57d944b4cb0c189861428e5d2) et [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) les modifications faites

</details>

- [x] Je replie cette section car je n'ai pas fait de modifications entrainant un point d'attention

---

<details closed><summary> FONCTIONNALITÉS APPS MOBILES  :iphone: </summary>

- [ ] Mes changements impactent l'application formation
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours
- [ ] Mes changements impactent l'application erp
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours

</details>

- [x] Je replie cette section car mes modifications n'ont pas d'impact sur les applications mobiles

_Si tu as lu cette description, pense à réagir avec un :eye:_
