### PR TITLE
COM-3371 update github action library

### DIFF
--- a/.github/workflows/integration.js.yml
+++ b/.github/workflows/integration.js.yml
@@ -20,9 +20,9 @@ jobs:
 
     steps:
       # Check out the repository
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       # Install Node.js
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: 16.18.0
       - run: npm ci

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,12 +8,12 @@ jobs:
     name: Run ESLint
     runs-on: ubuntu-latest
     steps:
-      
+
       # Check out the repository
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Install Node.js
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: 16.18.0
 


### PR DESCRIPTION
Mise à jour des library `actions/checkout` et `actions/setup-node` car les actions utilisant node12 est bientot déprécié.