### PR TITLE
COM-3698 - get only Expectations and End_of_course questionnaires if query is {}

### DIFF
--- a/src/helpers/questionnaires.js
+++ b/src/helpers/questionnaires.js
@@ -64,7 +64,8 @@ exports.list = async (credentials, query = {}) => {
   const { course: courseId } = query;
 
   if (!courseId) {
-    return Questionnaire.find(query).populate({ path: 'historiesCount', options: { isVendorUser } }).lean();
+    const findQuery = query.program ? query : { type: [EXPECTATIONS, END_OF_COURSE] };
+    return Questionnaire.find(findQuery).populate({ path: 'historiesCount', options: { isVendorUser } }).lean();
   }
 
   const { isStrictlyELearning, courseTimeline, programId } = await exports.getCourseInfos(courseId);

--- a/tests/integration/questionnaires.test.js
+++ b/tests/integration/questionnaires.test.js
@@ -163,7 +163,7 @@ describe('QUESTIONNAIRES ROUTES - GET /questionnaires', () => {
       });
 
       expect(response.statusCode).toBe(200);
-      expect(response.result.data.questionnaires.length).toEqual(questionnairesList.length);
+      expect(response.result.data.questionnaires.length).toEqual(3);
     });
 
     it('should get published questionnaires linked to a course (EXPECTATIONS and SELF_POSITIONNING)', async () => {

--- a/tests/unit/helpers/questionnaires.test.js
+++ b/tests/unit/helpers/questionnaires.test.js
@@ -58,11 +58,12 @@ describe('list', () => {
     UtilsMock.unmockCurrentDate();
   });
 
-  it('should return all questionnaires (DRAFT OR PUBLISHED)', async () => {
+  it('should return all EXPECTATIONS OR END_OF_COURSE questionnaires (DRAFT OR PUBLISHED)', async () => {
     const credentials = { role: { vendor: { name: TRAINING_ORGANISATION_MANAGER } } };
     const questionnairesList = [
-      { name: 'test', stauts: PUBLISHED },
-      { name: 'test2', status: DRAFT },
+      { name: 'test', type: EXPECTATIONS, status: PUBLISHED },
+      { name: 'test2', type: EXPECTATIONS, status: DRAFT },
+      { name: 'test2', type: END_OF_COURSE, status: DRAFT },
     ];
 
     findQuestionnaires.returns(SinonMongoose.stubChainedQueries(questionnairesList));
@@ -73,7 +74,7 @@ describe('list', () => {
     SinonMongoose.calledOnceWithExactly(
       findQuestionnaires,
       [
-        { query: 'find', args: [{}] },
+        { query: 'find', args: [{ type: [EXPECTATIONS, END_OF_COURSE] }] },
         { query: 'populate', args: [{ path: 'historiesCount', options: { isVendorUser: true } }] },
         { query: 'lean' },
       ]


### PR DESCRIPTION
<details open><summary> TESTS  :computer: </summary>

- [x] J'ai codé les tests unitaires
- [ ] J'ai codé les tests d'intégration -np
- [ ] C'est une ancienne route utilisée par les apps mobiles.
  - [ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens
</details>

- [ ] Je replie cette section car mes modifications n'ont pas besoin de tests unitaires ou d'intégration

---

<details closed><summary> POINTS D'ATTENTION POUR CETTE PR  :warning: </summary>

- [x] J'ai fait des modifications sur une route utilisée sur plusieurs plateformes [Doc de détail](https://www.notion.so/Points-d-attention-sur-les-routes-a548a8e32d314d5e92cb342e66cce443)
- [ ] J'ai modifié un modèle utilisé en mobile [Doc de détail](https://www.notion.so/Point-d-attention-sur-les-mod-les-e46fbf180cd34a569f3c6102366e47ca)
- [ ] J'ai ajouté un modèle spécifique à une structure 
  - [ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés
- [ ] J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile
  - [ ] Si oui, j'ai précisé sur le [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) qu'il faut forcer la mise à jour
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [Doc de MES](https://www.notion.so/Pas-pas-Mise-en-staging-01755ac57d944b4cb0c189861428e5d2) et [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) les modifications faites

</details>

- [ ] Je replie cette section car je n'ai pas fait de modifications entrainant un point d'attention

---

<details closed><summary> FONCTIONNALITÉS APPS MOBILES  :iphone: </summary>

- [ ] Mes changements impactent l'application formation
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours
- [ ] Mes changements impactent l'application erp
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours

</details>

- [x] Je replie cette section car mes modifications n'ont pas d'impact sur les applications mobiles

_Si tu as lu cette description, pense à réagir avec un :eye:_
