### PR TITLE
COM-3484: can't get attendance sheets in inter as coach

### DIFF
--- a/src/routes/courses.js
+++ b/src/routes/courses.js
@@ -289,7 +289,7 @@ exports.plugin = {
         validate: {
           params: Joi.object({ _id: Joi.objectId().required() }),
         },
-        pre: [{ method: authorizeGetAttendanceSheets }],
+        pre: [{ method: authorizeGetDocumentsAndSms }, { method: authorizeGetAttendanceSheets }],
       },
       handler: downloadAttendanceSheets,
     });

--- a/src/routes/preHandlers/courses.js
+++ b/src/routes/preHandlers/courses.js
@@ -89,7 +89,7 @@ exports.authorizeGetDocumentsAndSms = async (req) => {
   const courseTrainerId = get(course, 'trainer') || null;
   this.checkAuthorization(credentials, courseTrainerId, course.companies);
 
-  return course;
+  return null;
 };
 
 exports.checkInterlocutors = async (req, courseCompanyId) => {
@@ -424,13 +424,13 @@ exports.authorizeGetQuestionnaires = async (req) => {
 };
 
 exports.authorizeGetAttendanceSheets = async (req) => {
-  const course = await exports.authorizeGetDocumentsAndSms(req);
   const { credentials } = req.auth;
   const userVendorRole = get(credentials, 'role.vendor.name');
 
   const slots = await CourseSlot.find({ course: req.params._id }).populate({ path: 'step', select: 'type' }).lean();
   if (!slots.some(s => s.step.type === ON_SITE)) throw Boom.notFound(translate[language].courseAttendanceNotGenerated);
 
+  const course = await Course.findOne({ _id: req.params._id }, { type: 1 }).lean();
   if (course.type === INTER_B2B && !userVendorRole) throw Boom.forbidden();
 
   return null;

--- a/tests/integration/courses.test.js
+++ b/tests/integration/courses.test.js
@@ -3014,6 +3014,17 @@ describe('COURSES ROUTES - GET /:_id/attendance-sheets', () => {
 
       expect(response.statusCode).toBe(403);
     });
+
+    it('should return 403 as user is client_admin requesting on inter b2b course', async () => {
+      authToken = await getToken('client_admin');
+      const response = await app.inject({
+        method: 'GET',
+        url: `/courses/${interCourseIdFromAuthCompany}/attendance-sheets`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(403);
+    });
   });
 });
 


### PR DESCRIPTION
<details open><summary> TESTS  :computer: </summary>

- [ ] J'ai codé les tests unitaires -np
- [x] J'ai codé les tests d'intégration
- [ ] ~~C'est une ancienne route utilisée par les apps mobiles.~~
  - [ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens
</details>

- [ ] Je replie cette section car mes modifications n'ont pas besoin de tests unitaires ou d'intégration

---

<details><summary> POINTS D'ATTENTION POUR CETTE PR  :warning: </summary>

- [ ] J'ai fait des modifications sur une route utilisée sur plusieurs plateformes [Doc de détail](https://www.notion.so/Points-d-attention-sur-les-routes-a548a8e32d314d5e92cb342e66cce443)
- [ ] J'ai modifié un modèle utilisé en mobile [Doc de détail](https://www.notion.so/Point-d-attention-sur-les-mod-les-e46fbf180cd34a569f3c6102366e47ca)
- [ ] J'ai ajouté un modèle spécifique à une structure 
  - [ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés
- [ ] J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile
  - [ ] Si oui, j'ai précisé sur le [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) qu'il faut forcer la mise à jour
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [Doc de MES](https://www.notion.so/Pas-pas-Mise-en-staging-01755ac57d944b4cb0c189861428e5d2) et [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) les modifications faites

</details>

- [x] Je replie cette section car je n'ai pas fait de modifications entrainant un point d'attention

---

<details><summary> FONCTIONNALITÉS APPS MOBILES  :iphone: </summary>

- [ ] Mes changements impactent l'application formation
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours
- [ ] Mes changements impactent l'application erp
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours

</details>

- [x] Je replie cette section car mes modifications n'ont pas d'impact sur les applications mobiles

_Si tu as lu cette description, pense à réagir avec un :eye:_
