### PR TITLE
COM-3828 - authorize all trainers to get and download attendance Sheets

### DIFF
--- a/src/routes/preHandlers/attendanceSheets.js
+++ b/src/routes/preHandlers/attendanceSheets.js
@@ -13,27 +13,27 @@ const {
   TRAINING_ORGANISATION_MANAGER,
 } = require('../../helpers/constants');
 
-const isVendorAndAuthorized = (courseTrainer, credentials) => {
+const isVendorAndAuthorized = (courseTrainers, credentials) => {
   const loggedUserId = get(credentials, '_id');
   const vendorRole = get(credentials, 'role.vendor');
 
   const isRofOrAdmin = [VENDOR_ADMIN, TRAINING_ORGANISATION_MANAGER].includes(get(vendorRole, 'name'));
   if (isRofOrAdmin) return true;
 
-  const loggedUserIsCourseTrainer = courseTrainer && UtilsHelper.areObjectIdsEquals(loggedUserId, courseTrainer);
+  const loggedUserIsCourseTrainer = UtilsHelper.doesArrayIncludeId(courseTrainers, loggedUserId);
 
   return get(vendorRole, 'name') === TRAINER && loggedUserIsCourseTrainer;
 };
 
 exports.authorizeAttendanceSheetsGet = async (req) => {
   const course = await Course
-    .findOne({ _id: req.query.course }, { type: 1, companies: 1, trainer: 1, holding: 1 })
+    .findOne({ _id: req.query.course }, { type: 1, companies: 1, trainers: 1, holding: 1 })
     .lean();
   if (!course) throw Boom.notFound();
 
   const { credentials } = req.auth;
 
-  if (isVendorAndAuthorized(course.trainer, credentials)) return null;
+  if (isVendorAndAuthorized(course.trainers, credentials)) return null;
 
   if (get(req.query, 'company')) {
     const loggedUserCompany = get(credentials, 'company._id');

--- a/tests/integration/attendanceSheets.test.js
+++ b/tests/integration/attendanceSheets.test.js
@@ -1,21 +1,25 @@
-// const { expect } = require('expect');
+const { expect } = require('expect');
 // const sinon = require('sinon');
-// const { ObjectId } = require('mongodb');
+const { ObjectId } = require('mongodb');
 // const GCloudStorageHelper = require('../../src/helpers/gCloudStorage');
-// const app = require('../../server');
-// const { populateDB, coursesList, attendanceSheetList } = require('./seed/attendanceSheetsSeed');
-// const { getToken, getTokenByCredentials } = require('./helpers/authentication');
+const app = require('../../server');
+const {
+  populateDB,
+  coursesList,
+  // attendanceSheetList
+} = require('./seed/attendanceSheetsSeed');
+const { getToken, getTokenByCredentials } = require('./helpers/authentication');
 // const { generateFormData, getStream } = require('./utils');
 // const { WEBAPP, MOBILE } = require('../../src/helpers/constants');
-// const AttendanceSheet = require('../../src/models/AttendanceSheet');
-// const { holdingAdminFromOtherCompany, trainerAndCoach } = require('../seed/authUsersSeed');
-// const { authCompany, otherCompany, otherHolding, authHolding } = require('../seed/authCompaniesSeed');
+const AttendanceSheet = require('../../src/models/AttendanceSheet');
+const { holdingAdminFromOtherCompany, trainerAndCoach } = require('../seed/authUsersSeed');
+const { authCompany, otherCompany, otherHolding, authHolding } = require('../seed/authCompaniesSeed');
 
-// describe('NODE ENV', () => {
-//   it('should be \'test\'', () => {
-//     expect(process.env.NODE_ENV).toBe('test');
-//   });
-// });
+describe('NODE ENV', () => {
+  it('should be \'test\'', () => {
+    expect(process.env.NODE_ENV).toBe('test');
+  });
+});
 
 // describe('ATTENDANCE SHEETS ROUTES - POST /attendancesheets', () => {
 //   let authToken;
@@ -367,218 +371,217 @@
 //   });
 // });
 
-// describe('ATTENDANCE SHEETS ROUTES - GET /attendancesheets', () => {
-//   let authToken;
+describe('ATTENDANCE SHEETS ROUTES - GET /attendancesheets', () => {
+  let authToken;
 
-//   describe('TRAINER', () => {
-//     beforeEach(populateDB);
-//     beforeEach(async () => {
-//       authToken = await getToken('trainer');
-//     });
+  describe('TRAINER', () => {
+    beforeEach(populateDB);
+    beforeEach(async () => {
+      authToken = await getToken('trainer');
+    });
 
-//     it('should get course\'s attendance sheets', async () => {
-//       const attendanceSheetsLength = await AttendanceSheet.countDocuments({ course: coursesList[0]._id });
+    it('should get course\'s attendance sheets', async () => {
+      const attendanceSheetsLength = await AttendanceSheet.countDocuments({ course: coursesList[0]._id });
 
-//       const response = await app.inject({
-//         method: 'GET',
-//         url: `/attendancesheets?course=${coursesList[0]._id}`,
-//         headers: { Cookie: `alenvi_token=${authToken}` },
-//       });
+      const response = await app.inject({
+        method: 'GET',
+        url: `/attendancesheets?course=${coursesList[0]._id}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
 
-//       expect(response.statusCode).toBe(200);
-//       expect(response.result.data.attendanceSheets.length).toEqual(attendanceSheetsLength);
-//     });
+      expect(response.statusCode).toBe(200);
+      expect(response.result.data.attendanceSheets.length).toEqual(attendanceSheetsLength);
+    });
 
-//     it('should return a 404 if course doesn\'t exist', async () => {
-//       const response = await app.inject({
-//         method: 'GET',
-//         url: `/attendancesheets?course=${new ObjectId()}`,
-//         headers: { Cookie: `alenvi_token=${authToken}` },
-//       });
+    it('should return a 404 if course doesn\'t exist', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/attendancesheets?course=${new ObjectId()}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
 
-//       expect(response.statusCode).toBe(404);
-//     });
+      expect(response.statusCode).toBe(404);
+    });
 
-//     it('should return a 403 if trainer is from an other company', async () => {
-//       const response = await app.inject({
-//         method: 'GET',
-//         url: `/attendancesheets?course=${coursesList[2]._id}`,
-//         headers: { Cookie: `alenvi_token=${authToken}` },
-//       });
+    it('should return a 403 if trainer is from an other company', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/attendancesheets?course=${coursesList[2]._id}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
 
-//       expect(response.statusCode).toBe(403);
-//     });
-//   });
+      expect(response.statusCode).toBe(403);
+    });
+  });
 
-//   describe('COACH', () => {
-//     beforeEach(populateDB);
-//     beforeEach(async () => {
-//       authToken = await getToken('coach');
-//     });
+  describe('COACH', () => {
+    beforeEach(populateDB);
+    beforeEach(async () => {
+      authToken = await getToken('coach');
+    });
 
-//     it('should get only authCompany\'s attendance sheets for interB2B course if user does not have vendor role',
-//       async () => {
-//         authToken = await getToken('coach');
+    it('should get only authCompany\'s attendance sheets for interB2B course if user does not have vendor role',
+      async () => {
+        authToken = await getToken('coach');
 
-//         const response = await app.inject({
-//           method: 'GET',
-//           url: `/attendancesheets?course=${coursesList[1]._id}&company=${authCompany._id}`,
-//           headers: { Cookie: `alenvi_token=${authToken}` },
-//         });
+        const response = await app.inject({
+          method: 'GET',
+          url: `/attendancesheets?course=${coursesList[1]._id}&company=${authCompany._id}`,
+          headers: { Cookie: `alenvi_token=${authToken}` },
+        });
 
-//         expect(response.statusCode).toBe(200);
-//         expect(response.result.data.attendanceSheets.length).toEqual(1);
-//       });
+        expect(response.statusCode).toBe(200);
+        expect(response.result.data.attendanceSheets.length).toEqual(1);
+      });
 
-//     it('should get attendance sheets if user is trainer but not course trainer but is coach from course company',
-//       async () => {
-//         authToken = await getTokenByCredentials(trainerAndCoach.local);
+    it('should get attendance sheets if user is trainer but not course trainer but is coach from course company',
+      async () => {
+        authToken = await getTokenByCredentials(trainerAndCoach.local);
 
-//         const response = await app.inject({
-//           method: 'GET',
-//           url: `/attendancesheets?course=${coursesList[1]._id}&company=${authCompany._id}`,
-//           headers: { Cookie: `alenvi_token=${authToken}` },
-//         });
+        const response = await app.inject({
+          method: 'GET',
+          url: `/attendancesheets?course=${coursesList[1]._id}&company=${authCompany._id}`,
+          headers: { Cookie: `alenvi_token=${authToken}` },
+        });
 
-//         expect(response.statusCode).toBe(200);
-//       });
+        expect(response.statusCode).toBe(200);
+      });
 
-//     it('should return a 403 if company is not in course', async () => {
-//       authToken = await getToken('coach');
-//       const response = await app.inject({
-//         method: 'GET',
-//         url: `/attendancesheets?course=${coursesList[4]._id}&company=${authCompany._id}`,
-//         headers: { Cookie: `alenvi_token=${authToken}` },
-//       });
+    it('should return a 403 if company is not in course', async () => {
+      authToken = await getToken('coach');
+      const response = await app.inject({
+        method: 'GET',
+        url: `/attendancesheets?course=${coursesList[4]._id}&company=${authCompany._id}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
 
-//       expect(response.statusCode).toBe(403);
-//     });
+      expect(response.statusCode).toBe(403);
+    });
 
-//     it('should return a 403 if user is not in company', async () => {
-//       authToken = await getToken('coach');
-//       const response = await app.inject({
-//         method: 'GET',
-//         url: `/attendancesheets?course=${coursesList[4]._id}&company=${otherCompany._id}`,
-//         headers: { Cookie: `alenvi_token=${authToken}` },
-//       });
+    it('should return a 403 if user is not in company', async () => {
+      authToken = await getToken('coach');
+      const response = await app.inject({
+        method: 'GET',
+        url: `/attendancesheets?course=${coursesList[4]._id}&company=${otherCompany._id}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
 
-//       expect(response.statusCode).toBe(403);
-//     });
+      expect(response.statusCode).toBe(403);
+    });
 
-//     it('should return a 403 if company doesn\'t exist', async () => {
-//       authToken = await getToken('coach');
-//       const response = await app.inject({
-//         method: 'GET',
-//         url: `/attendancesheets?course=${coursesList[4]._id}&company=${new ObjectId()}`,
-//         headers: { Cookie: `alenvi_token=${authToken}` },
-//       });
+    it('should return a 403 if company doesn\'t exist', async () => {
+      authToken = await getToken('coach');
+      const response = await app.inject({
+        method: 'GET',
+        url: `/attendancesheets?course=${coursesList[4]._id}&company=${new ObjectId()}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
 
-//       expect(response.statusCode).toBe(403);
-//     });
-//   });
+      expect(response.statusCode).toBe(403);
+    });
+  });
 
-//   describe('HOLDING_ADMIN', () => {
-//     beforeEach(populateDB);
-//     beforeEach(async () => {
-//       authToken = await getTokenByCredentials(holdingAdminFromOtherCompany.local);
-//     });
+  describe('HOLDING_ADMIN', () => {
+    beforeEach(populateDB);
+    beforeEach(async () => {
+      authToken = await getTokenByCredentials(holdingAdminFromOtherCompany.local);
+    });
 
-//     it('should get holding\'s attendance sheets for interB2B course', async () => {
-//       const response = await app.inject({
-//         method: 'GET',
-//         url: `/attendancesheets?course=${coursesList[1]._id}&holding=${otherHolding._id}`,
-//         headers: { Cookie: `alenvi_token=${authToken}` },
-//       });
+    it('should get holding\'s attendance sheets for interB2B course', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/attendancesheets?course=${coursesList[1]._id}&holding=${otherHolding._id}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
 
-//       expect(response.statusCode).toBe(200);
-//       expect(response.result.data.attendanceSheets.length).toEqual(1);
-//     });
+      expect(response.statusCode).toBe(200);
+      expect(response.result.data.attendanceSheets.length).toEqual(1);
+    });
 
-//     it('should return 200 even if no company in course (intra_holding)', async () => {
-//       const response = await app.inject({
-//         method: 'GET',
-//         url: `/attendancesheets?course=${coursesList[6]._id}&holding=${otherHolding._id}`,
-//         headers: { Cookie: `alenvi_token=${authToken}` },
-//       });
+    it('should return 200 even if no company in course (intra_holding)', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/attendancesheets?course=${coursesList[6]._id}&holding=${otherHolding._id}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
 
-//       expect(response.statusCode).toBe(200);
-//     });
+      expect(response.statusCode).toBe(200);
+    });
 
-//     it('should return 403 if course company is not in holding', async () => {
-//       const response = await app.inject({
-//         method: 'GET',
-//         url: `/attendancesheets?course=${coursesList[0]._id}&holding=${otherHolding._id}`,
-//         headers: { Cookie: `alenvi_token=${authToken}` },
-//       });
+    it('should return 403 if course company is not in holding', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/attendancesheets?course=${coursesList[0]._id}&holding=${otherHolding._id}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
 
-//       expect(response.statusCode).toBe(403);
-//     });
+      expect(response.statusCode).toBe(403);
+    });
 
-//     it('should return 403 if user is not in holding', async () => {
-//       const response = await app.inject({
-//         method: 'GET',
-//         url: `/attendancesheets?course=${coursesList[0]._id}&holding=${authHolding._id}`,
-//         headers: { Cookie: `alenvi_token=${authToken}` },
-//       });
+    it('should return 403 if user is not in holding', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/attendancesheets?course=${coursesList[0]._id}&holding=${authHolding._id}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
 
-//       expect(response.statusCode).toBe(403);
-//     });
+      expect(response.statusCode).toBe(403);
+    });
 
-//     it('should return 403 if holding doesn\'t exist', async () => {
-//       const response = await app.inject({
-//         method: 'GET',
-//         url: `/attendancesheets?course=${coursesList[0]._id}&holding=${new ObjectId()}`,
-//         headers: { Cookie: `alenvi_token=${authToken}` },
-//       });
+    it('should return 403 if holding doesn\'t exist', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/attendancesheets?course=${coursesList[0]._id}&holding=${new ObjectId()}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
 
-//       expect(response.statusCode).toBe(403);
-//     });
+      expect(response.statusCode).toBe(403);
+    });
 
-//     it('should return 403 if no vendor role and no holding or company query', async () => {
-//       const response = await app.inject({
-//         method: 'GET',
-//         url: `/attendancesheets?course=${coursesList[1]._id}`,
-//         headers: { Cookie: `alenvi_token=${authToken}` },
-//       });
+    it('should return 403 if no vendor role and no holding or company query', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/attendancesheets?course=${coursesList[1]._id}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
 
-//       expect(response.statusCode).toBe(403);
-//     });
+      expect(response.statusCode).toBe(403);
+    });
 
-//     it('should return 400 if holding and company query', async () => {
-//       const response = await app.inject({
-//         method: 'GET',
-//         url: `/attendancesheets?course=${coursesList[1]._id}&holding=${otherHolding._id}&company=
-// ${otherCompany._id}`,
-//         headers: { Cookie: `alenvi_token=${authToken}` },
-//       });
+    it('should return 400 if holding and company query', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/attendancesheets?course=${coursesList[1]._id}&holding=${otherHolding._id}&company=${otherCompany._id}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
 
-//       expect(response.statusCode).toBe(400);
-//     });
-//   });
+      expect(response.statusCode).toBe(400);
+    });
+  });
 
-//   describe('Other roles', () => {
-//     beforeEach(populateDB);
+  describe('Other roles', () => {
+    beforeEach(populateDB);
 
-//     const roles = [
-//       { name: 'helper', expectedCode: 403 },
-//       { name: 'planning_referent', expectedCode: 403 },
-//       { name: 'coach', expectedCode: 200 },
-//     ];
+    const roles = [
+      { name: 'helper', expectedCode: 403 },
+      { name: 'planning_referent', expectedCode: 403 },
+      { name: 'coach', expectedCode: 200 },
+    ];
 
-//     roles.forEach((role) => {
-//       it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
-//         authToken = await getToken(role.name);
-//         const response = await app.inject({
-//           method: 'GET',
-//           url: `/attendancesheets?course=${coursesList[0]._id}&company=${authCompany._id}`,
-//           headers: { Cookie: `alenvi_token=${authToken}` },
-//         });
+    roles.forEach((role) => {
+      it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
+        authToken = await getToken(role.name);
+        const response = await app.inject({
+          method: 'GET',
+          url: `/attendancesheets?course=${coursesList[0]._id}&company=${authCompany._id}`,
+          headers: { Cookie: `alenvi_token=${authToken}` },
+        });
 
-//         expect(response.statusCode).toBe(role.expectedCode);
-//       });
-//     });
-//   });
-// });
+        expect(response.statusCode).toBe(role.expectedCode);
+      });
+    });
+  });
+});
 
 // describe('ATTENDANCE SHEETS ROUTES - DELETE /attendancesheets/{_id}', () => {
 //   let authToken;

