### PR TITLE
COM-3426: can get and update activity declaration number

### DIFF
--- a/src/routes/vendorCompanies.js
+++ b/src/routes/vendorCompanies.js
@@ -25,6 +25,7 @@ exports.plugin = {
             name: Joi.string(),
             address: addressValidation,
             siret: siretValidation,
+            activityDeclarationNumber: Joi.string(),
           }),
         },
         auth: { scope: ['config:vendor'] },

--- a/tests/integration/vendorCompanies.test.js
+++ b/tests/integration/vendorCompanies.test.js
@@ -86,6 +86,7 @@ describe('VENDOR COMPANY ROUTES - PUT /vendorcompanies', () => {
         },
       },
       { key: 'siret', value: '12345678901235' },
+      { key: 'activityDeclarationNumber', value: '10736353175' },
     ];
     payloads.forEach((payload) => {
       it(`should update vendor company ${payload.key}`, async () => {
@@ -120,6 +121,7 @@ describe('VENDOR COMPANY ROUTES - PUT /vendorcompanies', () => {
         value: '12 rue de ponthieu 75008 Paris',
       },
       { key: 'siret', value: '13244' },
+      { key: 'activityDeclarationNumber', value: '' },
     ];
     wrongValues.forEach((payload) => {
       it(`should not update vendor company ${payload.key} with wrong value`, async () => {


### PR DESCRIPTION
<details open><summary> TESTS  :computer: </summary>

- [ ] J'ai codé les tests unitaires -np
- [x] J'ai codé les tests d'intégration
- [ ] ~~C'est une ancienne route utilisée par les apps mobiles.~~
  - [ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens
</details>

- [ ] Je replie cette section car mes modifications n'ont pas besoin de tests unitaires ou d'intégration

---

<details><summary> POINTS D'ATTENTION POUR CETTE PR  :warning: </summary>

- [ ] J'ai fait des modifications sur une route utilisée sur plusieurs plateformes [Doc de détail](https://www.notion.so/Points-d-attention-sur-les-routes-a548a8e32d314d5e92cb342e66cce443)
- [ ] J'ai modifié un modèle utilisé en mobile [Doc de détail](https://www.notion.so/Point-d-attention-sur-les-mod-les-e46fbf180cd34a569f3c6102366e47ca)
- [ ] J'ai ajouté un modèle spécifique à une structure 
  - [ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés
- [ ] J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile
  - [ ] Si oui, j'ai précisé sur le [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) qu'il faut forcer la mise à jour
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [Doc de MES](https://www.notion.so/Pas-pas-Mise-en-staging-01755ac57d944b4cb0c189861428e5d2) et [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) les modifications faites

</details>

- [x] Je replie cette section car je n'ai pas fait de modifications entrainant un point d'attention

---

<details><summary> FONCTIONNALITÉS APPS MOBILES  :iphone: </summary>

- [ ] Mes changements impactent l'application formation
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours
- [ ] Mes changements impactent l'application erp
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours

</details>

- [x] Je replie cette section car mes modifications n'ont pas d'impact sur les applications mobiles

_Si tu as lu cette description, pense à réagir avec un :eye:_