--- a/tests/integration/courses.test.js
+++ b/tests/integration/courses.test.js
@@ -840,7 +840,7 @@ describe('COURSES ROUTES - GET /courses', () => {
       });
 
       expect(response.statusCode).toBe(200);
-      expect(response.result.data.courses.length).toEqual(15);
+      expect(response.result.data.courses.length).toEqual(13);
     });
 
     it('should get trainer\'s course (ops mobile)', async () => {
@@ -852,7 +852,7 @@ describe('COURSES ROUTES - GET /courses', () => {
       });
 
       expect(response.statusCode).toBe(200);
-      expect(response.result.data.courses.length).toEqual(15);
+      expect(response.result.data.courses.length).toEqual(13);
 
       const course =
          response.result.data.courses.find(c => UtilsHelper.areObjectIdsEquals(coursesList[2]._id, c._id));
@@ -3752,9 +3752,9 @@ describe('COURSES ROUTES - GET /{_id}/attendance-sheets', () => {
   const courseIdFromOtherCompany = coursesList[1]._id;
   beforeEach(populateDB);
 
-  describe('TRAINER', () => {
+  describe('TRAINING_ORGANISATION_MANAGER', () => {
     beforeEach(async () => {
-      authToken = await getToken('trainer');
+      authToken = await getToken('training_organisation_manager');
     });
 
     it('should return 200 for intra course', async () => {

--- a/tests/integration/courses.test.js
+++ b/tests/integration/courses.test.js
@@ -840,7 +840,7 @@ describe('COURSES ROUTES - GET /courses', () => {
       });
 
       expect(response.statusCode).toBe(200);
-      expect(response.result.data.courses.length).toEqual(13);
+      expect(response.result.data.courses.length).toEqual(15);
     });
 
     it('should get trainer\'s course (ops mobile)', async () => {
@@ -852,7 +852,7 @@ describe('COURSES ROUTES - GET /courses', () => {
       });
 
       expect(response.statusCode).toBe(200);
-      expect(response.result.data.courses.length).toEqual(13);
+      expect(response.result.data.courses.length).toEqual(15);
 
       const course =
          response.result.data.courses.find(c => UtilsHelper.areObjectIdsEquals(coursesList[2]._id, c._id));
@@ -3744,7 +3744,7 @@ describe('COURSES ROUTES - DELETE /courses/{_id}/trainees/{traineeId}', () => {
   });
 });
 
-describe('COURSES ROUTES - GET /:_id/attendance-sheets', () => {
+describe('COURSES ROUTES - GET /{_id}/attendance-sheets', () => {
   let authToken;
   const intraCourseIdFromAuthCompany = coursesList[2]._id;
   const interCourseIdFromAuthCompany = coursesList[5]._id;
@@ -3752,9 +3752,9 @@ describe('COURSES ROUTES - GET /:_id/attendance-sheets', () => {
   const courseIdFromOtherCompany = coursesList[1]._id;
   beforeEach(populateDB);
 
-  describe('TRAINING_ORGANISATION_MANAGER', () => {
+  describe('TRAINER', () => {
     beforeEach(async () => {
-      authToken = await getToken('training_organisation_manager');
+      authToken = await getToken('trainer');
     });
 
     it('should return 200 for intra course', async () => {
@@ -3843,8 +3843,7 @@ describe('COURSES ROUTES - GET /:_id/attendance-sheets', () => {
       { name: 'coach', expectedCode: 200 },
     ];
     roles.forEach((role) => {
-      it(`should return ${role.expectedCode} as user is ${role.name}, requesting on his company
-(intra)`, async () => {
+      it(`should return ${role.expectedCode} as user is ${role.name}, requesting on his company (intra)`, async () => {
         authToken = await getToken(role.name);
         const response = await app.inject({
           method: 'GET',
@@ -3855,8 +3854,7 @@ describe('COURSES ROUTES - GET /:_id/attendance-sheets', () => {
         expect(response.statusCode).toBe(role.expectedCode);
       });
 
-      it(`should return ${role.expectedCode} as user is ${role.name}, company in course
- (intra_holding)`, async () => {
+      it(`should return ${role.expectedCode} as user is ${role.name}, company in course (intra_holding)`, async () => {
         authToken = await getToken(role.name);
         const response = await app.inject({
           method: 'GET',

--- a/tests/integration/seed/coursesSeed.js
+++ b/tests/integration/seed/coursesSeed.js
@@ -403,7 +403,6 @@ const coursesList = [
     misc: 'inter b2b session NOT concerning auth company',
     type: INTER_B2B,
     format: BLENDED,
-    trainers: [trainer._id],
     trainees: [noRole._id],
     companies: [thirdCompany._id],
     operationsRepresentative: vendorAdmin._id,
@@ -470,7 +469,6 @@ const coursesList = [
     trainees: [],
     companies: [authCompany._id],
     operationsRepresentative: vendorAdmin._id,
-    trainers: [trainer._id],
   },
   { // 13 course without trainee
     _id: new ObjectId(),

--- a/tests/integration/seed/coursesSeed.js
+++ b/tests/integration/seed/coursesSeed.js
@@ -403,6 +403,7 @@ const coursesList = [
     misc: 'inter b2b session NOT concerning auth company',
     type: INTER_B2B,
     format: BLENDED,
+    trainers: [trainer._id],
     trainees: [noRole._id],
     companies: [thirdCompany._id],
     operationsRepresentative: vendorAdmin._id,
@@ -469,6 +470,7 @@ const coursesList = [
     trainees: [],
     companies: [authCompany._id],
     operationsRepresentative: vendorAdmin._id,
+    trainers: [trainer._id],
   },
   { // 13 course without trainee
     _id: new ObjectId(),


### PR DESCRIPTION
<details open><summary> TESTS  :computer: </summary>

- [ ] J'ai codé les tests unitaires -np
- [x] J'ai codé les tests d'intégration
- [ ] C'est une ancienne route utilisée par les apps mobiles.
  - [ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens
</details>

- [ ] Je replie cette section car mes modifications n'ont pas besoin de tests unitaires ou d'intégration

---

<details closed><summary> POINTS D'ATTENTION POUR CETTE PR  :warning: </summary>

- [ ] J'ai fait des modifications sur une route utilisée sur plusieurs plateformes [Doc de détail](https://www.notion.so/Points-d-attention-sur-les-routes-a548a8e32d314d5e92cb342e66cce443)
- [ ] J'ai modifié un modèle utilisé en mobile [Doc de détail](https://www.notion.so/Point-d-attention-sur-les-mod-les-e46fbf180cd34a569f3c6102366e47ca)
- [ ] J'ai ajouté un modèle spécifique à une structure 
  - [ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés
- [ ] J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile
  - [ ] Si oui, j'ai précisé sur le [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) qu'il faut forcer la mise à jour
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [Doc de MES](https://www.notion.so/Pas-pas-Mise-en-staging-01755ac57d944b4cb0c189861428e5d2) et [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) les modifications faites

</details>

- [x] Je replie cette section car je n'ai pas fait de modifications entrainant un point d'attention

---

<details closed><summary> FONCTIONNALITÉS APPS MOBILES  :iphone: </summary>

- [x] Mes changements impactent l'application formation
  - [x] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours
- [ ] Mes changements impactent l'application erp
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours

</details>

- [x] Je replie cette section car mes modifications n'ont pas d'impact sur les applications mobiles

_Si tu as lu cette description, pense à réagir avec un :eye:_
